### PR TITLE
fix: register all 21 skills in plugin.json for Claude Code discovery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,27 @@
   },
   "homepage": "https://impeccable.style",
   "repository": "https://github.com/pbakaus/impeccable",
-  "skills": "./.claude/skills"
+  "skills": [
+    "./.claude/skills/adapt",
+    "./.claude/skills/animate",
+    "./.claude/skills/arrange",
+    "./.claude/skills/audit",
+    "./.claude/skills/bolder",
+    "./.claude/skills/clarify",
+    "./.claude/skills/colorize",
+    "./.claude/skills/critique",
+    "./.claude/skills/delight",
+    "./.claude/skills/distill",
+    "./.claude/skills/extract",
+    "./.claude/skills/frontend-design",
+    "./.claude/skills/harden",
+    "./.claude/skills/normalize",
+    "./.claude/skills/onboard",
+    "./.claude/skills/optimize",
+    "./.claude/skills/overdrive",
+    "./.claude/skills/polish",
+    "./.claude/skills/quieter",
+    "./.claude/skills/teach-impeccable",
+    "./.claude/skills/typeset"
+  ]
 }


### PR DESCRIPTION
## Problem

Only `typeset` is discovered as a Claude Code skill. The other 20 skills (audit, critique, polish, optimize, animate, etc.) exist in `.claude/skills/` with proper SKILL.md files but aren't registered.

## Root cause

`plugin.json` has `"skills": "./.claude/skills"` as a single string pointing to the parent directory. Claude Code's plugin system expects an **array of paths**, where each path points to an individual skill directory containing a `SKILL.md`.

## Fix

Changed `skills` to an array explicitly listing all 21 skill directories:

```json
"skills": [
  "./.claude/skills/adapt",
  "./.claude/skills/animate",
  "./.claude/skills/arrange",
  "./.claude/skills/audit",
  ...
]
```

All SKILL.md files already exist with proper frontmatter (`name`, `description`, `user-invocable: true`). No other changes needed.

## Testing

After this fix, `/reload-plugins` should show all 21 impeccable skills available via slash commands (`/impeccable:audit`, `/impeccable:polish`, etc.)