### PR TITLE
security: use JSON.stringify for selector escaping in devtools panel

### DIFF
--- a/extension/devtools/panel.js
+++ b/extension/devtools/panel.js
@@ -501,10 +501,10 @@ function renderFindings(findings) {
 }
 
 function inspectElement(selector) {
-  const escaped = selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  const json = JSON.stringify(selector);
   chrome.devtools.inspectedWindow.eval(
     `(function() {
-      var el = document.querySelector('${escaped}');
+      var el = document.querySelector(${json});
       if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); inspect(el); }
     })()`
   );


### PR DESCRIPTION
## Summary

- Replaces manual `replace()` escaping with `JSON.stringify()` in the devtools panel's `inspectElement` function
- Eliminates a potential JS injection surface in `chrome.devtools.inspectedWindow.eval()`

## Motivation

The `inspectElement` function in `extension/devtools/panel.js` passes CSS selectors into `chrome.devtools.inspectedWindow.eval()`. The previous escaping only handled backslashes and single quotes:

```js
const escaped = selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
```

This is incomplete: selectors containing backticks, newlines, null bytes, or Unicode escape sequences could break out of the single-quoted string literal and inject arbitrary JS into the inspected page's context.

`JSON.stringify()` produces a properly escaped double-quoted JS string literal that handles all special characters, eliminating the injection surface entirely.

## Changes

| File | Change |
|------|--------|
| `extension/devtools/panel.js` | `inspectElement()`: replace manual escaping with `JSON.stringify()` |

## Test plan

- [ ] Open DevTools panel on a page with findings
- [ ] Click a finding to inspect the element -- verify element highlights and scrolls into view
- [ ] Test with selectors containing special chars (e.g., `[data-value="test's"]`)