### PR TITLE
fix: preserve article casing in prefixed skill references

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -331,7 +331,10 @@ export function prefixSkillReferences(content, prefix, skillNames) {
     result = result.replace(new RegExp(`\\/(?=${escapeRegex(name)}(?:[^a-zA-Z0-9_-]|$))`, 'g'), `/${prefix}`);
 
     // Replace `the skillname skill` references
-    result = result.replace(new RegExp(`the ${escapeRegex(name)} skill`, 'gi'), `the ${prefixed} skill`);
+    result = result.replace(
+      new RegExp(`(the) ${escapeRegex(name)} skill`, 'gi'),
+      (_, article) => `${article} ${prefixed} skill`
+    );
   }
 
   return result;

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -677,7 +677,7 @@ describe('prefixSkillReferences', () => {
     const result = prefixSkillReferences('Run /audit then /polish. The audit skill is great.', 'i-', ['audit', 'polish']);
     expect(result).toContain('/i-audit');
     expect(result).toContain('/i-polish');
-    expect(result).toContain('the i-audit skill');
+    expect(result).toContain('The i-audit skill');
   });
 
   test('should not partially match longer skill names', () => {
@@ -687,8 +687,7 @@ describe('prefixSkillReferences', () => {
 
   test('should handle case-insensitive "the X skill" matching', () => {
     const result = prefixSkillReferences('The audit skill is useful.', 'i-', ['audit']);
-    // The regex replaces case-insensitively, so "The" becomes "the" in the replacement
-    expect(result).toBe('the i-audit skill is useful.');
+    expect(result).toBe('The i-audit skill is useful.');
   });
 
   test('should return content unchanged with empty prefix', () => {


### PR DESCRIPTION
## Summary
- preserve the matched article casing when prefixing `the {skill} skill` references, so `The audit skill` becomes `The i-audit skill`
- keep the existing lowercase article behavior and `/skillname` prefixing unchanged
- update the focused utils regression expectations to cover the mixed-case phrase path

## Validation
- `bun test tests/lib/utils.test.js`
- `bun test`