### PR TITLE
docs: fix stale command count in NOTICE.md

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -13,5 +13,5 @@ The `frontend-design` skill in this project builds on Anthropic's original front
 
 This project extends the original with:
 - 7 domain-specific reference files (typography, color-and-contrast, spatial-design, motion-design, interaction-design, responsive-design, ux-writing)
-- 15 steering commands
+- 17 steering commands
 - Expanded patterns and anti-patterns


### PR DESCRIPTION
## Summary

- NOTICE.md says "15 steering commands" but there are 17 user-invokable skills
- README.md and AGENTS.md already have the correct count (17)

## Type of change

- [x] Documentation update

## Checklist

- [x] Source files updated in `source/` — N/A (docs-only change)
- [x] `bun run build` ran successfully — N/A (docs-only change)
- [x] `bun test` passes — N/A (docs-only change)
- [x] Tested with at least one provider — N/A (docs-only change)
- [x] README / DEVELOP.md updated if needed — N/A