### PR TITLE
Fix Codex/Cursor skill download paths and clarify hidden .codex folder

### DIFF
--- a/api/download/[type]/[provider]/[id].js
+++ b/api/download/[type]/[provider]/[id].js
@@ -11,13 +11,13 @@ function getFilePath(type, provider, id) {
 
   if (type === "skill") {
     if (provider === "cursor") {
-      return join(distDir, "cursor", ".cursor", "rules", `${id}.md`);
+      return join(distDir, "cursor", ".cursor", "skills", id, "SKILL.md");
     } else if (provider === "claude-code") {
       return join(distDir, "claude-code", ".claude", "skills", id, "SKILL.md");
     } else if (provider === "gemini") {
       return join(distDir, "gemini", `GEMINI.${id}.md`);
     } else if (provider === "codex") {
-      return join(distDir, "codex", `AGENTS.${id}.md`);
+      return join(distDir, "codex", ".codex", "skills", id, "SKILL.md");
     }
   } else if (type === "command") {
     if (provider === "cursor") {
@@ -61,4 +61,3 @@ export default function handler(req, res) {
     res.status(500).json({ error: error.message });
   }
 }
-

--- a/public/index.html
+++ b/public/index.html
@@ -330,7 +330,7 @@
           <summary class="faq-question">Where do I put the downloaded files?</summary>
           <div class="faq-answer">
             <p>The easiest way is <code>npx skills add pbakaus/impeccable</code> — it auto-detects your AI harness and places files correctly.</p>
-            <p>If you downloaded the <strong>universal ZIP</strong>, extract it to your <strong>project root</strong> (same level as your <code>package.json</code> or <code>src/</code> folder). It creates hidden folders for each supported tool: <code>.cursor/</code>, <code>.claude/</code>, <code>.gemini/</code>, <code>.codex/</code>, and <code>.agents/</code>.</p>
+            <p>If you downloaded the <strong>universal ZIP</strong>, extract it to your <strong>project root</strong> (same level as your <code>package.json</code> or <code>src/</code> folder). It creates hidden folders for each supported tool: <code>.cursor/</code>, <code>.claude/</code>, <code>.gemini/</code>, <code>.codex/</code>, and <code>.agents/</code>. On macOS Finder, press <code>Cmd</code> + <code>Shift</code> + <code>.</code> to reveal hidden folders if it looks empty.</p>
             <p>Project-level installation takes precedence and lets you version control your skills.</p>
           </div>
         </details>


### PR DESCRIPTION
Quick fix for broken individual skill downloads in `api/download/[type]/[provider]/[id].js`.

  - Cursor skill path now points to `.cursor/skills/<id>/SKILL.md`
  - Codex skill path now points to `.codex/skills/<id>/SKILL.md`

  Also added a short FAQ note in `public/index.html` that `.codex` is hidden in macOS Finder (`Cmd + Shift + .`), since
  that made the Codex download look empty.