### PR TITLE
fix: normalize quoted user-invocable frontmatter

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -62,13 +62,19 @@ export function parseFrontmatter(content) {
       if (colonIndex > 0) {
         const key = trimmed.slice(0, colonIndex).trim();
         const value = trimmed.slice(colonIndex + 1).trim();
-        const normalizedValue =
-          (key === 'user-invocable' || key === 'user-invokable') && /^['"](?:true|false)['"]$/.test(value)
-            ? value.slice(1, -1)
-            : value;
+        const isQuoted = /^(".*"|'.*')$/.test(value);
+        const unquotedValue = isQuoted ? value.slice(1, -1) : value;
+        const shouldCoerceBoolean =
+          key === 'user-invocable' || key === 'user-invokable' || !isQuoted;
 
         if (value) {
-          frontmatter[key] = normalizedValue === 'true' ? true : normalizedValue === 'false' ? false : normalizedValue;
+          frontmatter[key] = shouldCoerceBoolean
+            ? unquotedValue === 'true'
+              ? true
+              : unquotedValue === 'false'
+                ? false
+                : unquotedValue
+            : unquotedValue;
           currentKey = key;
           currentArray = null;
         } else {

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -62,13 +62,13 @@ export function parseFrontmatter(content) {
       if (colonIndex > 0) {
         const key = trimmed.slice(0, colonIndex).trim();
         const value = trimmed.slice(colonIndex + 1).trim();
-
-        if (value) {
-          // Strip YAML quotes
-          const unquoted = (value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))
+        const normalizedValue =
+          (key === 'user-invocable' || key === 'user-invokable') && /^['"](?:true|false)['"]$/.test(value)
             ? value.slice(1, -1)
             : value;
-          frontmatter[key] = unquoted === 'true' ? true : unquoted === 'false' ? false : unquoted;
+
+        if (value) {
+          frontmatter[key] = normalizedValue === 'true' ? true : normalizedValue === 'false' ? false : normalizedValue;
           currentKey = key;
           currentArray = null;
         } else {

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -102,7 +102,7 @@ Body.`;
     expect(result.frontmatter['user-invocable']).toBe(true);
   });
 
-  test('should keep quoted non-user-invocable booleans as strings', () => {
+  test('should keep quoted non-user-invocable booleans as plain strings', () => {
     const content = `---
 name: test-skill
 description: 'true'
@@ -111,7 +111,7 @@ description: 'true'
 Body.`;
 
     const result = parseFrontmatter(content);
-    expect(result.frontmatter.description).toBe("'true'");
+    expect(result.frontmatter.description).toBe('true');
   });
 
   test('should parse allowed-tools field', () => {

--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -90,7 +90,7 @@ Body.`;
     expect(result.frontmatter['user-invocable']).toBe(true);
   });
 
-  test('should parse user-invocable as string true (code behavior)', () => {
+  test('should parse quoted user-invocable boolean as true', () => {
     const content = `---
 name: test-skill
 user-invocable: 'true'
@@ -99,8 +99,19 @@ user-invocable: 'true'
 Body.`;
 
     const result = parseFrontmatter(content);
-    // parseFrontmatter strips YAML quotes, so 'true' becomes boolean true
     expect(result.frontmatter['user-invocable']).toBe(true);
+  });
+
+  test('should keep quoted non-user-invocable booleans as strings', () => {
+    const content = `---
+name: test-skill
+description: 'true'
+---
+
+Body.`;
+
+    const result = parseFrontmatter(content);
+    expect(result.frontmatter.description).toBe("'true'");
   });
 
   test('should parse allowed-tools field', () => {
@@ -356,6 +367,25 @@ Skill instructions here.`;
 name: audit
 description: Run technical quality checks
 user-invocable: true
+---
+
+Audit the code.`;
+
+    const skillDir = path.join(testRootDir, 'source/skills/audit');
+    ensureDir(skillDir);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), skillContent);
+
+    const { skills } = readSourceFiles(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].userInvocable).toBe(true);
+  });
+
+  test('should read skill with quoted user-invocable flag', () => {
+    const skillContent = `---
+name: audit
+description: Run technical quality checks
+user-invocable: 'true'
 ---
 
 Audit the code.`;


### PR DESCRIPTION
## Summary
- normalize quoted boolean frontmatter values only for the `user-invocable` flag (while keeping the legacy `user-invokable` spelling readable too)
- stop coercing unrelated quoted values like `description: 'true'` into booleans
- add focused regression coverage for quoted flags in both raw frontmatter parsing and `readSourceFiles`

## Testing
- `bun test tests/lib/utils.test.js`
- `PATH=/home/cc/tmp/bunshim:$PATH bun run build`