### PR TITLE
docs(impeccable): three new derivative-template DON'T rules (hedged type stacks, flat tech-blue, default pill chip)

### DIFF
--- a/source/skills/impeccable/SKILL.md
+++ b/source/skills/impeccable/SKILL.md
@@ -124,6 +124,7 @@ DO vary font weights and sizes to create clear visual hierarchy.
 DO vary your font choices across projects. If you used a serif display font on the last project, look for a sans, monospace, or display face on this one.
 
 DO NOT use overused fonts like Inter, Roboto, Arial, Open Sans, or system defaults — but also do not simply switch to your second-favorite. Every font in the reflex_fonts_to_reject list above is banned. Look further.
+DO NOT hedge a type stack by listing two display or body families as interchangeable choices ("Family A or Family B"). That is deferred commitment, not a type system. Commit to one primary family per role; a second family is only legitimate as a named license fallback.
 DO NOT use monospace typography as lazy shorthand for "technical/developer" vibes.
 DO NOT put large icons with rounded corners above every heading. They rarely add value and make sites look templated.
 DO NOT use only one font family for the entire page. Pair a distinctive display font with a refined body font.
@@ -166,6 +167,7 @@ DO tint your neutrals toward your brand hue. Even a subtle hint creates subconsc
 DO NOT use gray text on colored backgrounds; it looks washed out. Use a shade of the background color instead.
 DO NOT use pure black (#000) or pure white (#fff). Always tint; pure black/white never appears in nature.
 DO NOT use the AI color palette: cyan-on-dark, purple-to-blue gradients, neon accents on dark backgrounds.
+DO NOT use the saturated tech-product-blue accent (hue ~215–225, high chroma, lightness ~50% — the flat bright blue that reads as "a dev-tool landing page"). If the brand genuinely needs blue, shift the hue off that default and pair it with a non-neutral secondary.
 DO NOT use gradient text for impact — see <absolute_bans> below for the strict definition. Solid colors only for text.
 DO NOT default to dark mode with glowing accents. It looks "cool" without requiring actual design decisions.
 DO NOT default to light mode "to be safe" either. The point is to choose, not to retreat to a safe option.
@@ -224,6 +226,7 @@ DO NOT: Use border-left or border-right greater than 1px as a colored accent str
 DO NOT: Use glassmorphism everywhere (blur effects, glass cards, glow borders used decoratively rather than purposefully).
 DO NOT: Use sparklines as decoration. Tiny charts that look sophisticated but convey nothing meaningful.
 DO NOT: Use rounded rectangles with generic drop shadows. Safe, forgettable, could be any AI output.
+DO NOT: Use the default rounded-full pill chip (faint tinted background, faint hairline border, ~11–12px label) for "Beta"/"New" tags or section labels. That exact pill has become a category tell for dev-tool dashboards. Pick a distinctive label shape — bracketed uppercase `[NEW]`, rectangular with a thick underline, inline italic, or type weight and color alone. If you keep the pill, change at least two of: radius, weight, case, border, spacing.
 DO NOT: Use modals unless there's truly no better alternative. Modals are lazy.
 
 ### Motion

--- a/source/skills/impeccable/SKILL.md
+++ b/source/skills/impeccable/SKILL.md
@@ -124,7 +124,7 @@ DO vary font weights and sizes to create clear visual hierarchy.
 DO vary your font choices across projects. If you used a serif display font on the last project, look for a sans, monospace, or display face on this one.
 
 DO NOT use overused fonts like Inter, Roboto, Arial, Open Sans, or system defaults — but also do not simply switch to your second-favorite. Every font in the reflex_fonts_to_reject list above is banned. Look further.
-DO NOT hedge a type stack by listing two display or body families as interchangeable choices ("Family A or Family B"). That is deferred commitment, not a type system. Commit to one primary family per role; a second family is only legitimate as a named license fallback.
+DO NOT pair fonts by reflex. Run `font_selection_procedure` on EACH role — display, body, any third — independently; each must clear `reflex_fonts_to_reject` and Steps 1–4 on their own merits. A pair where only one role survived the procedure is still monoculture; the reflex just moved into the other role.
 DO NOT use monospace typography as lazy shorthand for "technical/developer" vibes.
 DO NOT put large icons with rounded corners above every heading. They rarely add value and make sites look templated.
 DO NOT use only one font family for the entire page. Pair a distinctive display font with a refined body font.


### PR DESCRIPTION
## Summary

Adds **three net-new DON'T rules** to `source/skills/impeccable/SKILL.md`, inserted into the existing typography, color, and visual-details rule blocks. Each rule targets a 2020s derivative-template tell the skill does not currently catch.

- **+1 line** in `<typography_rules>` — closes a reflex-pairing loophole in `font_selection_procedure`. Each role in a type stack (display, body, any third) must independently clear `reflex_fonts_to_reject` and Steps 1–4; a pair where only one role survived the procedure is still monoculture, just displaced into the other role.
- **+1 line** in `<color_rules>` — bans the saturated tech-product-blue accent band (hue ~215–225, high chroma, lightness ~50%). Complements the existing AI-color-palette rule (which catches gradient/neon combos, not flat default blue).
- **+1 line** in the Visual Details DON'T bullets — bans the default rounded-full pill chip (faint tinted background, faint hairline border, ~11–12px label) when used for `"Beta"`/`"New"` tags or section labels. No existing rule covers badge/chip shape.

**Diff:** 1 file, 3 insertions, 0 deletions on the original commit, with the typography rule rewritten in a follow-up amendment to anchor it to `font_selection_procedure` / `reflex_fonts_to_reject` (see below).

## Why this is scoped the way it is

- **Only `source/skills/impeccable/SKILL.md` is touched.** `source/` is the editable source per `DEVELOP.md`; the `.agents/`, `.claude/`, `.codex/`, `.cursor/`, `.gemini/`, `.kiro/`, `.opencode/`, `.pi/`, `.rovodev/`, `.trae*/` mirrors are build artifacts — not hand-edited here.
- **Time- and product-agnostic wording.** The final DON'T lines name no specific product, year, or brand so they age with the skill instead of out of it. The rationale text uses generic category references ("dev-tool dashboards", "dev-tool landing page") rather than product names.
- **No reference files, no detector code.** Intentionally keeping PR 1 minimal. If a reference file or detector follow-up is useful, it can land as a scoped follow-up PR.

## Evidence

Each rule was surfaced by at least one documented design-review dogfood where the *absence* of the rule let the tell ship or nearly ship:

- **Reflex pairing:** a direction doc specified two display families as interchangeable for headings. Each family in isolation might have cleared `reflex_fonts_to_reject`, but running `font_selection_procedure` on each role independently would have surfaced that neither was selected from a brief — both were reflex grabs. The existing "overused fonts" rule only catches individual families, not the reflex-pairing shape, so a designer who committed to a single reflex font in each of two roles would still pass it.
- **Flat tech-product blue:** a design-system palette that used `#0066FF` as the primary accent passed the AI-color-palette rule (no gradient, no neon) but read as a generic dev-tool landing page. The existing rule targets glow/gradient combos, not the flat-high-chroma-blue default.
- **Default pill chip:** multiple section-label and `"Beta"`/`"New"` treatments across unrelated pages reached for the faint-tinted-pill-with-hairline-border at 11–12px. No existing rule addressed badge shape, so the pill shipped by default on every project until flagged by hand.

## Scope: two tells held local, not proposed upstream

Two additional derivative-template tells from our internal checklist are intentionally **not** in this PR:

- **Three-bucket mono discipline** (separate real metadata, mono-as-vibe decoration, and mono inside a mark / SVG logotype). Held local because the rule is anchored to a specific company wordmark-SVG regression where mono strings that looked structural were stale pseudo-data. The symptom generalizes, but the "three buckets" framing only earns its keep with that dogfood evidence; proposing it upstream without that context would read as prescriptive.
- **Specimen-grid carve-out** (a narrow exception when an equal-weight three-column grid is genuinely a type-specimen or swatch grid where hierarchy would be misleading). Held local because the carve-out is useful internally but risks reading as an escape hatch in a broader audience.

If either generalizes with more external evidence, we'll scope a dedicated follow-up PR. Not this one.

## Test plan

- [x] Edit is isolated to `source/skills/impeccable/SKILL.md`.
- [x] `git diff --stat` against `upstream/main` shows 1 file, 3 insertions.
- [x] No mirror directory (`.agents/`, `.claude/`, `.codex/`, `.cursor/`, `.gemini/`, `.kiro/`, `.opencode/`, `.pi/`, `.rovodev/`, `.trae*/`) is touched; they regenerate via `bun run build`.
- [x] Each new DON'T line matches the cadence and tag structure of the rules immediately surrounding it (`DO NOT …` inside `<typography_rules>` and `<color_rules>`, `DO NOT: …` inside Visual Details bullets).
- [x] Final DON'T lines contain no product or company names.
- [x] Typography rule anchors explicitly to the existing `font_selection_procedure` / `reflex_fonts_to_reject` blocks so it still reads correctly in a 2027+ context.
- [ ] Maintainer review: does the chip rule belong in Visual Details or in a new badges/labels section? Open to moving if you prefer.
- [ ] Maintainer review: is the parenthetical hue range (`~215–225`, high chroma, ~50% L) concrete enough, or would you prefer an OKLCH-specific phrasing given the skill's existing OKLCH guidance?

## Follow-ups

If this lands cleanly, there is one candidate for a scoped second PR: a `reference/template-tells-2025.md` with rationale and rewrite patterns for each of the three tells in this PR. Holding it back to keep review surface minimal. The two tells named in the Scope section above are **not** candidates for a follow-up PR — they stay local unless new external evidence generalizes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
