### PR TITLE
ci: Tessl skill review for SKILL.md pull requests

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,20 @@
+# Runs Tessl skill review on pull requests that touch any SKILL.md.
+# Posts (or updates) a single PR comment with scores and feedback.
+# See: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main


### PR DESCRIPTION
Hey @pbakaus 👋

Impeccable stands out because you treat cross-harness skills as a real engineering problem — one source of truth, real transforms, and docs that match how people ship. I’m grateful you merged [#55](https://github.com/pbakaus/impeccable/pull/55); the review was exactly the kind of sharp, fair maintainer signal that makes outside contributions land well (frontmatter detail, keeping PR-only files out of the tree).

Your note afterward stuck with me: you have your own pipeline to compile skills across providers, and it’s painful. **This workflow is not trying to replace that.** It doesn’t touch `bun run build`, transformers, or `dist/` — it only adds an optional, lightweight step for **reviewing skill content on PRs** (the same `tessl skill review` idea you said Tessl looks “super needed” for), so contributors get concrete feedback without you having to run it by hand every time.

## What this adds

A single file: [`.github/workflows/skill-review.yml`](https://github.com/rohan-tessl/impeccable/blob/feat/tessl-skill-review-action/.github/workflows/skill-review.yml).

- **When:** pull requests targeting `main` that change any `**/SKILL.md` (covers `source/skills/**` and other trees if those files appear in a diff).
- **What:** [`tesslio/skill-review`](https://github.com/tesslio/skill-review) installs the Tessl CLI, runs `tessl skill review` on **changed** skills only, and posts **one** PR comment (updated on new pushes — no spam).
- **Auth:** no Tessl account or API key for contributors. Only the default `GITHUB_TOKEN` is used to post that comment — standard for Actions that comment on PRs.
- **CI behavior:** by default it **does not fail** the check (`fail-threshold` is off unless you add it). So it’s feedback-first; you can turn on a gate later if you like.

## Why a separate workflow (not stuffed into `ci.yml`)

Path filtering keeps this job from running on unrelated PRs. If you’d rather fold it into `ci.yml` or narrow paths (e.g. only `source/skills/**/SKILL.md`), I’m happy to adjust in a follow-up commit.

## Optional: quality gate later

If you want PRs to fail when a skill regresses:

```yaml
- uses: tesslio/skill-review@main
  with:
    fail-threshold: 70
```

Totally your call — leaving it out keeps the first merge low-risk.

---

**Honest disclosure:** I work at @tesslio on tooling around agent skills. This isn’t a land grab for your build — it’s a small automation that matches what you already found useful in conversation, and you can rip it out or fork the workflow anytime.

Thanks again for Impeccable — it’s a reference project in this space. 🙏