### PR TITLE
fix(site): restore .prose class on docs and tutorial bodies

### DIFF
--- a/site/layouts/Doc.astro
+++ b/site/layouts/Doc.astro
@@ -76,7 +76,7 @@ for (const cat of CATEGORY_ORDER) {
           {tagline && <p class="sub-page-lede">{tagline}</p>}
         </header>
 
-        <div class="skills-detail-body docs-body">
+        <div class="skills-detail-body docs-body prose">
           <slot />
         </div>
 

--- a/site/pages/tutorials/[...slug].astro
+++ b/site/pages/tutorials/[...slug].astro
@@ -37,7 +37,7 @@ const { Content } = await render(entry);
       {entry.data.tagline && <p class="sub-page-lede">{entry.data.tagline}</p>}
     </header>
 
-    <div class="skills-detail-body docs-body tutorial-body">
+    <div class="skills-detail-body docs-body tutorial-body prose">
       <Content />
     </div>
   </div>


### PR DESCRIPTION
The Astro migration (b8f09c8) replaced the old generator's
`<section class="skill-detail-editorial prose">` wrapper with
`<div class="skills-detail-body docs-body">`, dropping the prose
class. The .prose rules in sub-pages.css were left intact but no
longer applied, so markdown bodies fell back to default browser
margins — heading top-margin shrank from 2.2em to ~0.83em and
line-height from 1.7 to 1.6, which read as cramped vertical
rhythm on mobile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds the `prose` CSS class to existing content wrappers, affecting presentation but not behavior or data handling.
> 
> **Overview**
> Restores sub-page markdown typography by adding the `prose` class back onto the main content wrappers in `Doc.astro` and `pages/tutorials/[...slug].astro`, so the existing `.prose` rules in `sub-pages.css` apply again (headings, spacing, line-height, max-width).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf6b12a2942311b9bf91255d8d0e65e2081f323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->