### PR TITLE
ci: Tessl skill review + optimize (GA)

### DIFF
--- a/.github/workflows/skill-apply-optimize.yml
+++ b/.github/workflows/skill-apply-optimize.yml
@@ -1,0 +1,24 @@
+# Comment `/apply-optimize` on a PR to commit suggested optimizations from the review workflow.
+# Pairs with skill-review.yml (tesslio/skill-review-and-optimize).
+name: Apply Skill Optimization
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          mode: "apply"

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,23 @@
+# Tessl skill review + optional AI optimization suggestions on SKILL.md PRs.
+# Superset of tesslio/skill-review; uses TESSL_API_TOKEN for optimize. See:
+# https://github.com/giuseppe-trisciuoglio/developer-kit/pull/160
+name: Skill Review & Optimize
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          optimize: "true"
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
## Hey @pbakaus

 this upgrades it to tesslio/skill-review-and-optimize, which is a direct superset. same review scoring, plus an optimize flow on top.

### What changes

**`.github/workflows/skill-review.yml`**
- Uses [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) (SHA-pinned) instead of `tesslio/skill-review@main`
- Same trigger idea as a basic review workflow: PRs that change `**/SKILL.md`**, scoped to `main` (matches your existing CI)
- Same review scoring as before, plus **optimization suggestions** in a collapsible PR comment when enabled
- Needs a **`TESSL_API_TOKEN`** repository secret (same as other repos using the optimize path)

**`.github/workflows/skill-apply-optimize.yml`**
- Triggered when someone comments **`/apply-optimize`** on a PR
- Commits the suggested optimizations onto the PR branch (via the action’s apply mode)

### Maintainer setup

Add **Repository secrets → `TESSL_API_TOKEN`** (Tessl API token with rights for this automation). Without it, the optimize portion of the review workflow will not be able to run as intended.

### Honest disclosure

I work at [@tesslio](https://github.com/tesslio) where we build tooling around agent skills. This is the same GA pairing we’ve been rolling out elsewhere so maintainers get consistent feedback on `SKILL.md` changes without extra contributor setup.

Thanks in advance — happy to tweak triggers (e.g. drop `branches:` if you want every base branch) if you prefer.

🙏