### PR TITLE
fix: add trailing slash to skills path in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   },
   "homepage": "https://impeccable.style",
   "repository": "https://github.com/pbakaus/impeccable",
-  "skills": "./.claude/skills"
+  "skills": "./.claude/skills/"
 }


### PR DESCRIPTION
Fixes #86

## Problem
The `skills` path in `.claude-plugin/plugin.json` was missing a trailing slash, which caused Claude Code to fail to recognize slash commands after installing the plugin.

## Solution
Added the missing trailing slash to the `skills` field:
```
-  "skills": "./.claude/skills"
+  "skills": "./.claude/skills/"
```

## Testing
All 220 existing tests pass (`bun test`). The fix was originally identified by the issue reporter, and this PR applies that exact one-character change.