### PR TITLE
feat(ci): add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      
+      - name: Install dependencies
+        run: bun install
+        
+      - name: Run tests
+        run: bun test
+        
+      - name: Build
+        run: bun run build
+        
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: impeccable-dist
+          path: dist/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI workflow to ensure code quality and prevent regressions.

## Changes

- **CI Workflow** (`.github/workflows/ci.yml`)
  - Runs on push and PR to `main` branch
  - Sets up Bun runtime for fast JavaScript execution
  - Installs dependencies with `bun install`
  - Runs tests with `bun test`
  - Builds project with `bun run build`
  - Uploads build artifacts (retention: 7 days)

## Why This Matters

Currently there's no CI pipeline, This PR adds automated testing to:
1. Catch test failures before merge
2. Ensure build succeeds on every change
3. Provide build artifacts for review

## Testing

Workflow will run automatically on this PR. Check the "Actions" tab.

Note: There are currently 65 failing tests (tracked in #16). This CI will help catch those failures going forward.