### PR TITLE
fix: normalize quoted user-invokable frontmatter

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -59,9 +59,13 @@ export function parseFrontmatter(content) {
       if (colonIndex > 0) {
         const key = trimmed.slice(0, colonIndex).trim();
         const value = trimmed.slice(colonIndex + 1).trim();
+        const normalizedValue =
+          key === 'user-invokable' && /^['"](?:true|false)['"]$/.test(value)
+            ? value.slice(1, -1)
+            : value;
 
         if (value) {
-          frontmatter[key] = value === 'true' ? true : value === 'false' ? false : value;
+          frontmatter[key] = normalizedValue === 'true' ? true : normalizedValue === 'false' ? false : normalizedValue;
           currentKey = key;
           currentArray = null;
         } else {

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -101,7 +101,7 @@ Body.`;
     expect(result.frontmatter['user-invokable']).toBe(true);
   });
 
-  test('should parse user-invokable as string true (code behavior)', () => {
+  test('should parse quoted user-invokable boolean as true', () => {
     const content = `---
 name: test-skill
 user-invokable: 'true'
@@ -110,8 +110,19 @@ user-invokable: 'true'
 Body.`;
 
     const result = parseFrontmatter(content);
-    // The parseFrontmatter function doesn't strip quotes from YAML string values
-    expect(result.frontmatter['user-invokable']).toBe("'true'");
+    expect(result.frontmatter['user-invokable']).toBe(true);
+  });
+
+  test('should keep quoted non-user-invokable booleans as strings', () => {
+    const content = `---
+name: test-skill
+description: 'true'
+---
+
+Body.`;
+
+    const result = parseFrontmatter(content);
+    expect(result.frontmatter.description).toBe("'true'");
   });
 
   test('should parse allowed-tools field', () => {
@@ -377,6 +388,25 @@ Skill instructions here.`;
 name: audit
 description: Run technical quality checks
 user-invokable: true
+---
+
+Audit the code.`;
+
+    const skillDir = path.join(testRootDir, 'source/skills/audit');
+    ensureDir(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), skillContent);
+
+    const { skills } = readSourceFiles(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].userInvokable).toBe(true);
+  });
+
+  test('should read skill with quoted user-invokable flag', () => {
+    const skillContent = `---
+name: audit
+description: Run technical quality checks
+user-invokable: 'true'
 ---
 
 Audit the code.`;


### PR DESCRIPTION
## Summary
- normalize quoted `user-invokable` frontmatter booleans so `'true'`/`"true"` are treated the same as bare `true`
- keep quoted booleans on other frontmatter keys as strings instead of broadening parser behavior
- add focused regressions for both `parseFrontmatter()` and `readSourceFiles()` on quoted user-invokable values

## Validation
- `bun test tests/lib/utils.test.js`
- `bun test`