### PR TITLE
Fix missing context gathering and AI-slop copy in 3 skills

### DIFF
--- a/source/skills/critique/SKILL.md
+++ b/source/skills/critique/SKILL.md
@@ -8,9 +8,26 @@ args:
 user-invokable: true
 ---
 
-Conduct a holistic design critique, evaluating whether the interface actually works—not just technically, but as a designed experience. Think like a design director giving feedback.
+## MANDATORY PREPARATION
 
-**First**: Use the frontend-design skill for design principles and anti-patterns.
+### Context Gathering (Do This First)
+
+You cannot do a great job without having necessary context, such as target audience (critical), desired use-cases (critical), brand personality/tone, and what the interface is trying to accomplish.
+
+Attempt to gather these from the current thread or codebase.
+
+1. If you don't find *exact* information and have to infer from existing design and functionality, you MUST STOP and {{ask_instruction}} whether you got it right.
+2. Otherwise, if you can't fully infer or your level of confidence is medium or lower, you MUST {{ask_instruction}} clarifying questions first to complete your context.
+
+Do NOT proceed until you have answers. Critique without context produces generic feedback.
+
+### Use frontend-design skill
+
+Use the frontend-design skill for design principles and anti-patterns. Do NOT proceed until it has executed and you know all DO's and DON'Ts.
+
+---
+
+Conduct a holistic design critique, evaluating whether the interface actually works—not just technically, but as a designed experience. Think like a design director giving feedback.
 
 ## Design Critique
 

--- a/source/skills/delight/SKILL.md
+++ b/source/skills/delight/SKILL.md
@@ -113,7 +113,7 @@ Add personality and joy through these methods:
 
 **Loading delight**:
 - Playful loading animations (not just spinners)
-- Personality in loading messages ("Herding pixels..." "Teaching robots to dance...")
+- Personality in loading messages (write product-specific ones, not generic AI filler)
 - Progress indication with encouraging messages
 - Skeleton screens with subtle animations
 
@@ -203,7 +203,7 @@ Add personality and joy through these methods:
 
 **Form interactions**:
 - Input fields that animate on focus
-- Checkboxes that bounce when checked
+- Checkboxes with a satisfying scale pulse when checked
 - Success state that celebrates valid input
 - Auto-grow textareas
 
@@ -253,12 +253,14 @@ Add personality and joy through these methods:
 - Countdown with encouraging messages
 
 ```
-Loading messages rotation:
-- "Waking up the servers..."
-- "Teaching robots to dance..."
-- "Consulting the magic 8-ball..."
-- "Counting backwards from infinity..."
+Loading messages — write ones specific to your product, not generic AI filler:
+- "Crunching your latest numbers..."
+- "Syncing with your team's changes..."
+- "Preparing your dashboard..."
+- "Checking for updates since yesterday..."
 ```
+
+**WARNING**: Avoid cliched loading messages like "Herding pixels", "Teaching robots to dance", "Consulting the magic 8-ball", "Counting backwards from infinity". These are AI-slop copy — instantly recognizable as machine-generated. Write messages that are specific to what your product actually does.
 
 ### Celebration Moments
 

--- a/source/skills/onboard/SKILL.md
+++ b/source/skills/onboard/SKILL.md
@@ -8,6 +8,25 @@ args:
 user-invokable: true
 ---
 
+## MANDATORY PREPARATION
+
+### Context Gathering (Do This First)
+
+You cannot do a great job without having necessary context, such as target audience (critical), desired use-cases (critical), the "aha moment" you want users to reach, and what users' experience level and motivation looks like.
+
+Attempt to gather these from the current thread or codebase.
+
+1. If you don't find *exact* information and have to infer from existing design and functionality, you MUST STOP and {{ask_instruction}} whether you got it right.
+2. Otherwise, if you can't fully infer or your level of confidence is medium or lower, you MUST {{ask_instruction}} clarifying questions first to complete your context.
+
+Do NOT proceed until you have answers. Onboarding designed for the wrong audience wastes everyone's time.
+
+### Use frontend-design skill
+
+Use the frontend-design skill for design principles and anti-patterns. Do NOT proceed until it has executed and you know all DO's and DON'Ts.
+
+---
+
 Create or improve onboarding experiences that help users understand, adopt, and succeed with the product quickly.
 
 ## Assess Onboarding Needs


### PR DESCRIPTION
## Summary

Found these issues while auditing all i-prefix skills for consistency. Three skills had gaps that the rest of the suite doesn't:

- **critique**: Missing MANDATORY PREPARATION block — every other skill that does design work (bolder, distill, delight, colorize, animate, quieter, adapt) requires context gathering before proceeding. Critique jumped straight to evaluation without it, which leads to generic feedback when audience/brand context is unknown.

- **onboard**: Same gap — no MANDATORY PREPARATION, no frontend-design skill loading. Onboarding designed for the wrong audience is worse than no onboarding.

- **delight**: Loading message examples ("Herding pixels", "Teaching robots to dance", "Consulting the magic 8-ball") are the exact kind of generic AI copy the suite's own anti-slop philosophy warns against. Replaced with product-specific examples and added a WARNING. Also changed "Checkboxes that bounce" to "scale pulse" since bounce easing contradicts the motion-design reference and every skill that mentions easing curves.

## Changes

| File | What changed |
|------|-------------|
| `source/skills/critique/SKILL.md` | Added MANDATORY PREPARATION block with `{{ask_instruction}}` template, enforced frontend-design loading |
| `source/skills/onboard/SKILL.md` | Added MANDATORY PREPARATION block with `{{ask_instruction}}` template, added frontend-design loading |
| `source/skills/delight/SKILL.md` | Replaced AI-slop loading messages with product-specific examples + warning, changed bounce checkbox to scale pulse |

## Test plan

- [ ] Verify `{{ask_instruction}}` template compiles correctly for all providers
- [ ] Confirm critique now asks for context before evaluating
- [ ] Confirm onboard now asks for context before designing flows
- [ ] Review delight loading message examples for appropriateness

🤖 Generated with [Claude Code](https://claude.com/claude-code)