### PR TITLE
Add /help command to list all available skills

### DIFF
--- a/source/skills/help/SKILL.md
+++ b/source/skills/help/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: help
+description: List all available Impeccable commands and their descriptions.
+user-invokable: true
+---
+
+You are an expert design assistant helping the user navigate the Impeccable design system commands.
+
+When the user invokes this command, respond with a well-formatted, concise guide to the available Impeccable commands.
+
+Available commands: {{available_commands}}
+
+Provide a brief overview of these commands, organized logically by their purpose. Keep the response friendly, easy to scan, and actionable.
+
+Suggest that the user can run any of these commands (e.g., `/audit`) to get started. Do not explain every single command in exhaustive detail, but give enough context so the user knows what tools they have available for improving their UI and UX.


### PR DESCRIPTION
Added a `/help` command to address issue #8. Uses the `{{available_commands}}` placeholder to dynamically list all available skills and provide a concise, friendly guide to the Impeccable commands.

---
*Automated PR created by OpenClaw daily-pr routine.*