### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/public/cheatsheet.html
+++ b/public/cheatsheet.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TEXGHC7V34"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TEXGHC7V34');
+  </script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Impeccable Command Cheatsheet</title>

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TEXGHC7V34"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TEXGHC7V34');
+  </script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Impeccable: The missing upgrade to Anthropic's frontend-design skill</title>


### PR DESCRIPTION
## Summary
- Adds Google Analytics (gtag.js, G-TEXGHC7V34) to both `index.html` and `cheatsheet.html`
- Snippet placed first in `<head>` for early pageview capture; loads async so non-render-blocking

## Test plan
- [ ] Deploy and verify real-time data appears in GA4 dashboard
- [ ] Confirm both `/` and `/cheatsheet` register pageviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)