### PR TITLE
fix(plugin): add trailing slash to skills path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   },
   "homepage": "https://impeccable.style",
   "repository": "https://github.com/pbakaus/impeccable",
-  "skills": "./.claude/skills"
+  "skills": "./.claude/skills/"
 }

--- a/tests/plugin-json.test.mjs
+++ b/tests/plugin-json.test.mjs
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+test('plugin.json skills path ends with trailing slash', () => {
+  const plugin = JSON.parse(fs.readFileSync('.claude-plugin/plugin.json', 'utf8'));
+  assert.equal(plugin.skills, './.claude/skills/');
+});


### PR DESCRIPTION
## Summary\n- update .claude-plugin/plugin.json to use ./\.claude/skills/ for the skills path\n- add a regression test asserting plugin skills path stays normalized with a trailing slash\n\n## Validation\n- node --test tests/plugin-json.test.mjs\n\nFixes #86