### PR TITLE
fix(windows): resolve browser script paths from file URLs

### DIFF
--- a/src/detect-antipatterns.mjs
+++ b/src/detect-antipatterns.mjs
@@ -26,10 +26,11 @@ const IS_BROWSER = typeof window !== 'undefined';
 const IS_NODE = !IS_BROWSER;
 
 // @browser-strip-start
-let fs, path;
+let fs, path, fileURLToPath;
 if (!IS_BROWSER) {
   fs = (await import('node:fs')).default;
   path = (await import('node:path')).default;
+  ({ fileURLToPath } = await import('node:url'));
 }
 // @browser-strip-end
 
@@ -2677,6 +2678,17 @@ async function detectHtml(filePath) {
 // Puppeteer detection (for URLs)
 // ---------------------------------------------------------------------------
 
+function browserScriptPathFromModulePath(modulePath, pathModule = path) {
+  return pathModule.resolve(
+    pathModule.dirname(modulePath),
+    'detect-antipatterns-browser.js'
+  );
+}
+
+function resolveBrowserScriptPath(moduleUrl = import.meta.url, pathModule = path) {
+  return browserScriptPathFromModulePath(fileURLToPath(moduleUrl), pathModule);
+}
+
 async function detectUrl(url) {
   let puppeteer;
   try {
@@ -2686,10 +2698,7 @@ async function detectUrl(url) {
   }
 
   // Read the browser detection script — reuse it instead of reimplementing
-  const browserScriptPath = path.resolve(
-    path.dirname(new URL(import.meta.url).pathname),
-    'detect-antipatterns-browser.js'
-  );
+  const browserScriptPath = resolveBrowserScriptPath();
   let browserScript;
   try {
     browserScript = fs.readFileSync(browserScriptPath, 'utf-8');
@@ -3503,7 +3512,7 @@ The server provides:
   }
 
   const http = await import('node:http');
-  const scriptPath = path.join(path.dirname(new URL(import.meta.url).pathname), 'detect-antipatterns-browser.js');
+  const scriptPath = resolveBrowserScriptPath();
 
   let browserScript;
   try {
@@ -3579,6 +3588,7 @@ export {
   ANTIPATTERNS, SAFE_TAGS, OVERUSED_FONTS, GENERIC_FONTS,
   checkElementBorders, checkElementMotion, checkElementGlow, checkPageTypography, checkPageLayout, isNeutralColor, isFullPage,
   detectHtml, detectUrl, detectText,
+  browserScriptPathFromModulePath, resolveBrowserScriptPath,
   walkDir, formatFindings, SCANNABLE_EXTENSIONS, SKIP_DIRS,
   extractStyleBlocks, extractCSSinJS,
   buildImportGraph, resolveImport,

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -5,6 +5,7 @@ import { spawnSync } from 'child_process';
 import {
   ANTIPATTERNS, checkElementBorders, checkElementMotion, checkElementGlow, isNeutralColor, isFullPage,
   detectText, extractStyleBlocks, extractCSSinJS,
+  browserScriptPathFromModulePath,
   walkDir, SCANNABLE_EXTENSIONS,
   buildImportGraph, resolveImport,
   detectFrameworkConfig, isPortListening, FRAMEWORK_CONFIGS,
@@ -89,6 +90,19 @@ describe('isNeutralColor', () => {
   test('blue is not neutral', () => expect(isNeutralColor('rgb(59, 130, 246)')).toBe(false));
   test('transparent is neutral', () => expect(isNeutralColor('transparent')).toBe(true));
   test('null is neutral', () => expect(isNeutralColor(null)).toBe(true));
+});
+
+describe('browserScriptPathFromModulePath', () => {
+  test('builds a valid Windows browser script path without duplicating the drive letter', () => {
+    const scriptPath = browserScriptPathFromModulePath(
+      'C:\\Users\\alice\\impeccable\\src\\detect-antipatterns.mjs',
+      path.win32
+    );
+
+    expect(scriptPath).toBe(
+      'C:\\Users\\alice\\impeccable\\src\\detect-antipatterns-browser.js'
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- replace `new URL(import.meta.url).pathname` with a `fileURLToPath`-based helper when resolving `detect-antipatterns-browser.js`
- reuse the same helper for both URL scanning and live server injection paths
- add a Windows path regression test so drive letters do not get doubled

## Testing

- `node - <<'NODE' ... browserScriptPathFromModulePath(..., path.win32) ... NODE`
- `bun test tests/detect-antipatterns.test.js`
  - the new Windows path regression passes
  - the suite still has the pre-existing `linked stylesheet detected (jsdom default)` failure unrelated to this change

Fixes #95