### PR TITLE
fix: correct typo user-invokable -> user-invocable in skill frontmatter

### DIFF
--- a/.claude/skills/adapt/SKILL.md
+++ b/.claude/skills/adapt/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: adapt
 description: Adapt designs to work across different screen sizes, devices, contexts, or platforms. Ensures consistent experience across varied environments.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to adapt (optional)

--- a/.claude/skills/animate/SKILL.md
+++ b/.claude/skills/animate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: animate
 description: Review a feature and enhance it with purposeful animations, micro-interactions, and motion effects that improve usability and delight.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to animate (optional)

--- a/.claude/skills/arrange/SKILL.md
+++ b/.claude/skills/arrange/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: arrange
 description: Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak visual hierarchy to create intentional compositions.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to improve layout for (optional)

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit
 description: Perform comprehensive audit of interface quality across accessibility, performance, theming, and responsive design. Generates detailed report of issues with severity ratings and recommendations.
-user-invokable: true
+user-invocable: true
 args:
   - name: area
     description: The feature or area to audit (optional)

--- a/.claude/skills/bolder/SKILL.md
+++ b/.claude/skills/bolder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bolder
 description: Amplify safe or boring designs to make them more visually interesting and stimulating. Increases impact while maintaining usability.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to make bolder (optional)

--- a/.claude/skills/clarify/SKILL.md
+++ b/.claude/skills/clarify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clarify
 description: Improve unclear UX copy, error messages, microcopy, labels, and instructions. Makes interfaces easier to understand and use.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component with unclear copy (optional)

--- a/.claude/skills/colorize/SKILL.md
+++ b/.claude/skills/colorize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: colorize
 description: Add strategic color to features that are too monochromatic or lack visual interest. Makes interfaces more engaging and expressive.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to colorize (optional)

--- a/.claude/skills/critique/SKILL.md
+++ b/.claude/skills/critique/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: critique
 description: Evaluate design effectiveness from a UX perspective. Assesses visual hierarchy, information architecture, emotional resonance, and overall design quality with actionable feedback.
-user-invokable: true
+user-invocable: true
 args:
   - name: area
     description: The feature or area to critique (optional)

--- a/.claude/skills/delight/SKILL.md
+++ b/.claude/skills/delight/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: delight
 description: Add moments of joy, personality, and unexpected touches that make interfaces memorable and enjoyable to use. Elevates functional to delightful.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or area to add delight to (optional)

--- a/.claude/skills/distill/SKILL.md
+++ b/.claude/skills/distill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: distill
 description: Strip designs to their essence by removing unnecessary complexity. Great design is simple, powerful, and clean.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to distill (optional)

--- a/.claude/skills/extract/SKILL.md
+++ b/.claude/skills/extract/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: extract
 description: Extract and consolidate reusable components, design tokens, and patterns into your design system. Identifies opportunities for systematic reuse and enriches your component library.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature, component, or area to extract from (optional)

--- a/.claude/skills/harden/SKILL.md
+++ b/.claude/skills/harden/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: harden
 description: Improve interface resilience through better error handling, i18n support, text overflow handling, and edge case management. Makes interfaces robust and production-ready.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or area to harden (optional)

--- a/.claude/skills/normalize/SKILL.md
+++ b/.claude/skills/normalize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: normalize
 description: Normalize design to match your design system and ensure consistency
-user-invokable: true
+user-invocable: true
 args:
   - name: feature
     description: The page, route, or feature to normalize (optional)

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: onboard
 description: Design or improve onboarding flows, empty states, and first-time user experiences. Helps users get started successfully and understand value quickly.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or area needing onboarding (optional)

--- a/.claude/skills/optimize/SKILL.md
+++ b/.claude/skills/optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: optimize
 description: Improve interface performance across loading speed, rendering, animations, images, and bundle size. Makes experiences faster and smoother.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or area to optimize (optional)

--- a/.claude/skills/overdrive/SKILL.md
+++ b/.claude/skills/overdrive/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: overdrive
 description: Push interfaces past conventional limits with technically ambitious implementations. Whether that's a shader, a 60fps virtual table, spring physics on a dialog, or scroll-driven reveals — make users ask "how did they do that?"
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or area to push into overdrive (optional)

--- a/.claude/skills/polish/SKILL.md
+++ b/.claude/skills/polish/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polish
 description: Final quality pass before shipping. Fixes alignment, spacing, consistency, and detail issues that separate good from great.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or area to polish (optional)

--- a/.claude/skills/quieter/SKILL.md
+++ b/.claude/skills/quieter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: quieter
 description: Tone down overly bold or visually aggressive designs. Reduces intensity while maintaining design quality and impact.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to make quieter (optional)

--- a/.claude/skills/teach-impeccable/SKILL.md
+++ b/.claude/skills/teach-impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: teach-impeccable
 description: One-time setup that gathers design context for your project and saves it to your AI config file. Run once to establish persistent design guidelines.
-user-invokable: true
+user-invocable: true
 ---
 
 Gather design context for this project, then persist it for all future sessions.

--- a/.claude/skills/typeset/SKILL.md
+++ b/.claude/skills/typeset/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: typeset
 description: Improve typography by fixing font choices, hierarchy, sizing, weight consistency, and readability. Makes text feel intentional and polished.
-user-invokable: true
+user-invocable: true
 args:
   - name: target
     description: The feature or component to improve typography for (optional)


### PR DESCRIPTION
Fixes #49

## Bug
All 20 skill files used `user-invokable: true` in their YAML frontmatter, but Claude Code expects `user-invocable: true` (with a **c**, not a **k**).

This meant none of the impeccable skills appeared in the `/` slash command autocomplete menu. They still worked when invoked by name, but were invisible in the menu.

## Fix
Find-and-replaced `user-invokable` → `user-invocable` across all 20 skill files under `.claude/skills/*/`

## Files Changed
- 20 SKILL.md files (1 character change each)