### PR TITLE
[RFC] feat: add finesse and juicy commands

### DIFF
--- a/.agents/skills/impeccable/SKILL.md
+++ b/.agents/skills/impeccable/SKILL.md
@@ -148,6 +148,8 @@ If someone could look at this interface and say "AI made that" without doubt, it
 | `layout [target]` | Enhance | Fix spacing, rhythm, and visual hierarchy | [reference/layout.md](reference/layout.md) |
 | `delight [target]` | Enhance | Add personality and memorable touches | [reference/delight.md](reference/delight.md) |
 | `overdrive [target]` | Enhance | Push past conventional limits | [reference/overdrive.md](reference/overdrive.md) |
+| `finesse [target]` | Enhance | Refine timing, easing, and choreography of existing interactions | [reference/finesse.md](reference/finesse.md) |
+| `juicy [target]` | Enhance | Add game-feel: cursor, drag, scroll, awareness, and optional sound | [reference/juicy.md](reference/juicy.md) |
 | `clarify [target]` | Fix | Improve UX copy, labels, and error messages | [reference/clarify.md](reference/clarify.md) |
 | `adapt [target]` | Fix | Adapt for different devices and screen sizes | [reference/adapt.md](reference/adapt.md) |
 | `optimize [target]` | Fix | Diagnose and fix UI performance | [reference/optimize.md](reference/optimize.md) |

--- a/.agents/skills/impeccable/reference/finesse.md
+++ b/.agents/skills/impeccable/reference/finesse.md
@@ -391,7 +391,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 2. **How fast must feedback be?**
    - Press feedback: ≤100ms (user perceives it as simultaneous with tap).
    - Toggle snap: 150ms (spring feel).
-   - Confirmation ripple: 600ms total (user sees result, confirmation appears then fades).
+   - Confirmation ripple: 600ms hold (enter + hold + exit ≈ 1s total).
 
 3. **Is this touch or mouse?**
    - Touch: hover states don't apply. Active states + haptic (where available) do.
@@ -433,7 +433,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 **Diff commentary**:
 - `transition-all` → `transition-[transform,background-color]` — prevents accidental capture of layout properties (margin, padding, border-radius).
 - `active:scale-[0.97]` — 3% reduction. More = theatrical; less = imperceptible.
-- `duration-100` — micro-interaction. Below 80ms threshold.
+- `duration-100` — micro-interaction. Near the 80ms threshold of perceived simultaneity.
 - `active:bg-blue-700` — color darkens on press, reinforcing press state visually.
 - Reduced-motion: no scale, instant color transition.
 
@@ -452,8 +452,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 **After** (CSS custom switch):
 ```css
 .switch-thumb {
-  transition: transform 150ms cubic-bezier(0.34, 1.2, 0.64, 1);
-  /* Slight spring overshoot (1.2 > 1.0) — controlled, not bouncy */
+  transition: transform 150ms cubic-bezier(0.65, 0, 0.35, 1);
 }
 
 .switch:checked .switch-thumb {
@@ -505,7 +504,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 
 **When not**: high-frequency actions (typing completion, filter changes), destructive actions that need a confirmation step.
 
-**Reasoning**: without a ripple, the user doesn't know the action registered. With a ripple, the success state announces itself and fades — 600ms total feels natural.
+**Reasoning**: without a ripple, the user doesn't know the action registered. With a ripple, the success state announces itself and fades — ~1s total (enter + confirm + exit) feels right: long enough to read, short enough not to linger.
 
 **After** (React with a temporary state):
 ```tsx
@@ -514,7 +513,7 @@ const [copied, setCopied] = useState(false);
 const handleCopy = () => {
   navigator.clipboard.writeText(value);
   setCopied(true);
-  setTimeout(() => setCopied(false), 1500);
+  setTimeout(() => setCopied(false), 600);
 };
 
 <button onClick={handleCopy} className="relative overflow-hidden">
@@ -744,15 +743,36 @@ function tweenNumber(from: number, to: number, el: HTMLElement, duration = 600) 
 
 **After**:
 ```tsx
-// Items exit with stagger, then empty state enters
+// import { AnimatePresence, motion } from 'framer-motion';
+// import type { CSSProperties } from 'react';
+
+// Items exit with stagger, then empty state enters.
+// ListItem and EmptyState must be motion.* components (or wrapped in motion.div)
+// with exit props so AnimatePresence can animate them out.
+// CSS-only alternative: apply the stagger pattern from Family 2 and v-if the empty state.
 const isEmpty = items.length === 0;
 
 <AnimatePresence>
   {items.map((item, i) => (
-    <ListItem key={item.id} style={{ '--i': i } as CSSProperties} />
+    <motion.li
+      key={item.id}
+      layout
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0, transition: { delay: i * 0.03 } }}
+      exit={{ opacity: 0, y: -8 }}
+    >
+      <ListItem data={item} />
+    </motion.li>
   ))}
   {isEmpty && (
-    <EmptyState className="animate-fade-in motion-reduce:animate-none" />
+    <motion.div
+      key="empty"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="motion-reduce:transition-none"
+    >
+      <EmptyState />
+    </motion.div>
   )}
 </AnimatePresence>
 ```
@@ -862,6 +882,7 @@ P3: banner entrance is instant (appears with no enter)
 ### After finesse
 
 ```tsx
+// import { Transition } from '@headlessui/react'; // or use <Transition> from your framework
 // NotificationBanner.tsx — after finesse
 export function NotificationBanner({ message, type, isVisible, onClose }: Props) {
   return (

--- a/.agents/skills/impeccable/reference/finesse.md
+++ b/.agents/skills/impeccable/reference/finesse.md
@@ -1,0 +1,930 @@
+> **Additional context needed**: existing motion conventions in codebase, `prefers-reduced-motion` support state, framework (Tailwind / vanilla CSS / CSS-in-JS).
+
+Refine the quality of interactions that already exist. Not adding new animations — correcting bad timing, replacing accidental defaults, choreographing state changes that are currently abrupt. The Japanese concept of *kodawari*: meticulous attention to things that don't need to be there, that most users won't consciously notice, but whose absence you always feel.
+
+The gap this fills: `animate` adds motion where there is none. `polish` fixes visual alignment and design-system drift. `delight` adds personality. `finesse` operates on *live interactions*, making the ones already there feel intentional.
+
+---
+
+## Register
+
+**Brand**: Apply finesse broadly — entrance choreography, page-level transitions, and micro-interactions contribute to the voice. Motion is part of the design identity.
+
+**Product**: Apply finesse at the interaction level, not the page level. Users are in a task; they don't wait for page-load choreography. Every interaction should give feedback; no interaction should feel jarring or unfinished.
+
+---
+
+## Scope
+
+**Does**: timing, easing curves, entrance/exit choreography, micro-feedback, state quality (hover, focus, active, loading, empty), asymmetric enter/exit, prefers-reduced-motion coverage.
+
+**Does not**: layout, typography, color, visual hierarchy — delegate those to `$impeccable layout`, `$impeccable typeset`, `$impeccable colorize`.
+
+---
+
+## Soft Dependencies
+
+Before starting, check if any of these outputs exist in the session or codebase:
+
+- **critique report**: use flagged "confusing" or "jarring" areas to prioritize patterns.
+- **audit report**: use a11y gaps (missing focus-visible, no reduced-motion) to drive Phase 2 order.
+- **polish notes**: avoid re-touching areas already polished; focus on what polish left.
+
+If none exist, proceed to Phase 1 with no prior context.
+
+---
+
+## Hard Block: `prefers-reduced-motion`
+
+**Never commit a motion pattern without a reduced-motion fallback.** Before applying any pattern from Phase 2, verify the target file has or will receive:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  /* fallback: typically opacity-only, no spatial movement */
+}
+```
+
+In Tailwind: `motion-reduce:transition-none`, `motion-reduce:scale-100`, `motion-reduce:translate-y-0`.
+
+Vestibular disorders affect ~35% of adults over 40. This is not optional. If the file lacks reduced-motion support and adding the patterns would introduce spatial movement, add the media query before applying the pattern.
+
+---
+
+## Phase 1: Audit
+
+Catalog all state changes in the target. Do not skip this phase. Applying patterns without an audit is how you introduce motion debt instead of removing it.
+
+### What to look for
+
+| Signal | What it means |
+|--------|--------------|
+| `transition-all` | Grabs everything including layout — replace with explicit properties |
+| `ease`, `linear`, no easing | CSS defaults that don't feel intentional |
+| Instant show/hide (`display: none` toggle, conditional render) | Abrupt — needs exit/entry |
+| `ease-in-out` on both enter and exit | Symmetric — should be asymmetric |
+| Duration > 500ms on feedback | Laggy — users will feel the wait |
+| Duration < 80ms on reveals | Too fast to track — increase to 150ms |
+| Missing `active:` state on interactive elements | No press feedback |
+| Missing `focus-visible:` | Keyboard users see nothing |
+| Bounce or elastic easing | Dated; remove |
+| Same duration on enter and exit | Exit should be ~75% of enter |
+| No `prefers-reduced-motion` coverage | Accessibility violation |
+
+### Audit output format
+
+Produce a prioritized list before applying anything:
+
+```
+FINESSE AUDIT — [ComponentName]
+
+P0 (blocking): transition-all in 3 places, no prefers-reduced-motion
+P1 (major):    instant show/hide on dropdown, no active: state on CTA button
+P2 (minor):    symmetric enter/exit on modal (both 300ms ease-in-out)
+P3 (polish):   hover lift missing on clickable cards
+```
+
+Apply P0 before P1, P1 before P2. Never apply everything at once — one pattern at a time, diff stays small.
+
+---
+
+## Phase 2: Apply
+
+### How to read each pattern
+
+Every pattern below has the same structure:
+- **When**: use this pattern.
+- **When not**: context where this pattern is wrong.
+- Short reasoning sentence (the *why*).
+- **Before / After**: worked code diff.
+- **Signal**: what correct feels like.
+
+---
+
+### Family 1: Exits
+
+#### Chain-of-thought: how to decide which exit pattern
+
+Before picking a pattern, answer in order:
+
+1. **Does the element occupy flow space, or float above content?**
+   - Occupies flow (chip, tag, list item, inline error) → choreographed exit (opacity then height collapse).
+   - Floats (tooltip, popover, toast, modal backdrop) → fade only (no height collapse needed).
+
+2. **Is the exit triggered by user action or external state change?**
+   - Direct action (user clicked Remove) → start immediately, aggressive ease-in (short).
+   - External change (timeout, server push) → gentle ease-in, give the eye time to track.
+
+3. **Is there a matching entry?**
+   - Yes → exit is ~75% of entry duration (from motion-design.md rule).
+   - No → use 150ms as default.
+
+4. **prefers-reduced-motion?** → Always provide opacity-only fallback.
+
+If you can't answer 1–3 without guessing, read the component context before applying.
+
+---
+
+#### Choreographed exit (for flow-occupying elements)
+
+**When**: removing chips, tags, list items, inline alerts, validation messages — elements that occupy space in the document flow.
+
+**When not**: overlays, tooltips, popovers, toasts that float over content.
+
+**Reasoning**: disappearing without collapsing leaves a gap that jumps — the element vanishes but space doesn't. Content around it lurches. Opacity fades first so the user sees the intent; then height collapses so surrounding content slides smoothly.
+
+**Before** (typical AI output):
+```tsx
+// v-if / conditional render — element just vanishes
+{isVisible && <Chip>{label}</Chip>}
+```
+
+**After** (Vue example):
+```vue
+<Transition
+  enter-active-class="transition-[opacity,max-height] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] overflow-hidden"
+  enter-from-class="opacity-0 max-h-0"
+  enter-to-class="opacity-100 max-h-[4rem]"
+  leave-active-class="transition-[opacity,max-height] duration-150 ease-[cubic-bezier(0.7,0,0.84,0)] overflow-hidden"
+  leave-from-class="opacity-100 max-h-[4rem]"
+  leave-to-class="opacity-0 max-h-0"
+>
+  <Chip v-if="isVisible">{{ label }}</Chip>
+</Transition>
+```
+
+**Diff commentary**:
+- Opacity goes first (200ms enter, 150ms exit — asymmetric).
+- Height collapse via `max-height` avoids animating `height: auto` directly.
+- `overflow-hidden` prevents content peeking during collapse.
+- Exit is 75% of enter duration (200 → 150ms).
+- `ease-out-expo` on enter (starts fast, decelerates into place). `ease-in` on exit (starts slow, accelerates away).
+
+**Signal**: element leaves, surrounding content shifts smoothly. User doesn't see a jump or a void.
+
+---
+
+#### Simple fade (for floating elements)
+
+**When**: tooltips, popovers, dropdowns, toast notifications, modal backdrops.
+
+**When not**: anything that occupies document flow — use choreographed exit instead.
+
+**Reasoning**: floating elements don't affect surrounding layout, so height choreography adds complexity with no visual benefit.
+
+**Before**:
+```css
+.tooltip { display: none; }
+.tooltip.visible { display: block; }
+```
+
+**After** (Tailwind + data-state pattern):
+```tsx
+<div
+  className="
+    transition-opacity duration-150
+    ease-[cubic-bezier(0.7,0,0.84,0)]
+    data-[state=closed]:opacity-0
+    data-[state=closed]:pointer-events-none
+    data-[state=open]:opacity-100
+    motion-reduce:transition-none
+  "
+  data-state={isOpen ? 'open' : 'closed'}
+>
+```
+
+**Signal**: tooltip appears and disappears. Eye tracks it. No snap-in, no snap-out.
+
+---
+
+#### Collapse vertical (for accordions and expandable sections)
+
+**When**: accordion panels, filter groups, validation error messages appearing/disappearing, details sections.
+
+**When not**: items in a flat list that are being *removed* — use choreographed exit. This pattern is for height toggling on the same element.
+
+**Reasoning**: `height: auto` can't be transitioned natively. Grid trick avoids JS measurement.
+
+**After** (CSS-only):
+```css
+.expandable {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 250ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.expandable.open {
+  grid-template-rows: 1fr;
+}
+
+.expandable-inner {
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .expandable { transition: none; }
+}
+```
+
+**Signal**: section opens with content arriving from top. No sudden appearance, no measurement jank.
+
+---
+
+#### Slide-out directional (for drawers and side panels)
+
+**When**: drawers, side panels, sheet overlays, off-canvas menus — elements with a clear origin edge.
+
+**When not**: inline content, dialogs without a directional relationship.
+
+**Reasoning**: direction must match the panel's origin. A right-side drawer slides right on exit. Sliding left on exit breaks spatial model.
+
+**After** (right panel exit):
+```css
+.panel-enter {
+  animation: slide-in-right 300ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.panel-exit {
+  animation: slide-out-right 200ms cubic-bezier(0.7, 0, 0.84, 0);
+}
+
+@keyframes slide-in-right {
+  from { transform: translateX(100%); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+
+@keyframes slide-out-right {
+  from { transform: translateX(0);    opacity: 1; }
+  to   { transform: translateX(100%); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel-enter, .panel-exit { animation: none; opacity: 1; }
+}
+```
+
+**Signal**: panel arrives from its source, leaves toward its source. Spatial model is consistent.
+
+---
+
+### Family 2: Entries
+
+#### Chain-of-thought: how to decide which entry pattern
+
+1. **Is this a list of items or a single element?**
+   - List of items → stagger (20–40ms per item, max 6–8 items staggered).
+   - Single element → fade-in or snap-in depending on context.
+
+2. **Does the element appear because of a user action or because data loaded?**
+   - User action (opened a dropdown, expanded a panel) → snap-in (scale + opacity, snappy).
+   - Data loaded (search results, list items rendered) → stagger fade.
+   - Route change → fade-in or dissolve depending on register.
+
+3. **Is there a corresponding exit?**
+   - Yes → enter is the inverse ease (exit ease-in → enter ease-out), ~33% longer than exit.
+
+4. **prefers-reduced-motion?** → fade only, no spatial movement.
+
+---
+
+#### Stagger (for lists of items)
+
+**When**: search results, card grids, permission lists, tag collections, notification feeds.
+
+**When not**: tables with >10 rows (fatigue), single-item reveals, page-level content.
+
+**Reasoning**: stagger reveals the list as a set with direction, not a batch dump. User perceives structure.
+
+**Before**:
+```tsx
+{items.map(item => <Card key={item.id} data={item} />)}
+```
+
+**After** (Tailwind + CSS custom property):
+```tsx
+{items.map((item, i) => (
+  <Card
+    key={item.id}
+    data={item}
+    className="animate-fade-in-up motion-reduce:animate-none"
+    style={{ '--i': i } as React.CSSProperties}
+  />
+))}
+```
+
+```css
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--i, 0) * 30ms);
+}
+```
+
+**Diff commentary**:
+- `--i` custom property drives stagger delay without JS.
+- 30ms per item × 8 items = 240ms total. Cap staggered count at 8; items 9+ appear simultaneously.
+- `both` fill mode: element starts in `from` state (opacity 0), ends in `to` (no snap-back).
+- `8px` translateY: subtle. More than 12px and it looks like a slide; less than 4px and it's imperceptible.
+
+**Signal**: list arrives with direction and rhythm. Not a screen of cards materializing at once.
+
+---
+
+#### Snap-in (for triggered overlays)
+
+**When**: dropdowns, popovers, context menus, dialogs — elements that appear in response to a direct user action.
+
+**When not**: list items, page content, passive notifications.
+
+**Reasoning**: snap-in confirms the user's action. The element must arrive fast — if it's slower than ~200ms, users wonder if the action registered.
+
+**After** (Tailwind):
+```tsx
+<Popover
+  className="
+    origin-top
+    data-[state=open]:animate-scale-in
+    data-[state=closed]:animate-scale-out
+    motion-reduce:data-[state=open]:animate-none
+    motion-reduce:data-[state=closed]:animate-none
+  "
+>
+```
+
+```css
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes scale-out {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.95); }
+}
+
+.animate-scale-in  { animation: scale-in  150ms cubic-bezier(0.16, 1, 0.3, 1); }
+.animate-scale-out { animation: scale-out 100ms cubic-bezier(0.7,  0, 0.84, 0); }
+```
+
+**Diff commentary**:
+- Scale from 0.95 (not 0.5, not 0.8) — subtle enough to feel physical, not theatrical.
+- Exit is 100ms (vs 150ms enter) — faster exit = snappier feel.
+- `origin-top` anchors scale to origin point. Use `origin-top-left` for right-edge dropdowns.
+- No bounce, no elastic.
+
+**Signal**: dropdown appears. User doesn't register "an animation happened" — they register "it's there."
+
+---
+
+### Family 3: Feedback
+
+#### Chain-of-thought: how to decide which feedback pattern
+
+1. **What is the user doing?**
+   - Pressing a button → press feedback.
+   - Toggling a switch or checkbox → toggle snap.
+   - Hovering a card or navigable item → hover lift (only if truly clickable).
+   - Completing an action (save, copy, delete) → ripple/confirmation.
+
+2. **How fast must feedback be?**
+   - Press feedback: ≤100ms (user perceives it as simultaneous with tap).
+   - Toggle snap: 150ms (spring feel).
+   - Confirmation ripple: 600ms total (user sees result, confirmation appears then fades).
+
+3. **Is this touch or mouse?**
+   - Touch: hover states don't apply. Active states + haptic (where available) do.
+   - Mouse: hover states are the primary affordance signal.
+
+---
+
+#### Press feedback (for all interactive buttons)
+
+**When**: every primary button, secondary button, IconButton, CTA, submit.
+
+**When not**: links in prose, dense list items, pagination controls.
+
+**Reasoning**: 80ms is the threshold of perceived simultaneity. Press feedback below 100ms feels like a physical button. Above 200ms, users wonder if the tap registered.
+
+**Before** (typical AI output):
+```tsx
+<button className="bg-blue-500 hover:bg-blue-600 transition-all duration-200">
+  Submit
+</button>
+```
+
+**After**:
+```tsx
+<button className="
+  bg-blue-500
+  hover:bg-blue-600
+  active:scale-[0.97] active:bg-blue-700
+  transition-[transform,background-color]
+  duration-100
+  ease-[cubic-bezier(0.16,1,0.3,1)]
+  motion-reduce:transition-none
+  motion-reduce:active:scale-100
+">
+  Submit
+</button>
+```
+
+**Diff commentary**:
+- `transition-all` → `transition-[transform,background-color]` — prevents accidental capture of layout properties (margin, padding, border-radius).
+- `active:scale-[0.97]` — 3% reduction. More = theatrical; less = imperceptible.
+- `duration-100` — micro-interaction. Below 80ms threshold.
+- `active:bg-blue-700` — color darkens on press, reinforcing press state visually.
+- Reduced-motion: no scale, instant color transition.
+
+**Signal**: user presses the button and doesn't consciously think about animation. But remove it and they notice something's missing.
+
+---
+
+#### Toggle snap (for switches and checkboxes)
+
+**When**: toggle switches, checkboxes that confirm a state change (not selection in a list).
+
+**When not**: bulk selection checkboxes in tables (too many state changes; stagger would be overwhelming).
+
+**Reasoning**: a switch communicates binary state — it should *snap* to position, not drift. The motion is faster than a reveal and uses a different easing.
+
+**After** (CSS custom switch):
+```css
+.switch-thumb {
+  transition: transform 150ms cubic-bezier(0.34, 1.2, 0.64, 1);
+  /* Slight spring overshoot (1.2 > 1.0) — controlled, not bouncy */
+}
+
+.switch:checked .switch-thumb {
+  transform: translateX(20px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-thumb { transition: none; }
+}
+```
+
+**Signal**: switch snaps to new position. Feels like a physical toggle, not a slow slide.
+
+---
+
+#### Hover lift (for navigable cards)
+
+**When**: cards or list items that navigate somewhere on click. The lift signals "this is clickable."
+
+**When not**: dense list items (the lift becomes noise), non-navigable cards (misleads), text links.
+
+**Reasoning**: shadow + micro-translate communicates "this element rises above the surface" — a physical affordance for clickability.
+
+**After**:
+```tsx
+<Card className="
+  transition-[transform,box-shadow]
+  duration-200
+  ease-[cubic-bezier(0.16,1,0.3,1)]
+  hover:-translate-y-0.5
+  hover:shadow-md
+  motion-reduce:hover:translate-y-0
+  motion-reduce:hover:shadow-md
+">
+```
+
+**Diff commentary**:
+- `2px` translateY (`-translate-y-0.5`) — visible but not dramatic.
+- `shadow-md` → one step up. Don't jump to `shadow-xl`; that's for modals.
+- `motion-reduce`: keep the shadow (visual affordance), remove the translate (spatial movement).
+
+**Signal**: user hovers a card and perceives "I can click this." Hover on non-navigable cards would be misleading — hence the "when not."
+
+---
+
+#### Confirmation ripple (for completed actions)
+
+**When**: copy-to-clipboard, save, send, upload complete, delete confirmation — one-shot actions where success isn't otherwise visible.
+
+**When not**: high-frequency actions (typing completion, filter changes), destructive actions that need a confirmation step.
+
+**Reasoning**: without a ripple, the user doesn't know the action registered. With a ripple, the success state announces itself and fades — 600ms total feels natural.
+
+**After** (React with a temporary state):
+```tsx
+const [copied, setCopied] = useState(false);
+
+const handleCopy = () => {
+  navigator.clipboard.writeText(value);
+  setCopied(true);
+  setTimeout(() => setCopied(false), 1500);
+};
+
+<button onClick={handleCopy} className="relative overflow-hidden">
+  <span className={`
+    transition-[opacity,transform] duration-200
+    ${copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'}
+  `}>Copy</span>
+  <span className={`
+    absolute inset-0 flex items-center justify-center
+    transition-[opacity,transform] duration-200
+    text-green-600
+    ${copied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'}
+  `}>✓ Copied</span>
+</button>
+```
+
+**Signal**: user clicks Copy. "✓ Copied" appears briefly and fades. No toast needed for inline confirmations.
+
+---
+
+### Family 4: Coordinated Sequences
+
+#### Chain-of-thought: how to sequence multi-element transitions
+
+When multiple elements change together, they should not change simultaneously.
+
+**Rule**: lead with context, follow with content.
+- Context elements (backdrop, overlay, container) appear first.
+- Content elements (modal body, panel content, list items) appear second, with a 50–80ms delay.
+
+Why: showing content before context gives the user nothing to orient against. The container arriving first establishes *where* content will be before it appears.
+
+**Rule for exits**: reverse the order.
+- Content exits first (the important part is leaving).
+- Context (backdrop, container) exits after a 50ms delay.
+
+---
+
+#### Backdrop before content (modal entry/exit)
+
+**When**: any overlay with a backdrop (modal, dialog, sheet).
+
+**When not**: overlays without backdrop (tooltips, popovers).
+
+**After**:
+```tsx
+// Backdrop — 150ms
+<div className="
+  fixed inset-0 bg-black/50
+  data-[state=open]:animate-fade-in
+  data-[state=closed]:animate-fade-out
+  motion-reduce:data-[state=open]:opacity-50
+  motion-reduce:data-[state=closed]:opacity-0
+" />
+
+// Content — 200ms, 50ms delay
+<div className="
+  fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2
+  data-[state=open]:animate-scale-in
+  data-[state=closed]:animate-scale-out
+  motion-reduce:data-[state=open]:animate-none
+" style={{ animationDelay: '50ms' }} />
+```
+
+**Signal**: backdrop arrives. Eye adjusts. Modal content arrives into that context. Feels staged, not dumped.
+
+---
+
+#### Skeleton → content (crossfade without layout shift)
+
+**When**: any component that loads async data where the skeleton has a fixed shape.
+
+**When not**: streaming content, variable-height content where exact skeleton height is unknown.
+
+**Reasoning**: the skeleton and real content must have identical dimensions. If they don't, the crossfade causes layout shift. This is worse than no animation.
+
+**After**:
+```tsx
+<div className="relative">
+  {/* Skeleton — fades out when data arrives */}
+  <div className={`
+    absolute inset-0
+    transition-opacity duration-200
+    ${isLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+    motion-reduce:transition-none
+  `}>
+    <SkeletonCard />
+  </div>
+
+  {/* Content — fades in when data arrives */}
+  <div className={`
+    transition-opacity duration-200
+    ${isLoaded ? 'opacity-100' : 'opacity-0'}
+    motion-reduce:transition-none
+  `}>
+    <RealCard data={data} />
+  </div>
+</div>
+```
+
+**Critical**: `absolute inset-0` on skeleton means it never shifts layout. Both layers occupy the same space. `pointer-events-none` on the exiting skeleton prevents click interception.
+
+**Signal**: content loads. Users sees a smooth crossfade, not a height jump.
+
+---
+
+#### Loading inline (button holds its width)
+
+**When**: any button that triggers an async action and shows a loading state.
+
+**When not**: buttons that navigate synchronously.
+
+**Reasoning**: a button changing size during loading shifts layout. If the CTA is 180px, it should be 180px whether it shows a label or a spinner.
+
+**After**:
+```tsx
+<button
+  disabled={isLoading}
+  className="min-w-[120px] h-10 transition-colors duration-150"
+>
+  {isLoading ? (
+    <Spinner className="mx-auto h-4 w-4 animate-spin motion-reduce:animate-none" />
+  ) : (
+    label
+  )}
+</button>
+```
+
+**Signal**: user clicks. Spinner appears. Button doesn't move. The rest of the form doesn't jump.
+
+---
+
+#### Error shake (validation feedback)
+
+**When**: form submission with validation errors.
+
+**When not**: on every keystroke (too much). Only on submission or on blur-and-resubmit.
+
+**Reasoning**: shake is universal language for "wrong." 3 cycles, 4px amplitude, 300ms total.
+
+**After**:
+```css
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60%  { transform: translateX(-4px); }
+  40%, 80%  { transform: translateX( 4px); }
+}
+
+.field-error {
+  animation: shake 300ms ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field-error {
+    animation: none;
+    outline: 2px solid red;
+    outline-offset: 2px;
+  }
+}
+```
+
+**Signal**: user submits invalid form. Field shakes briefly. Error message expands. User knows exactly which field failed without reading an error banner.
+
+---
+
+### Family 5: Data Transitions
+
+#### Animated number (counters and metrics)
+
+**When**: dashboards, counters, numeric badges that update — cases where the delta between old and new value is semantically meaningful.
+
+**When not**: input fields, IDs, codes, any number that isn't a meaningful quantity.
+
+```ts
+// Minimal JS tween (no library needed)
+function tweenNumber(from: number, to: number, el: HTMLElement, duration = 600) {
+  const start = performance.now();
+  const update = (now: number) => {
+    const t = Math.min((now - start) / duration, 1);
+    const eased = 1 - Math.pow(1 - t, 4); // ease-out-quart
+    el.textContent = String(Math.round(from + (to - from) * eased));
+    if (t < 1) requestAnimationFrame(update);
+  };
+  requestAnimationFrame(update);
+}
+```
+
+**Reduced-motion**: check `matchMedia('(prefers-reduced-motion: reduce)')` — if true, set value immediately.
+
+**Signal**: metric changes from 1,240 to 1,312. User sees the number counting up. Communicates live data, not a static snapshot.
+
+---
+
+#### Content swap (value changes in place)
+
+**When**: a displayed value changes (user selects a variant, locale changes a price, status updates).
+
+**When not**: values changing faster than 250ms (would look flickery).
+
+**After**:
+```css
+.value-swap-leave { animation: fade-out-up 80ms cubic-bezier(0.7, 0, 0.84, 0) both; }
+.value-swap-enter { animation: fade-in-up  80ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+
+@keyframes fade-out-up {
+  to { opacity: 0; transform: translateY(-4px); }
+}
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(4px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .value-swap-leave, .value-swap-enter { animation: none; }
+}
+```
+
+**Signal**: price changes from $12 to $15. Old value slides up and fades; new value slides up and arrives. User sees the change clearly.
+
+---
+
+#### Empty state transition
+
+**When**: a list transitions from populated to empty (items deleted, filter returns no results).
+
+**When not**: initial page load into an empty state — that's onboard territory.
+
+**After**:
+```tsx
+// Items exit with stagger, then empty state enters
+const isEmpty = items.length === 0;
+
+<AnimatePresence>
+  {items.map((item, i) => (
+    <ListItem key={item.id} style={{ '--i': i } as CSSProperties} />
+  ))}
+  {isEmpty && (
+    <EmptyState className="animate-fade-in motion-reduce:animate-none" />
+  )}
+</AnimatePresence>
+```
+
+**Signal**: user deletes last item. Items exit with stagger. Empty state fades in. User sees a narrative: "items gone → now empty." No jarring teleport.
+
+---
+
+### Family 6: Easing Quality
+
+#### Audit existing curves
+
+**When**: always — this is the first thing to fix before any other pattern.
+
+**What to search for and replace**:
+
+| Replace | With | Reason |
+|---------|------|--------|
+| `transition-all` | `transition-[transform,opacity]` or explicit properties | Catches layout properties accidentally |
+| `ease` (default) | `cubic-bezier(0.16, 1, 0.3, 1)` (expo-out) | Default ease is a compromise, not a choice |
+| `ease-linear` | Remove or use only for infinite loops (spinners) | Linear motion looks mechanical |
+| `ease-in-out` on enter | `ease-out` variant | Enters should decelerate into rest |
+| `ease-in-out` on exit | `ease-in` variant | Exits should accelerate away |
+| Same duration for enter and exit | Exit = 75% of enter | Exits should feel snappier |
+| `transition: all 300ms bounce` | `cubic-bezier(0.16, 1, 0.3, 1)` | Bounce easing looks dated |
+
+---
+
+#### Asymmetric enter/exit easing
+
+**When**: any element with both an enter and exit animation.
+
+**Reasoning**: objects entering our field of view decelerate as they settle (ease-out). Objects leaving accelerate away (ease-in). Symmetric easing (same curve on both) ignores physics and feels flat.
+
+**Canonical curves** (re-use from motion-design.md):
+```css
+--ease-enter: cubic-bezier(0.16, 1, 0.3, 1);   /* expo-out: confident deceleration */
+--ease-exit:  cubic-bezier(0.7,  0, 0.84, 0);   /* expo-in:  accelerates away */
+--ease-toggle: cubic-bezier(0.65, 0, 0.35, 1);  /* in-out: for state toggles only */
+```
+
+---
+
+#### Duration by distance
+
+**When**: any element that moves spatially (slides, translates, expands).
+
+| Motion distance | Duration |
+|----------------|----------|
+| Micro (button press, icon hover) | 80–100ms |
+| Short (tooltip, badge) | 150ms |
+| Medium (dropdown, popover, modal enter) | 200–250ms |
+| Long (drawer, full-panel) | 300–350ms |
+| Page-level (route change) | 350–500ms |
+
+An element traveling 8px should not take 500ms. An element traveling 400px should not take 100ms.
+
+---
+
+## Worked Example
+
+A full audit-to-application walkthrough on a `NotificationBanner` component.
+
+### Starting point
+
+```tsx
+// NotificationBanner.tsx — before finesse
+export function NotificationBanner({ message, type, onClose }: Props) {
+  return (
+    <div className={`
+      flex items-center gap-3 p-4 rounded-lg border
+      transition-all duration-300
+      ${type === 'error' ? 'bg-red-50 border-red-200' : 'bg-blue-50 border-blue-200'}
+    `}>
+      <Icon type={type} />
+      <p>{message}</p>
+      <button onClick={onClose} className="ml-auto hover:opacity-70">
+        <X size={16} />
+      </button>
+    </div>
+  );
+}
+```
+
+### Phase 1 Audit
+
+```
+FINESSE AUDIT — NotificationBanner
+
+P0: transition-all — grabs border, padding, border-radius on color change; risk of layout reflow
+P0: no prefers-reduced-motion coverage anywhere
+P1: onClose triggers instant removal — no exit animation
+P1: close button has no active: state, only opacity hover (no press feedback)
+P1: focus-visible ring missing on close button
+P2: ease default (not intentional) on transition
+P3: banner entrance is instant (appears with no enter)
+```
+
+### Decision: what to apply first
+
+1. P0: Replace `transition-all` with `transition-[background-color,border-color]`.
+2. P0: Add `prefers-reduced-motion` wrapper.
+3. P1: Wrap in `<Transition>` for choreographed exit (it occupies flow space).
+4. P1: Add `active:scale-[0.97]` + `focus-visible:ring-2` to close button.
+5. P3: Add fade-in entry.
+
+### After finesse
+
+```tsx
+// NotificationBanner.tsx — after finesse
+export function NotificationBanner({ message, type, isVisible, onClose }: Props) {
+  return (
+    <Transition
+      show={isVisible}
+      enter="transition-[opacity,max-height] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] overflow-hidden"
+      enterFrom="opacity-0 max-h-0"
+      enterTo="opacity-100 max-h-24"
+      leave="transition-[opacity,max-height] duration-150 ease-[cubic-bezier(0.7,0,0.84,0)] overflow-hidden"
+      leaveFrom="opacity-100 max-h-24"
+      leaveTo="opacity-0 max-h-0"
+    >
+      <div className={`
+        flex items-center gap-3 p-4 rounded-lg border
+        transition-[background-color,border-color] duration-200
+        ease-[cubic-bezier(0.16,1,0.3,1)]
+        motion-reduce:transition-none
+        ${type === 'error' ? 'bg-red-50 border-red-200' : 'bg-blue-50 border-blue-200'}
+      `}>
+        <Icon type={type} />
+        <p>{message}</p>
+        <button
+          onClick={onClose}
+          className="
+            ml-auto
+            hover:opacity-70
+            active:scale-[0.97]
+            transition-[transform,opacity] duration-100
+            ease-[cubic-bezier(0.16,1,0.3,1)]
+            focus-visible:ring-2 focus-visible:ring-offset-1
+            focus-visible:ring-current rounded
+            motion-reduce:transition-none
+            motion-reduce:active:scale-100
+          "
+          aria-label="Dismiss notification"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </Transition>
+  );
+}
+```
+
+### Verification checklist
+
+- [ ] Click dismiss: banner fades out while collapsing height. Surrounding content slides up smoothly.
+- [ ] Tab to close button: focus ring visible.
+- [ ] Press close button: 3% scale-down visible on active.
+- [ ] Switch `type` prop while visible: color transitions, no layout jump.
+- [ ] Set OS reduced-motion: no spatial movement. Opacity crossfades acceptable. Color change instant.
+- [ ] Banner re-appears (new notification): fade-in entry works.
+
+---
+
+## NEVER
+
+- Apply `transition-all` — always be explicit about which properties to transition.
+- Use bounce or elastic easing — they draw attention to the animation, not the content.
+- Animate `width`, `height`, `top`, `left`, `margin` directly — use transform, max-height, grid-template-rows, or FLIP.
+- Apply all patterns at once — one diff at a time. Motion debt compounds; so does motion noise.
+- Skip prefers-reduced-motion — this is an a11y violation, not a nice-to-have.
+- Add hover states that also fire on touch — `@media (hover: hover)` guards hover-only affordances.
+- Use the same duration on enter and exit — exit is ~75% of enter.
+
+When the interactions feel intentional without the user knowing why, hand off to `$impeccable polish` for the final pass.

--- a/.agents/skills/impeccable/reference/juicy.md
+++ b/.agents/skills/impeccable/reference/juicy.md
@@ -674,7 +674,7 @@ export function KanbanCard({ card, isDragging, onDragStart }: Props) {
         bg-white rounded border p-3 mb-2
         cursor-grab active:cursor-grabbing
         select-none
-        transition-[transform,opacity,shadow] duration-150
+        transition-[transform,opacity,box-shadow] duration-150
         ${isDragging
           ? 'opacity-40 scale-95 rotate-1 shadow-lg'
           : 'opacity-100 scale-100 rotate-0 shadow-sm'

--- a/.agents/skills/impeccable/reference/juicy.md
+++ b/.agents/skills/impeccable/reference/juicy.md
@@ -1,0 +1,746 @@
+> **Additional context needed**: brand register (consumer SaaS vs institutional), input modality (touch vs mouse primary), whether audio is appropriate for this context.
+
+Add game-feel to interactions that already work. *Juicy*, in game design, means every action has multiple layers of feedback — the interface is generous in what it gives back. `finesse` makes interactions intentional; `juicy` makes them satisfying.
+
+The distinction matters: a well-timed button press is finesse. The same button press with a cursor that acknowledges the drag, a drop zone that glows when valid, and a micro-click sound on confirm — that's juicy. It's a layer above polish, not a replacement.
+
+**Context gate**: before applying any pattern from this command, assess:
+- Is this SaaS / consumer product or institutional / financial / medical?
+- Is the primary modality touch or mouse?
+- Does the brand brief mention sound or haptics?
+
+Institutional contexts (government portals, banking, medical records, legal software) should default to `$impeccable finesse` only. Do not add sound, custom cursors, or drag choreography without an explicit brief that invites it.
+
+---
+
+## Register
+
+**Brand**: juicy is at home here — cursor customization, sound design, scroll choreography, and ambient awareness all contribute to brand voice. Apply broadly.
+
+**Product**: apply juicy at specific high-value moments, not globally. Completion states, drag-and-drop flows, interactive data visualizations. Productivity tools should be fast and quiet everywhere else.
+
+---
+
+## Soft Pre-requisite
+
+Run `$impeccable finesse` before `$impeccable juicy`. Juicy layers *on top of* correct timing and easing — adding drag choreography to a button that still uses `transition-all` creates an incoherent experience. Fix the foundation first.
+
+---
+
+## Hard Blocks
+
+1. **prefers-reduced-motion**: any pattern adding spatial motion requires a fallback (same rule as finesse).
+2. **Sound**: all audio patterns require: (a) user opt-in or system sound setting check, (b) AudioContext not `<audio>`, (c) volume ≤ -18dBFS, (d) global mute path.
+3. **Custom cursor**: never override cursor on text content, inputs, or textareas — this breaks UX.
+
+---
+
+## Phase 1: Audit
+
+Catalog gaps in the following categories before applying anything:
+
+| Area | What to look for |
+|------|-----------------|
+| Cursor | Draggable elements without `cursor-grab`, resizable panels without `cursor-col-resize`, copyable elements without `cursor-copy`, disabled elements with `cursor-default` instead of `cursor-not-allowed` |
+| Drag | Drag handlers using browser-default ghost image, no drop zone visual feedback, no reorder animation on list sort |
+| Scroll | Carousels without `scroll-snap`, long horizontal lists without snap, scroll-behavior not set, sticky headers that change height without transition |
+| Awareness | Missing `prefers-color-scheme` theme transition (flash instead of crossfade), missing `prefers-contrast` handling, hover states not guarded by `@media (hover: hover)` |
+| Selection | `::selection` using browser default (blue), range inputs with default thumb, search results without highlight animation |
+| Keyboard | Missing shortcut echo, focus ring that's correct but visually generic, no tab indicator on complex nav |
+| Sound | High-value interactions (toggle, confirm, delete) with no audio layer — note only if consumer/SaaS context |
+
+Produce a prioritized list, same P0–P3 format as finesse.
+
+---
+
+## Phase 2: Apply
+
+---
+
+### Family 1: Cursor
+
+#### Chain-of-thought: cursor decisions
+
+1. **What is the user about to do?**
+   - Grab and drag → `cursor-grab`, `cursor-grabbing` on active.
+   - Resize a panel → `cursor-col-resize` or `cursor-row-resize`.
+   - Click to zoom/expand → `cursor-zoom-in`.
+   - Copy content → `cursor-copy`.
+   - Interact with something currently unavailable → `cursor-not-allowed`.
+
+2. **Is this a text area, input, or selectable text?** → Do not override cursor. Browser defaults are correct here.
+
+3. **Is this a custom SVG cursor?** → Use only if it communicates something the system cursors can't (e.g., a canvas tool). Brand-logo cursors are noise.
+
+---
+
+#### Drag affordance cursors
+
+**When**: any draggable element — sortable list items, kanban cards, resize handles, panel splitters.
+
+**When not**: text, inputs, non-interactive elements.
+
+**After**:
+```tsx
+// Sortable list item
+<li
+  className="
+    cursor-grab
+    active:cursor-grabbing
+    select-none
+  "
+  draggable
+>
+```
+
+```css
+/* Panel resize handle */
+.resize-handle {
+  cursor: col-resize;
+  user-select: none;
+}
+
+/* When resizing is active */
+body.resizing {
+  cursor: col-resize;
+  user-select: none;
+}
+```
+
+**Diff commentary**:
+- `select-none` prevents text selection during drag (the most common drag UX bug).
+- Set `cursor-grabbing` on `body` during active drag — not just on the element — so cursor stays consistent if pointer moves off the element.
+- `cursor-grab` on hover, `cursor-grabbing` on mousedown.
+
+**Signal**: user hovers a draggable item and their hand cursor changes to a grab. No need to read documentation to know it's draggable.
+
+---
+
+#### Context-aware cursor vocabulary
+
+```tsx
+// Zoom-able image or map
+<div className="cursor-zoom-in hover:cursor-zoom-in">
+
+// Copyable token / code block
+<code className="cursor-copy" onClick={handleCopy}>
+
+// Disabled but visible (not hidden) control
+<button disabled className="cursor-not-allowed opacity-50">
+
+// Active painting or drawing tool
+// cursor: url('./brush.svg') 8 8, crosshair;
+// (hotspot at 8,8 = center of 16px icon)
+```
+
+**Signal**: cursor changes communicate affordance without tooltips. Users know what's interactive before they click.
+
+---
+
+### Family 2: Drag Choreography
+
+#### Chain-of-thought: drag quality decisions
+
+1. **What is being dragged?**
+   - A sortable list item → ghost + drop preview + reorder animation.
+   - A file into a drop zone → drop zone activation feedback.
+   - A resizable panel splitter → cursor + no ghost (it's not detached).
+
+2. **What does the drop zone need to communicate?**
+   - Idle (nothing being dragged) → normal appearance.
+   - Hovering with valid item → positive highlight (ring, background tint).
+   - Hovering with invalid item → negative signal (different color, `cursor-no-drop`).
+   - Dropped successfully → brief flash, then reorder animation.
+
+3. **Is there a reorder animation?**
+   - Yes → use FLIP or `View Transitions API` so displaced items slide to new positions.
+   - No → items teleport — jarring.
+
+---
+
+#### Custom ghost element
+
+**When**: any HTML5 drag-and-drop implementation where the browser default ghost (a semi-transparent copy) looks wrong.
+
+**After** (suppress browser ghost, use custom):
+```ts
+const handleDragStart = (e: DragEvent, item: Item) => {
+  // Suppress browser ghost
+  const ghost = document.createElement('div');
+  ghost.style.cssText = 'position:fixed;top:-9999px;left:-9999px;';
+  document.body.appendChild(ghost);
+  e.dataTransfer!.setDragImage(ghost, 0, 0);
+  setTimeout(() => ghost.remove(), 0);
+
+  // Show custom ghost (your styled element, following cursor via JS)
+  setDragging(item);
+};
+```
+
+```tsx
+// Custom ghost follows pointer
+{dragging && (
+  <div
+    className="
+      fixed pointer-events-none z-50
+      bg-white shadow-xl rounded-lg border border-gray-200
+      scale-105 rotate-1 opacity-90
+      transition-none
+    "
+    style={{ top: pointerY - 8, left: pointerX - 8 }}
+  >
+    <DragPreview item={dragging} />
+  </div>
+)}
+```
+
+**Signal**: dragged item lifts from surface, tilts slightly, follows cursor. Looks intentional, not like a browser screenshot.
+
+---
+
+#### Drop zone progressive feedback
+
+**When**: any designated drop target (file upload, kanban column, list reorder zone).
+
+**After**:
+```tsx
+<div
+  className={`
+    rounded-lg border-2 border-dashed p-4
+    transition-[border-color,background-color] duration-150
+    ${dragState === 'idle'     ? 'border-gray-200 bg-transparent' : ''}
+    ${dragState === 'hovering' ? 'border-blue-400 bg-blue-50 scale-[1.01]' : ''}
+    ${dragState === 'invalid'  ? 'border-red-300 bg-red-50' : ''}
+    motion-reduce:transition-none
+    motion-reduce:scale-100
+  `}
+>
+```
+
+**Three states required**: idle, hovering-valid, hovering-invalid. A drop zone that only changes on valid hover misses the feedback opportunity on invalid items.
+
+---
+
+#### Reorder animation (FLIP)
+
+**When**: sortable lists where items slide to new positions when one is moved.
+
+**Reasoning**: without reorder animation, the list appears to teleport. With it, users see spatial continuity — where each item came from and where it's going.
+
+```ts
+// FLIP: First, Last, Invert, Play
+function animateReorder(listEl: HTMLElement) {
+  // First: snapshot positions
+  const first = new Map<string, DOMRect>();
+  listEl.querySelectorAll('[data-id]').forEach(el => {
+    first.set(el.getAttribute('data-id')!, el.getBoundingClientRect());
+  });
+
+  // (DOM update happens here — React re-renders with new order)
+  requestAnimationFrame(() => {
+    // Last: measure new positions
+    listEl.querySelectorAll('[data-id]').forEach(el => {
+      const id = el.getAttribute('data-id')!;
+      const last = el.getBoundingClientRect();
+      const prev = first.get(id);
+      if (!prev) return;
+
+      // Invert
+      const dy = prev.top - last.top;
+      if (dy === 0) return;
+
+      // Play
+      el.animate(
+        [{ transform: `translateY(${dy}px)` }, { transform: 'translateY(0)' }],
+        { duration: 250, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }
+      );
+    });
+  });
+}
+```
+
+**Reduced-motion**: check `matchMedia('(prefers-reduced-motion: reduce)')` — skip the animation, let items teleport.
+
+**Signal**: user drops item. Displaced items slide to their new positions. No teleport.
+
+---
+
+### Family 3: Scroll
+
+#### scroll-snap (for carousels and horizontal lists)
+
+**When**: image carousels, horizontal card strips, mobile-style navigation, tab bars that scroll.
+
+**When not**: long vertical lists, data tables, free-form scroll areas.
+
+**After**:
+```css
+.carousel {
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none; /* Firefox */
+  -webkit-overflow-scrolling: touch;
+}
+
+.carousel::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel-item {
+  scroll-snap-align: start;
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel { scroll-behavior: auto; }
+}
+```
+
+**Signal**: user swipes carousel. Items snap to grid. No partial views between items.
+
+---
+
+#### Sticky header with scroll transform
+
+**When**: app headers or nav bars that should compress or change character on scroll.
+
+**When not**: headers on content pages where the header should remain fully visible.
+
+**After**:
+```tsx
+const { scrollY } = useScroll();
+const headerHeight = useTransform(scrollY, [0, 80], ['5rem', '3rem']);
+const shadowOpacity = useTransform(scrollY, [0, 40], [0, 1]);
+
+<motion.header
+  style={{ height: headerHeight }}
+  className="sticky top-0 z-10 bg-white transition-shadow"
+>
+  <motion.div
+    style={{ opacity: shadowOpacity }}
+    className="absolute inset-x-0 bottom-0 h-px bg-black/10"
+  />
+```
+
+**Reduced-motion**: use a single `ScrollObserver` to add a class when scrolled past threshold — apply shadow only, no height change.
+
+**Signal**: page scrolls. Header compresses. Shadow appears. User knows they're no longer at the top without looking for a scroll indicator.
+
+---
+
+### Family 4: Awareness
+
+#### Hover guard (touch devices)
+
+**When**: any component with `:hover` styles.
+
+**Reasoning**: touch devices fire `mouseover` on tap, then linger. A card that hover-lifts on touch stays lifted permanently. This is the most common cross-device polishing miss.
+
+**After**:
+```css
+/* Only apply hover effects when hover is the primary input */
+@media (hover: hover) {
+  .card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+  }
+}
+
+/* Touch-specific tap feedback instead */
+@media (hover: none) {
+  .card:active {
+    transform: scale(0.98);
+    transition: transform 80ms;
+  }
+}
+```
+
+**Signal**: card hover works on desktop. On mobile, tap gives press feedback instead of a stuck hover state.
+
+---
+
+#### Theme crossfade (no flash on color-scheme change)
+
+**When**: any app supporting both light and dark mode via `prefers-color-scheme` or a user toggle.
+
+**Reasoning**: switching themes without a transition causes an abrupt flash. A 200ms crossfade turns a jarring moment into a smooth state change.
+
+**After** (user-toggled theme):
+```css
+:root {
+  /* All color tokens go here */
+  transition: background-color 200ms ease-out, color 200ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root { transition: none; }
+}
+```
+
+**For system-level changes** (`prefers-color-scheme`): CSS transitions don't fire on media query changes — use a brief JS-added class to enable transitions only when theme toggle is triggered by user.
+
+**Signal**: user switches theme. Colors dissolve to new palette. No flash. No jank.
+
+---
+
+#### prefers-contrast awareness
+
+**When**: any app that should be usable by high-contrast users.
+
+**What changes** at high contrast:
+- Borders become more defined (increase border opacity or width).
+- Shadows become borders (drop shadows are invisible in forced colors mode; replace with solid borders).
+- Subtle backgrounds get removed (transparent surfaces become opaque).
+
+```css
+@media (forced-colors: active) {
+  .card {
+    border: 1px solid ButtonText;
+    box-shadow: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .muted-text { color: var(--color-text-primary); }
+  .border-subtle { border-color: var(--color-border-strong); }
+}
+```
+
+---
+
+### Family 5: Selection and Text
+
+#### Brand ::selection color
+
+**When**: always — this is one of the most overlooked details in every codebase.
+
+**Reasoning**: browser default blue selection doesn't match most brands. A selection in brand accent color costs one CSS rule and signals extreme attention to detail.
+
+**After**:
+```css
+::selection {
+  background-color: oklch(85% 0.15 var(--brand-hue) / 40%);
+  color: inherit;
+}
+```
+
+**Notes**:
+- Keep opacity low (30–50%) so text contrast isn't affected.
+- Use brand hue from design tokens, not a hardcoded hex.
+- `color: inherit` prevents selection from changing text color.
+
+**Signal**: user selects text. Selection is brand-colored. Nobody will say "nice selection color" — but they'll feel the product is made with intent.
+
+---
+
+#### Range input thumb
+
+**When**: any `<input type="range">` that uses browser default styling.
+
+**Reasoning**: browser-default range thumbs look like OS controls, not branded UI. Restyling them with consistent shape and animation signals ownership.
+
+**After**:
+```css
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--color-surface-3);
+  outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  cursor: pointer;
+  transition: transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 150ms;
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+input[type="range"]::-webkit-slider-thumb:active {
+  transform: scale(1.1);
+  box-shadow: 0 0 0 6px oklch(60% 0.2 var(--brand-hue) / 20%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  input[type="range"]::-webkit-slider-thumb { transition: none; }
+}
+```
+
+---
+
+### Family 6: Keyboard Feedback
+
+#### Shortcut echo
+
+**When**: any keyboard shortcut that triggers an action without obvious visual confirmation.
+
+**Reasoning**: sighted users who trigger shortcuts need feedback. Without it, they repeat the shortcut assuming it failed.
+
+**After**:
+```tsx
+// Show a brief badge near the triggered element or globally
+const [shortcutEcho, setShortcutEcho] = useState<string | null>(null);
+
+const echo = (label: string) => {
+  setShortcutEcho(label);
+  setTimeout(() => setShortcutEcho(null), 600);
+};
+
+// On shortcut trigger:
+echo('⌘K');
+
+// Echo badge
+{shortcutEcho && (
+  <div className="
+    fixed bottom-4 right-4
+    bg-gray-900 text-white text-xs
+    px-2 py-1 rounded
+    font-mono
+    animate-fade-in
+    motion-reduce:animate-none
+  ">
+    {shortcutEcho}
+  </div>
+)}
+```
+
+---
+
+#### Polished focus ring
+
+**When**: any interactive element that currently has a generic browser focus ring or `outline: none`.
+
+**Reasoning**: accessible focus ring ≠ beautiful focus ring. Both requirements can be satisfied simultaneously.
+
+**After**:
+```css
+/* Global polished focus-visible */
+:focus-visible {
+  outline: none;
+}
+
+/* Components set their own ring */
+.interactive:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--color-background),   /* gap */
+    0 0 0 4px var(--color-accent);       /* ring */
+}
+
+/* Inverse for dark surfaces */
+.inverse .interactive:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--color-surface-dark),
+    0 0 0 4px oklch(90% 0.05 var(--brand-hue));
+}
+```
+
+**Signal**: keyboard user tabs through UI. Every interactive element has a clean, brand-consistent ring. No generic blue, no invisible outline.
+
+---
+
+### Family 7: Sound (opt-in, contextual only)
+
+**Context gate**: only apply this family when:
+- Register is consumer SaaS, creative tool, productivity tool with brand permission for audio.
+- Product brief mentions or implies sound as part of UX.
+- NOT: institutional, financial, medical, government, enterprise admin, customer service tooling.
+
+If unsure: ask. Default to no sound.
+
+#### Architecture
+
+```ts
+// sound-manager.ts
+class SoundManager {
+  private context: AudioContext | null = null;
+  private enabled: boolean;
+
+  constructor() {
+    // Respect OS sound setting
+    this.enabled = !matchMedia('(prefers-reduced-motion: reduce)').matches;
+    // Note: no direct OS "mute" API — rely on app-level toggle
+  }
+
+  private getContext() {
+    if (!this.context) {
+      this.context = new AudioContext();
+    }
+    return this.context;
+  }
+
+  play(buffer: AudioBuffer, volume = 0.15) {
+    if (!this.enabled) return;
+    const ctx = this.getContext();
+    const source = ctx.createBufferSource();
+    const gain = ctx.createGain();
+    gain.gain.value = volume;
+    source.buffer = buffer;
+    source.connect(gain).connect(ctx.destination);
+    source.start();
+  }
+
+  setEnabled(v: boolean) { this.enabled = v; }
+}
+
+export const sounds = new SoundManager();
+```
+
+#### Sound vocabulary
+
+| Interaction | Duration | Character |
+|-------------|----------|-----------|
+| Toggle on | 10–20ms | Short, bright, +pitch |
+| Toggle off | 10–20ms | Short, muted, -pitch |
+| Item confirmed/checked | 15–25ms | Soft click, resolved |
+| Item removed/deleted | 20–30ms | Short descending |
+| Notification arrive | 30–50ms | Distinct, not harsh |
+| Error | 20–30ms | Low, brief |
+| Success (major) | 80–150ms | Ascending, resolved |
+
+**Volume target**: -18 to -24 dBFS. This is quiet — background noise level of a quiet room, not a notification.
+
+```ts
+// Generate a micro-sound with Web Audio API (no file needed)
+function createClick(ctx: AudioContext, freq = 800, dur = 0.015): AudioBuffer {
+  const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * dur), ctx.sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < data.length; i++) {
+    const t = i / ctx.sampleRate;
+    const env = Math.exp(-t * 300); // fast decay
+    data[i] = Math.sin(2 * Math.PI * freq * t) * env * 0.15;
+  }
+  return buf;
+}
+```
+
+**Signal**: user toggles a switch. A brief, soft click confirms the action. Remove it and the toggle feels slightly less physical. Users who notice it usually describe it as "snappy" — not "sounds."
+
+---
+
+## Worked Example
+
+A full audit-to-application walkthrough on a Kanban board card with drag-and-drop.
+
+### Starting point
+
+```tsx
+// KanbanCard.tsx — before juicy
+export function KanbanCard({ card, onDrag }: Props) {
+  return (
+    <div
+      className="bg-white rounded border p-3 mb-2 cursor-pointer"
+      draggable
+      onDragStart={() => onDrag(card.id)}
+    >
+      <h3 className="text-sm font-medium">{card.title}</h3>
+      <p className="text-xs text-gray-500">{card.assignee}</p>
+    </div>
+  );
+}
+```
+
+### Phase 1 Audit
+
+```
+JUICY AUDIT — KanbanCard / KanbanColumn
+
+P0: cursor-pointer on draggable element (should be cursor-grab)
+P0: no cursor:grabbing on active drag state
+P1: browser-default drag ghost (screenshot of card, semi-transparent)
+P1: drop zone has no visual feedback on hover-with-item
+P1: reorder has no animation — cards teleport to new positions
+P2: select-none missing — text gets selected during drag
+P3: ::selection color is browser default
+```
+
+### After juicy
+
+```tsx
+// KanbanCard.tsx — after juicy
+export function KanbanCard({ card, isDragging, onDragStart }: Props) {
+  return (
+    <div
+      className={`
+        bg-white rounded border p-3 mb-2
+        cursor-grab active:cursor-grabbing
+        select-none
+        transition-[transform,opacity,shadow] duration-150
+        ${isDragging
+          ? 'opacity-40 scale-95 rotate-1 shadow-lg'
+          : 'opacity-100 scale-100 rotate-0 shadow-sm'
+        }
+        motion-reduce:transition-none
+        motion-reduce:scale-100
+        motion-reduce:rotate-0
+      `}
+      draggable
+      onDragStart={onDragStart}
+    >
+      <h3 className="text-sm font-medium">{card.title}</h3>
+      <p className="text-xs text-gray-500">{card.assignee}</p>
+    </div>
+  );
+}
+
+// KanbanColumn.tsx — after juicy
+export function KanbanColumn({ cards, isDragOver, isInvalidTarget }: Props) {
+  return (
+    <div
+      className={`
+        flex flex-col gap-2 p-2 rounded-lg border-2 border-dashed min-h-[120px]
+        transition-[border-color,background-color] duration-150
+        ${isDragOver && !isInvalidTarget ? 'border-blue-400 bg-blue-50' : ''}
+        ${isInvalidTarget ? 'border-red-300 bg-red-50' : ''}
+        ${!isDragOver ? 'border-gray-200 bg-transparent' : ''}
+        motion-reduce:transition-none
+      `}
+    >
+      {cards.map((card, i) => (
+        <KanbanCard
+          key={card.id}
+          card={card}
+          data-id={card.id}
+          isDragging={false}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+### Verification checklist
+
+- [ ] Hover card: cursor is a grab hand.
+- [ ] Click-hold card: cursor becomes closed fist.
+- [ ] Drag card: source card fades and scales slightly (still visible, but receded).
+- [ ] Drag over valid column: column gets blue highlight.
+- [ ] Drag over invalid column: column gets red highlight.
+- [ ] Drop: displaced cards animate to new positions (FLIP).
+- [ ] Select text in card on desktop: `select-none` prevents accidental selection.
+- [ ] Touch device: no hover states; active feedback on tap.
+- [ ] OS reduced-motion: cursor changes work, but no scale/rotate on drag source, no reorder animation.
+
+---
+
+## NEVER
+
+- Add sound without user opt-in and volume control.
+- Add sound in institutional, financial, medical, or enterprise contexts without an explicit brief.
+- Override cursor on text, inputs, or textareas.
+- Use scroll-snap on long vertical lists (traps users).
+- Use custom SVG cursors as decoration (brand logo as cursor = noise, not craft).
+- Apply juicy to a codebase that still has `transition-all` (fix finesse first).
+- Assume touch users should see hover states — guard with `@media (hover: hover)`.
+- Use `<audio>` for UI sounds — use AudioContext API for microsounds.
+
+When game-feel layers on top of intentional motion, hand off to `$impeccable polish` for the final pass.

--- a/.agents/skills/impeccable/reference/juicy.md
+++ b/.agents/skills/impeccable/reference/juicy.md
@@ -308,6 +308,7 @@ function animateReorder(listEl: HTMLElement) {
 
 **After**:
 ```tsx
+// import { useScroll, useTransform, motion } from 'framer-motion';
 const { scrollY } = useScroll();
 const headerHeight = useTransform(scrollY, [0, 80], ['5rem', '3rem']);
 const shadowOpacity = useTransform(scrollY, [0, 40], [0, 1]);
@@ -566,9 +567,9 @@ class SoundManager {
   private enabled: boolean;
 
   constructor() {
-    // Respect OS sound setting
-    this.enabled = !matchMedia('(prefers-reduced-motion: reduce)').matches;
-    // Note: no direct OS "mute" API — rely on app-level toggle
+    // prefers-reduced-motion ≠ mute. Sound and motion are independent preferences.
+    // Use an app-level flag; give users a dedicated sound toggle, not a motion toggle proxy.
+    this.enabled = localStorage.getItem('ui-sounds') !== 'disabled';
   }
 
   private getContext() {
@@ -578,7 +579,8 @@ class SoundManager {
     return this.context;
   }
 
-  play(buffer: AudioBuffer, volume = 0.15) {
+  // volume: linear gain — 0.08 ≈ -22 dBFS (within -18 to -24 dBFS target)
+  play(buffer: AudioBuffer, volume = 0.08) {
     if (!this.enabled) return;
     const ctx = this.getContext();
     const source = ctx.createBufferSource();
@@ -611,13 +613,15 @@ export const sounds = new SoundManager();
 
 ```ts
 // Generate a micro-sound with Web Audio API (no file needed)
+// Buffer samples are normalized (peak ~1.0); volume is controlled by play()'s gain node.
+// Do NOT multiply by a gain factor here — that compounds with play()'s volume param.
 function createClick(ctx: AudioContext, freq = 800, dur = 0.015): AudioBuffer {
   const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * dur), ctx.sampleRate);
   const data = buf.getChannelData(0);
   for (let i = 0; i < data.length; i++) {
     const t = i / ctx.sampleRate;
     const env = Math.exp(-t * 300); // fast decay
-    data[i] = Math.sin(2 * Math.PI * freq * t) * env * 0.15;
+    data[i] = Math.sin(2 * Math.PI * freq * t) * env;
   }
   return buf;
 }
@@ -693,7 +697,10 @@ export function KanbanCard({ card, isDragging, onDragStart }: Props) {
 }
 
 // KanbanColumn.tsx — after juicy
-export function KanbanColumn({ cards, isDragOver, isInvalidTarget }: Props) {
+// isDragOver and isInvalidTarget must be wired to your DnD library's drag events.
+// dnd-kit: use useDroppable() + useDndMonitor(); react-dnd: use useDrop().
+// This example shows the visual logic; wire the boolean props to your library.
+export function KanbanColumn({ cards, activeCardId, isDragOver, isInvalidTarget }: Props) {
   return (
     <div
       className={`
@@ -705,12 +712,13 @@ export function KanbanColumn({ cards, isDragOver, isInvalidTarget }: Props) {
         motion-reduce:transition-none
       `}
     >
-      {cards.map((card, i) => (
+      {cards.map((card) => (
         <KanbanCard
           key={card.id}
           card={card}
           data-id={card.id}
-          isDragging={false}
+          isDragging={activeCardId === card.id} // wire to DnD library active item id
+          onDragStart={/* wire to library's drag-start handler */ undefined}
         />
       ))}
     </div>

--- a/.agents/skills/impeccable/scripts/command-metadata.json
+++ b/.agents/skills/impeccable/scripts/command-metadata.json
@@ -90,5 +90,13 @@
   "typeset": {
     "description": "Improves typography by fixing font choices, hierarchy, sizing, weight, and readability so text feels intentional. Use when the user mentions fonts, type, readability, text hierarchy, sizing looks off, or wants more polished, intentional typography.",
     "argumentHint": "[target]"
+  },
+  "finesse": {
+    "description": "Refine the timing, easing, and choreography of existing interactions — not adding new motion, but correcting bad defaults, asymmetric enter/exit curves, missing press feedback, abrupt show/hide, and unguarded prefers-reduced-motion. Use when interactions feel functional but not intentional, or when you want the kodawari pass on a component or page.",
+    "argumentHint": "[target]"
+  },
+  "juicy": {
+    "description": "Add game-feel layers to interactions that already have correct finesse: cursor affordances (grab, resize, copy), drag choreography (custom ghost, drop zone feedback, FLIP reorder), scroll snap, theme crossfade, brand ::selection color, and optional micro-sounds for consumer SaaS contexts. Run finesse before juicy.",
+    "argumentHint": "[target]"
   }
 }

--- a/.agents/skills/impeccable/scripts/pin.mjs
+++ b/.agents/skills/impeccable/scripts/pin.mjs
@@ -31,6 +31,7 @@ const VALID_COMMANDS = [
   'critique', 'audit',
   'polish', 'bolder', 'quieter', 'distill', 'harden', 'onboard', 'live',
   'animate', 'colorize', 'typeset', 'layout', 'delight', 'overdrive',
+  'finesse', 'juicy',
   'clarify', 'adapt', 'optimize',
 ];
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "impeccable",
-  "description": "Design fluency for frontend development. 1 skill with 23 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
-  "version": "3.0.7",
+  "description": "Design fluency for frontend development. 1 skill with 25 commands (/impeccable polish, /impeccable finesse, /impeccable juicy, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
+  "version": "3.1.0",
   "author": {
     "name": "Paul Bakaus",
     "email": "paul@paulbakaus.com"

--- a/.claude/skills/impeccable/SKILL.md
+++ b/.claude/skills/impeccable/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 3.0.7
+version: 3.1.0
 user-invocable: true
-argument-hint: "[craft|shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · teach|document|extract|live] [target]"
+argument-hint: "[craft|shape · audit|critique · animate|bolder|colorize|delight|finesse|juicy|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · teach|document|extract|live] [target]"
 license: Apache 2.0. Based on Anthropic's frontend-design skill. See NOTICE.md for attribution.
 allowed-tools:
   - Bash(npx impeccable *)
@@ -154,6 +154,8 @@ If someone could look at this interface and say "AI made that" without doubt, it
 | `layout [target]` | Enhance | Fix spacing, rhythm, and visual hierarchy | [reference/layout.md](reference/layout.md) |
 | `delight [target]` | Enhance | Add personality and memorable touches | [reference/delight.md](reference/delight.md) |
 | `overdrive [target]` | Enhance | Push past conventional limits | [reference/overdrive.md](reference/overdrive.md) |
+| `finesse [target]` | Enhance | Refine timing, easing, and choreography of existing interactions | [reference/finesse.md](reference/finesse.md) |
+| `juicy [target]` | Enhance | Add game-feel: cursor, drag, scroll, awareness, and optional sound | [reference/juicy.md](reference/juicy.md) |
 | `clarify [target]` | Fix | Improve UX copy, labels, and error messages | [reference/clarify.md](reference/clarify.md) |
 | `adapt [target]` | Fix | Adapt for different devices and screen sizes | [reference/adapt.md](reference/adapt.md) |
 | `optimize [target]` | Fix | Diagnose and fix UI performance | [reference/optimize.md](reference/optimize.md) |

--- a/.claude/skills/impeccable/reference/finesse.md
+++ b/.claude/skills/impeccable/reference/finesse.md
@@ -1,0 +1,930 @@
+> **Additional context needed**: existing motion conventions in codebase, `prefers-reduced-motion` support state, framework (Tailwind / vanilla CSS / CSS-in-JS).
+
+Refine the quality of interactions that already exist. Not adding new animations — correcting bad timing, replacing accidental defaults, choreographing state changes that are currently abrupt. The Japanese concept of *kodawari*: meticulous attention to things that don't need to be there, that most users won't consciously notice, but whose absence you always feel.
+
+The gap this fills: `animate` adds motion where there is none. `polish` fixes visual alignment and design-system drift. `delight` adds personality. `finesse` operates on *live interactions*, making the ones already there feel intentional.
+
+---
+
+## Register
+
+**Brand**: Apply finesse broadly — entrance choreography, page-level transitions, and micro-interactions contribute to the voice. Motion is part of the design identity.
+
+**Product**: Apply finesse at the interaction level, not the page level. Users are in a task; they don't wait for page-load choreography. Every interaction should give feedback; no interaction should feel jarring or unfinished.
+
+---
+
+## Scope
+
+**Does**: timing, easing curves, entrance/exit choreography, micro-feedback, state quality (hover, focus, active, loading, empty), asymmetric enter/exit, prefers-reduced-motion coverage.
+
+**Does not**: layout, typography, color, visual hierarchy — delegate those to `/impeccable layout`, `/impeccable typeset`, `/impeccable colorize`.
+
+---
+
+## Soft Dependencies
+
+Before starting, check if any of these outputs exist in the session or codebase:
+
+- **critique report**: use flagged "confusing" or "jarring" areas to prioritize patterns.
+- **audit report**: use a11y gaps (missing focus-visible, no reduced-motion) to drive Phase 2 order.
+- **polish notes**: avoid re-touching areas already polished; focus on what polish left.
+
+If none exist, proceed to Phase 1 with no prior context.
+
+---
+
+## Hard Block: `prefers-reduced-motion`
+
+**Never commit a motion pattern without a reduced-motion fallback.** Before applying any pattern from Phase 2, verify the target file has or will receive:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  /* fallback: typically opacity-only, no spatial movement */
+}
+```
+
+In Tailwind: `motion-reduce:transition-none`, `motion-reduce:scale-100`, `motion-reduce:translate-y-0`.
+
+Vestibular disorders affect ~35% of adults over 40. This is not optional. If the file lacks reduced-motion support and adding the patterns would introduce spatial movement, add the media query before applying the pattern.
+
+---
+
+## Phase 1: Audit
+
+Catalog all state changes in the target. Do not skip this phase. Applying patterns without an audit is how you introduce motion debt instead of removing it.
+
+### What to look for
+
+| Signal | What it means |
+|--------|--------------|
+| `transition-all` | Grabs everything including layout — replace with explicit properties |
+| `ease`, `linear`, no easing | CSS defaults that don't feel intentional |
+| Instant show/hide (`display: none` toggle, conditional render) | Abrupt — needs exit/entry |
+| `ease-in-out` on both enter and exit | Symmetric — should be asymmetric |
+| Duration > 500ms on feedback | Laggy — users will feel the wait |
+| Duration < 80ms on reveals | Too fast to track — increase to 150ms |
+| Missing `active:` state on interactive elements | No press feedback |
+| Missing `focus-visible:` | Keyboard users see nothing |
+| Bounce or elastic easing | Dated; remove |
+| Same duration on enter and exit | Exit should be ~75% of enter |
+| No `prefers-reduced-motion` coverage | Accessibility violation |
+
+### Audit output format
+
+Produce a prioritized list before applying anything:
+
+```
+FINESSE AUDIT — [ComponentName]
+
+P0 (blocking): transition-all in 3 places, no prefers-reduced-motion
+P1 (major):    instant show/hide on dropdown, no active: state on CTA button
+P2 (minor):    symmetric enter/exit on modal (both 300ms ease-in-out)
+P3 (polish):   hover lift missing on clickable cards
+```
+
+Apply P0 before P1, P1 before P2. Never apply everything at once — one pattern at a time, diff stays small.
+
+---
+
+## Phase 2: Apply
+
+### How to read each pattern
+
+Every pattern below has the same structure:
+- **When**: use this pattern.
+- **When not**: context where this pattern is wrong.
+- Short reasoning sentence (the *why*).
+- **Before / After**: worked code diff.
+- **Signal**: what correct feels like.
+
+---
+
+### Family 1: Exits
+
+#### Chain-of-thought: how to decide which exit pattern
+
+Before picking a pattern, answer in order:
+
+1. **Does the element occupy flow space, or float above content?**
+   - Occupies flow (chip, tag, list item, inline error) → choreographed exit (opacity then height collapse).
+   - Floats (tooltip, popover, toast, modal backdrop) → fade only (no height collapse needed).
+
+2. **Is the exit triggered by user action or external state change?**
+   - Direct action (user clicked Remove) → start immediately, aggressive ease-in (short).
+   - External change (timeout, server push) → gentle ease-in, give the eye time to track.
+
+3. **Is there a matching entry?**
+   - Yes → exit is ~75% of entry duration (from motion-design.md rule).
+   - No → use 150ms as default.
+
+4. **prefers-reduced-motion?** → Always provide opacity-only fallback.
+
+If you can't answer 1–3 without guessing, read the component context before applying.
+
+---
+
+#### Choreographed exit (for flow-occupying elements)
+
+**When**: removing chips, tags, list items, inline alerts, validation messages — elements that occupy space in the document flow.
+
+**When not**: overlays, tooltips, popovers, toasts that float over content.
+
+**Reasoning**: disappearing without collapsing leaves a gap that jumps — the element vanishes but space doesn't. Content around it lurches. Opacity fades first so the user sees the intent; then height collapses so surrounding content slides smoothly.
+
+**Before** (typical AI output):
+```tsx
+// v-if / conditional render — element just vanishes
+{isVisible && <Chip>{label}</Chip>}
+```
+
+**After** (Vue example):
+```vue
+<Transition
+  enter-active-class="transition-[opacity,max-height] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] overflow-hidden"
+  enter-from-class="opacity-0 max-h-0"
+  enter-to-class="opacity-100 max-h-[4rem]"
+  leave-active-class="transition-[opacity,max-height] duration-150 ease-[cubic-bezier(0.7,0,0.84,0)] overflow-hidden"
+  leave-from-class="opacity-100 max-h-[4rem]"
+  leave-to-class="opacity-0 max-h-0"
+>
+  <Chip v-if="isVisible">{{ label }}</Chip>
+</Transition>
+```
+
+**Diff commentary**:
+- Opacity goes first (200ms enter, 150ms exit — asymmetric).
+- Height collapse via `max-height` avoids animating `height: auto` directly.
+- `overflow-hidden` prevents content peeking during collapse.
+- Exit is 75% of enter duration (200 → 150ms).
+- `ease-out-expo` on enter (starts fast, decelerates into place). `ease-in` on exit (starts slow, accelerates away).
+
+**Signal**: element leaves, surrounding content shifts smoothly. User doesn't see a jump or a void.
+
+---
+
+#### Simple fade (for floating elements)
+
+**When**: tooltips, popovers, dropdowns, toast notifications, modal backdrops.
+
+**When not**: anything that occupies document flow — use choreographed exit instead.
+
+**Reasoning**: floating elements don't affect surrounding layout, so height choreography adds complexity with no visual benefit.
+
+**Before**:
+```css
+.tooltip { display: none; }
+.tooltip.visible { display: block; }
+```
+
+**After** (Tailwind + data-state pattern):
+```tsx
+<div
+  className="
+    transition-opacity duration-150
+    ease-[cubic-bezier(0.7,0,0.84,0)]
+    data-[state=closed]:opacity-0
+    data-[state=closed]:pointer-events-none
+    data-[state=open]:opacity-100
+    motion-reduce:transition-none
+  "
+  data-state={isOpen ? 'open' : 'closed'}
+>
+```
+
+**Signal**: tooltip appears and disappears. Eye tracks it. No snap-in, no snap-out.
+
+---
+
+#### Collapse vertical (for accordions and expandable sections)
+
+**When**: accordion panels, filter groups, validation error messages appearing/disappearing, details sections.
+
+**When not**: items in a flat list that are being *removed* — use choreographed exit. This pattern is for height toggling on the same element.
+
+**Reasoning**: `height: auto` can't be transitioned natively. Grid trick avoids JS measurement.
+
+**After** (CSS-only):
+```css
+.expandable {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 250ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.expandable.open {
+  grid-template-rows: 1fr;
+}
+
+.expandable-inner {
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .expandable { transition: none; }
+}
+```
+
+**Signal**: section opens with content arriving from top. No sudden appearance, no measurement jank.
+
+---
+
+#### Slide-out directional (for drawers and side panels)
+
+**When**: drawers, side panels, sheet overlays, off-canvas menus — elements with a clear origin edge.
+
+**When not**: inline content, dialogs without a directional relationship.
+
+**Reasoning**: direction must match the panel's origin. A right-side drawer slides right on exit. Sliding left on exit breaks spatial model.
+
+**After** (right panel exit):
+```css
+.panel-enter {
+  animation: slide-in-right 300ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.panel-exit {
+  animation: slide-out-right 200ms cubic-bezier(0.7, 0, 0.84, 0);
+}
+
+@keyframes slide-in-right {
+  from { transform: translateX(100%); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+
+@keyframes slide-out-right {
+  from { transform: translateX(0);    opacity: 1; }
+  to   { transform: translateX(100%); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel-enter, .panel-exit { animation: none; opacity: 1; }
+}
+```
+
+**Signal**: panel arrives from its source, leaves toward its source. Spatial model is consistent.
+
+---
+
+### Family 2: Entries
+
+#### Chain-of-thought: how to decide which entry pattern
+
+1. **Is this a list of items or a single element?**
+   - List of items → stagger (20–40ms per item, max 6–8 items staggered).
+   - Single element → fade-in or snap-in depending on context.
+
+2. **Does the element appear because of a user action or because data loaded?**
+   - User action (opened a dropdown, expanded a panel) → snap-in (scale + opacity, snappy).
+   - Data loaded (search results, list items rendered) → stagger fade.
+   - Route change → fade-in or dissolve depending on register.
+
+3. **Is there a corresponding exit?**
+   - Yes → enter is the inverse ease (exit ease-in → enter ease-out), ~33% longer than exit.
+
+4. **prefers-reduced-motion?** → fade only, no spatial movement.
+
+---
+
+#### Stagger (for lists of items)
+
+**When**: search results, card grids, permission lists, tag collections, notification feeds.
+
+**When not**: tables with >10 rows (fatigue), single-item reveals, page-level content.
+
+**Reasoning**: stagger reveals the list as a set with direction, not a batch dump. User perceives structure.
+
+**Before**:
+```tsx
+{items.map(item => <Card key={item.id} data={item} />)}
+```
+
+**After** (Tailwind + CSS custom property):
+```tsx
+{items.map((item, i) => (
+  <Card
+    key={item.id}
+    data={item}
+    className="animate-fade-in-up motion-reduce:animate-none"
+    style={{ '--i': i } as React.CSSProperties}
+  />
+))}
+```
+
+```css
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--i, 0) * 30ms);
+}
+```
+
+**Diff commentary**:
+- `--i` custom property drives stagger delay without JS.
+- 30ms per item × 8 items = 240ms total. Cap staggered count at 8; items 9+ appear simultaneously.
+- `both` fill mode: element starts in `from` state (opacity 0), ends in `to` (no snap-back).
+- `8px` translateY: subtle. More than 12px and it looks like a slide; less than 4px and it's imperceptible.
+
+**Signal**: list arrives with direction and rhythm. Not a screen of cards materializing at once.
+
+---
+
+#### Snap-in (for triggered overlays)
+
+**When**: dropdowns, popovers, context menus, dialogs — elements that appear in response to a direct user action.
+
+**When not**: list items, page content, passive notifications.
+
+**Reasoning**: snap-in confirms the user's action. The element must arrive fast — if it's slower than ~200ms, users wonder if the action registered.
+
+**After** (Tailwind):
+```tsx
+<Popover
+  className="
+    origin-top
+    data-[state=open]:animate-scale-in
+    data-[state=closed]:animate-scale-out
+    motion-reduce:data-[state=open]:animate-none
+    motion-reduce:data-[state=closed]:animate-none
+  "
+>
+```
+
+```css
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes scale-out {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.95); }
+}
+
+.animate-scale-in  { animation: scale-in  150ms cubic-bezier(0.16, 1, 0.3, 1); }
+.animate-scale-out { animation: scale-out 100ms cubic-bezier(0.7,  0, 0.84, 0); }
+```
+
+**Diff commentary**:
+- Scale from 0.95 (not 0.5, not 0.8) — subtle enough to feel physical, not theatrical.
+- Exit is 100ms (vs 150ms enter) — faster exit = snappier feel.
+- `origin-top` anchors scale to origin point. Use `origin-top-left` for right-edge dropdowns.
+- No bounce, no elastic.
+
+**Signal**: dropdown appears. User doesn't register "an animation happened" — they register "it's there."
+
+---
+
+### Family 3: Feedback
+
+#### Chain-of-thought: how to decide which feedback pattern
+
+1. **What is the user doing?**
+   - Pressing a button → press feedback.
+   - Toggling a switch or checkbox → toggle snap.
+   - Hovering a card or navigable item → hover lift (only if truly clickable).
+   - Completing an action (save, copy, delete) → ripple/confirmation.
+
+2. **How fast must feedback be?**
+   - Press feedback: ≤100ms (user perceives it as simultaneous with tap).
+   - Toggle snap: 150ms (spring feel).
+   - Confirmation ripple: 600ms total (user sees result, confirmation appears then fades).
+
+3. **Is this touch or mouse?**
+   - Touch: hover states don't apply. Active states + haptic (where available) do.
+   - Mouse: hover states are the primary affordance signal.
+
+---
+
+#### Press feedback (for all interactive buttons)
+
+**When**: every primary button, secondary button, IconButton, CTA, submit.
+
+**When not**: links in prose, dense list items, pagination controls.
+
+**Reasoning**: 80ms is the threshold of perceived simultaneity. Press feedback below 100ms feels like a physical button. Above 200ms, users wonder if the tap registered.
+
+**Before** (typical AI output):
+```tsx
+<button className="bg-blue-500 hover:bg-blue-600 transition-all duration-200">
+  Submit
+</button>
+```
+
+**After**:
+```tsx
+<button className="
+  bg-blue-500
+  hover:bg-blue-600
+  active:scale-[0.97] active:bg-blue-700
+  transition-[transform,background-color]
+  duration-100
+  ease-[cubic-bezier(0.16,1,0.3,1)]
+  motion-reduce:transition-none
+  motion-reduce:active:scale-100
+">
+  Submit
+</button>
+```
+
+**Diff commentary**:
+- `transition-all` → `transition-[transform,background-color]` — prevents accidental capture of layout properties (margin, padding, border-radius).
+- `active:scale-[0.97]` — 3% reduction. More = theatrical; less = imperceptible.
+- `duration-100` — micro-interaction. Below 80ms threshold.
+- `active:bg-blue-700` — color darkens on press, reinforcing press state visually.
+- Reduced-motion: no scale, instant color transition.
+
+**Signal**: user presses the button and doesn't consciously think about animation. But remove it and they notice something's missing.
+
+---
+
+#### Toggle snap (for switches and checkboxes)
+
+**When**: toggle switches, checkboxes that confirm a state change (not selection in a list).
+
+**When not**: bulk selection checkboxes in tables (too many state changes; stagger would be overwhelming).
+
+**Reasoning**: a switch communicates binary state — it should *snap* to position, not drift. The motion is faster than a reveal and uses a different easing.
+
+**After** (CSS custom switch):
+```css
+.switch-thumb {
+  transition: transform 150ms cubic-bezier(0.34, 1.2, 0.64, 1);
+  /* Slight spring overshoot (1.2 > 1.0) — controlled, not bouncy */
+}
+
+.switch:checked .switch-thumb {
+  transform: translateX(20px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-thumb { transition: none; }
+}
+```
+
+**Signal**: switch snaps to new position. Feels like a physical toggle, not a slow slide.
+
+---
+
+#### Hover lift (for navigable cards)
+
+**When**: cards or list items that navigate somewhere on click. The lift signals "this is clickable."
+
+**When not**: dense list items (the lift becomes noise), non-navigable cards (misleads), text links.
+
+**Reasoning**: shadow + micro-translate communicates "this element rises above the surface" — a physical affordance for clickability.
+
+**After**:
+```tsx
+<Card className="
+  transition-[transform,box-shadow]
+  duration-200
+  ease-[cubic-bezier(0.16,1,0.3,1)]
+  hover:-translate-y-0.5
+  hover:shadow-md
+  motion-reduce:hover:translate-y-0
+  motion-reduce:hover:shadow-md
+">
+```
+
+**Diff commentary**:
+- `2px` translateY (`-translate-y-0.5`) — visible but not dramatic.
+- `shadow-md` → one step up. Don't jump to `shadow-xl`; that's for modals.
+- `motion-reduce`: keep the shadow (visual affordance), remove the translate (spatial movement).
+
+**Signal**: user hovers a card and perceives "I can click this." Hover on non-navigable cards would be misleading — hence the "when not."
+
+---
+
+#### Confirmation ripple (for completed actions)
+
+**When**: copy-to-clipboard, save, send, upload complete, delete confirmation — one-shot actions where success isn't otherwise visible.
+
+**When not**: high-frequency actions (typing completion, filter changes), destructive actions that need a confirmation step.
+
+**Reasoning**: without a ripple, the user doesn't know the action registered. With a ripple, the success state announces itself and fades — 600ms total feels natural.
+
+**After** (React with a temporary state):
+```tsx
+const [copied, setCopied] = useState(false);
+
+const handleCopy = () => {
+  navigator.clipboard.writeText(value);
+  setCopied(true);
+  setTimeout(() => setCopied(false), 1500);
+};
+
+<button onClick={handleCopy} className="relative overflow-hidden">
+  <span className={`
+    transition-[opacity,transform] duration-200
+    ${copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'}
+  `}>Copy</span>
+  <span className={`
+    absolute inset-0 flex items-center justify-center
+    transition-[opacity,transform] duration-200
+    text-green-600
+    ${copied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'}
+  `}>✓ Copied</span>
+</button>
+```
+
+**Signal**: user clicks Copy. "✓ Copied" appears briefly and fades. No toast needed for inline confirmations.
+
+---
+
+### Family 4: Coordinated Sequences
+
+#### Chain-of-thought: how to sequence multi-element transitions
+
+When multiple elements change together, they should not change simultaneously.
+
+**Rule**: lead with context, follow with content.
+- Context elements (backdrop, overlay, container) appear first.
+- Content elements (modal body, panel content, list items) appear second, with a 50–80ms delay.
+
+Why: showing content before context gives the user nothing to orient against. The container arriving first establishes *where* content will be before it appears.
+
+**Rule for exits**: reverse the order.
+- Content exits first (the important part is leaving).
+- Context (backdrop, container) exits after a 50ms delay.
+
+---
+
+#### Backdrop before content (modal entry/exit)
+
+**When**: any overlay with a backdrop (modal, dialog, sheet).
+
+**When not**: overlays without backdrop (tooltips, popovers).
+
+**After**:
+```tsx
+// Backdrop — 150ms
+<div className="
+  fixed inset-0 bg-black/50
+  data-[state=open]:animate-fade-in
+  data-[state=closed]:animate-fade-out
+  motion-reduce:data-[state=open]:opacity-50
+  motion-reduce:data-[state=closed]:opacity-0
+" />
+
+// Content — 200ms, 50ms delay
+<div className="
+  fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2
+  data-[state=open]:animate-scale-in
+  data-[state=closed]:animate-scale-out
+  motion-reduce:data-[state=open]:animate-none
+" style={{ animationDelay: '50ms' }} />
+```
+
+**Signal**: backdrop arrives. Eye adjusts. Modal content arrives into that context. Feels staged, not dumped.
+
+---
+
+#### Skeleton → content (crossfade without layout shift)
+
+**When**: any component that loads async data where the skeleton has a fixed shape.
+
+**When not**: streaming content, variable-height content where exact skeleton height is unknown.
+
+**Reasoning**: the skeleton and real content must have identical dimensions. If they don't, the crossfade causes layout shift. This is worse than no animation.
+
+**After**:
+```tsx
+<div className="relative">
+  {/* Skeleton — fades out when data arrives */}
+  <div className={`
+    absolute inset-0
+    transition-opacity duration-200
+    ${isLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+    motion-reduce:transition-none
+  `}>
+    <SkeletonCard />
+  </div>
+
+  {/* Content — fades in when data arrives */}
+  <div className={`
+    transition-opacity duration-200
+    ${isLoaded ? 'opacity-100' : 'opacity-0'}
+    motion-reduce:transition-none
+  `}>
+    <RealCard data={data} />
+  </div>
+</div>
+```
+
+**Critical**: `absolute inset-0` on skeleton means it never shifts layout. Both layers occupy the same space. `pointer-events-none` on the exiting skeleton prevents click interception.
+
+**Signal**: content loads. Users sees a smooth crossfade, not a height jump.
+
+---
+
+#### Loading inline (button holds its width)
+
+**When**: any button that triggers an async action and shows a loading state.
+
+**When not**: buttons that navigate synchronously.
+
+**Reasoning**: a button changing size during loading shifts layout. If the CTA is 180px, it should be 180px whether it shows a label or a spinner.
+
+**After**:
+```tsx
+<button
+  disabled={isLoading}
+  className="min-w-[120px] h-10 transition-colors duration-150"
+>
+  {isLoading ? (
+    <Spinner className="mx-auto h-4 w-4 animate-spin motion-reduce:animate-none" />
+  ) : (
+    label
+  )}
+</button>
+```
+
+**Signal**: user clicks. Spinner appears. Button doesn't move. The rest of the form doesn't jump.
+
+---
+
+#### Error shake (validation feedback)
+
+**When**: form submission with validation errors.
+
+**When not**: on every keystroke (too much). Only on submission or on blur-and-resubmit.
+
+**Reasoning**: shake is universal language for "wrong." 3 cycles, 4px amplitude, 300ms total.
+
+**After**:
+```css
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60%  { transform: translateX(-4px); }
+  40%, 80%  { transform: translateX( 4px); }
+}
+
+.field-error {
+  animation: shake 300ms ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field-error {
+    animation: none;
+    outline: 2px solid red;
+    outline-offset: 2px;
+  }
+}
+```
+
+**Signal**: user submits invalid form. Field shakes briefly. Error message expands. User knows exactly which field failed without reading an error banner.
+
+---
+
+### Family 5: Data Transitions
+
+#### Animated number (counters and metrics)
+
+**When**: dashboards, counters, numeric badges that update — cases where the delta between old and new value is semantically meaningful.
+
+**When not**: input fields, IDs, codes, any number that isn't a meaningful quantity.
+
+```ts
+// Minimal JS tween (no library needed)
+function tweenNumber(from: number, to: number, el: HTMLElement, duration = 600) {
+  const start = performance.now();
+  const update = (now: number) => {
+    const t = Math.min((now - start) / duration, 1);
+    const eased = 1 - Math.pow(1 - t, 4); // ease-out-quart
+    el.textContent = String(Math.round(from + (to - from) * eased));
+    if (t < 1) requestAnimationFrame(update);
+  };
+  requestAnimationFrame(update);
+}
+```
+
+**Reduced-motion**: check `matchMedia('(prefers-reduced-motion: reduce)')` — if true, set value immediately.
+
+**Signal**: metric changes from 1,240 to 1,312. User sees the number counting up. Communicates live data, not a static snapshot.
+
+---
+
+#### Content swap (value changes in place)
+
+**When**: a displayed value changes (user selects a variant, locale changes a price, status updates).
+
+**When not**: values changing faster than 250ms (would look flickery).
+
+**After**:
+```css
+.value-swap-leave { animation: fade-out-up 80ms cubic-bezier(0.7, 0, 0.84, 0) both; }
+.value-swap-enter { animation: fade-in-up  80ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+
+@keyframes fade-out-up {
+  to { opacity: 0; transform: translateY(-4px); }
+}
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(4px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .value-swap-leave, .value-swap-enter { animation: none; }
+}
+```
+
+**Signal**: price changes from $12 to $15. Old value slides up and fades; new value slides up and arrives. User sees the change clearly.
+
+---
+
+#### Empty state transition
+
+**When**: a list transitions from populated to empty (items deleted, filter returns no results).
+
+**When not**: initial page load into an empty state — that's onboard territory.
+
+**After**:
+```tsx
+// Items exit with stagger, then empty state enters
+const isEmpty = items.length === 0;
+
+<AnimatePresence>
+  {items.map((item, i) => (
+    <ListItem key={item.id} style={{ '--i': i } as CSSProperties} />
+  ))}
+  {isEmpty && (
+    <EmptyState className="animate-fade-in motion-reduce:animate-none" />
+  )}
+</AnimatePresence>
+```
+
+**Signal**: user deletes last item. Items exit with stagger. Empty state fades in. User sees a narrative: "items gone → now empty." No jarring teleport.
+
+---
+
+### Family 6: Easing Quality
+
+#### Audit existing curves
+
+**When**: always — this is the first thing to fix before any other pattern.
+
+**What to search for and replace**:
+
+| Replace | With | Reason |
+|---------|------|--------|
+| `transition-all` | `transition-[transform,opacity]` or explicit properties | Catches layout properties accidentally |
+| `ease` (default) | `cubic-bezier(0.16, 1, 0.3, 1)` (expo-out) | Default ease is a compromise, not a choice |
+| `ease-linear` | Remove or use only for infinite loops (spinners) | Linear motion looks mechanical |
+| `ease-in-out` on enter | `ease-out` variant | Enters should decelerate into rest |
+| `ease-in-out` on exit | `ease-in` variant | Exits should accelerate away |
+| Same duration for enter and exit | Exit = 75% of enter | Exits should feel snappier |
+| `transition: all 300ms bounce` | `cubic-bezier(0.16, 1, 0.3, 1)` | Bounce easing looks dated |
+
+---
+
+#### Asymmetric enter/exit easing
+
+**When**: any element with both an enter and exit animation.
+
+**Reasoning**: objects entering our field of view decelerate as they settle (ease-out). Objects leaving accelerate away (ease-in). Symmetric easing (same curve on both) ignores physics and feels flat.
+
+**Canonical curves** (re-use from motion-design.md):
+```css
+--ease-enter: cubic-bezier(0.16, 1, 0.3, 1);   /* expo-out: confident deceleration */
+--ease-exit:  cubic-bezier(0.7,  0, 0.84, 0);   /* expo-in:  accelerates away */
+--ease-toggle: cubic-bezier(0.65, 0, 0.35, 1);  /* in-out: for state toggles only */
+```
+
+---
+
+#### Duration by distance
+
+**When**: any element that moves spatially (slides, translates, expands).
+
+| Motion distance | Duration |
+|----------------|----------|
+| Micro (button press, icon hover) | 80–100ms |
+| Short (tooltip, badge) | 150ms |
+| Medium (dropdown, popover, modal enter) | 200–250ms |
+| Long (drawer, full-panel) | 300–350ms |
+| Page-level (route change) | 350–500ms |
+
+An element traveling 8px should not take 500ms. An element traveling 400px should not take 100ms.
+
+---
+
+## Worked Example
+
+A full audit-to-application walkthrough on a `NotificationBanner` component.
+
+### Starting point
+
+```tsx
+// NotificationBanner.tsx — before finesse
+export function NotificationBanner({ message, type, onClose }: Props) {
+  return (
+    <div className={`
+      flex items-center gap-3 p-4 rounded-lg border
+      transition-all duration-300
+      ${type === 'error' ? 'bg-red-50 border-red-200' : 'bg-blue-50 border-blue-200'}
+    `}>
+      <Icon type={type} />
+      <p>{message}</p>
+      <button onClick={onClose} className="ml-auto hover:opacity-70">
+        <X size={16} />
+      </button>
+    </div>
+  );
+}
+```
+
+### Phase 1 Audit
+
+```
+FINESSE AUDIT — NotificationBanner
+
+P0: transition-all — grabs border, padding, border-radius on color change; risk of layout reflow
+P0: no prefers-reduced-motion coverage anywhere
+P1: onClose triggers instant removal — no exit animation
+P1: close button has no active: state, only opacity hover (no press feedback)
+P1: focus-visible ring missing on close button
+P2: ease default (not intentional) on transition
+P3: banner entrance is instant (appears with no enter)
+```
+
+### Decision: what to apply first
+
+1. P0: Replace `transition-all` with `transition-[background-color,border-color]`.
+2. P0: Add `prefers-reduced-motion` wrapper.
+3. P1: Wrap in `<Transition>` for choreographed exit (it occupies flow space).
+4. P1: Add `active:scale-[0.97]` + `focus-visible:ring-2` to close button.
+5. P3: Add fade-in entry.
+
+### After finesse
+
+```tsx
+// NotificationBanner.tsx — after finesse
+export function NotificationBanner({ message, type, isVisible, onClose }: Props) {
+  return (
+    <Transition
+      show={isVisible}
+      enter="transition-[opacity,max-height] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] overflow-hidden"
+      enterFrom="opacity-0 max-h-0"
+      enterTo="opacity-100 max-h-24"
+      leave="transition-[opacity,max-height] duration-150 ease-[cubic-bezier(0.7,0,0.84,0)] overflow-hidden"
+      leaveFrom="opacity-100 max-h-24"
+      leaveTo="opacity-0 max-h-0"
+    >
+      <div className={`
+        flex items-center gap-3 p-4 rounded-lg border
+        transition-[background-color,border-color] duration-200
+        ease-[cubic-bezier(0.16,1,0.3,1)]
+        motion-reduce:transition-none
+        ${type === 'error' ? 'bg-red-50 border-red-200' : 'bg-blue-50 border-blue-200'}
+      `}>
+        <Icon type={type} />
+        <p>{message}</p>
+        <button
+          onClick={onClose}
+          className="
+            ml-auto
+            hover:opacity-70
+            active:scale-[0.97]
+            transition-[transform,opacity] duration-100
+            ease-[cubic-bezier(0.16,1,0.3,1)]
+            focus-visible:ring-2 focus-visible:ring-offset-1
+            focus-visible:ring-current rounded
+            motion-reduce:transition-none
+            motion-reduce:active:scale-100
+          "
+          aria-label="Dismiss notification"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </Transition>
+  );
+}
+```
+
+### Verification checklist
+
+- [ ] Click dismiss: banner fades out while collapsing height. Surrounding content slides up smoothly.
+- [ ] Tab to close button: focus ring visible.
+- [ ] Press close button: 3% scale-down visible on active.
+- [ ] Switch `type` prop while visible: color transitions, no layout jump.
+- [ ] Set OS reduced-motion: no spatial movement. Opacity crossfades acceptable. Color change instant.
+- [ ] Banner re-appears (new notification): fade-in entry works.
+
+---
+
+## NEVER
+
+- Apply `transition-all` — always be explicit about which properties to transition.
+- Use bounce or elastic easing — they draw attention to the animation, not the content.
+- Animate `width`, `height`, `top`, `left`, `margin` directly — use transform, max-height, grid-template-rows, or FLIP.
+- Apply all patterns at once — one diff at a time. Motion debt compounds; so does motion noise.
+- Skip prefers-reduced-motion — this is an a11y violation, not a nice-to-have.
+- Add hover states that also fire on touch — `@media (hover: hover)` guards hover-only affordances.
+- Use the same duration on enter and exit — exit is ~75% of enter.
+
+When the interactions feel intentional without the user knowing why, hand off to `/impeccable polish` for the final pass.

--- a/.claude/skills/impeccable/reference/finesse.md
+++ b/.claude/skills/impeccable/reference/finesse.md
@@ -391,7 +391,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 2. **How fast must feedback be?**
    - Press feedback: ≤100ms (user perceives it as simultaneous with tap).
    - Toggle snap: 150ms (spring feel).
-   - Confirmation ripple: 600ms total (user sees result, confirmation appears then fades).
+   - Confirmation ripple: 600ms hold (enter + hold + exit ≈ 1s total).
 
 3. **Is this touch or mouse?**
    - Touch: hover states don't apply. Active states + haptic (where available) do.
@@ -433,7 +433,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 **Diff commentary**:
 - `transition-all` → `transition-[transform,background-color]` — prevents accidental capture of layout properties (margin, padding, border-radius).
 - `active:scale-[0.97]` — 3% reduction. More = theatrical; less = imperceptible.
-- `duration-100` — micro-interaction. Below 80ms threshold.
+- `duration-100` — micro-interaction. Near the 80ms threshold of perceived simultaneity.
 - `active:bg-blue-700` — color darkens on press, reinforcing press state visually.
 - Reduced-motion: no scale, instant color transition.
 
@@ -452,8 +452,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 **After** (CSS custom switch):
 ```css
 .switch-thumb {
-  transition: transform 150ms cubic-bezier(0.34, 1.2, 0.64, 1);
-  /* Slight spring overshoot (1.2 > 1.0) — controlled, not bouncy */
+  transition: transform 150ms cubic-bezier(0.65, 0, 0.35, 1);
 }
 
 .switch:checked .switch-thumb {
@@ -505,7 +504,7 @@ If you can't answer 1–3 without guessing, read the component context before ap
 
 **When not**: high-frequency actions (typing completion, filter changes), destructive actions that need a confirmation step.
 
-**Reasoning**: without a ripple, the user doesn't know the action registered. With a ripple, the success state announces itself and fades — 600ms total feels natural.
+**Reasoning**: without a ripple, the user doesn't know the action registered. With a ripple, the success state announces itself and fades — ~1s total (enter + confirm + exit) feels right: long enough to read, short enough not to linger.
 
 **After** (React with a temporary state):
 ```tsx
@@ -514,7 +513,7 @@ const [copied, setCopied] = useState(false);
 const handleCopy = () => {
   navigator.clipboard.writeText(value);
   setCopied(true);
-  setTimeout(() => setCopied(false), 1500);
+  setTimeout(() => setCopied(false), 600);
 };
 
 <button onClick={handleCopy} className="relative overflow-hidden">
@@ -744,15 +743,36 @@ function tweenNumber(from: number, to: number, el: HTMLElement, duration = 600) 
 
 **After**:
 ```tsx
-// Items exit with stagger, then empty state enters
+// import { AnimatePresence, motion } from 'framer-motion';
+// import type { CSSProperties } from 'react';
+
+// Items exit with stagger, then empty state enters.
+// ListItem and EmptyState must be motion.* components (or wrapped in motion.div)
+// with exit props so AnimatePresence can animate them out.
+// CSS-only alternative: apply the stagger pattern from Family 2 and v-if the empty state.
 const isEmpty = items.length === 0;
 
 <AnimatePresence>
   {items.map((item, i) => (
-    <ListItem key={item.id} style={{ '--i': i } as CSSProperties} />
+    <motion.li
+      key={item.id}
+      layout
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0, transition: { delay: i * 0.03 } }}
+      exit={{ opacity: 0, y: -8 }}
+    >
+      <ListItem data={item} />
+    </motion.li>
   ))}
   {isEmpty && (
-    <EmptyState className="animate-fade-in motion-reduce:animate-none" />
+    <motion.div
+      key="empty"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="motion-reduce:transition-none"
+    >
+      <EmptyState />
+    </motion.div>
   )}
 </AnimatePresence>
 ```
@@ -862,6 +882,7 @@ P3: banner entrance is instant (appears with no enter)
 ### After finesse
 
 ```tsx
+// import { Transition } from '@headlessui/react'; // or use <Transition> from your framework
 // NotificationBanner.tsx — after finesse
 export function NotificationBanner({ message, type, isVisible, onClose }: Props) {
   return (

--- a/.claude/skills/impeccable/reference/juicy.md
+++ b/.claude/skills/impeccable/reference/juicy.md
@@ -674,7 +674,7 @@ export function KanbanCard({ card, isDragging, onDragStart }: Props) {
         bg-white rounded border p-3 mb-2
         cursor-grab active:cursor-grabbing
         select-none
-        transition-[transform,opacity,shadow] duration-150
+        transition-[transform,opacity,box-shadow] duration-150
         ${isDragging
           ? 'opacity-40 scale-95 rotate-1 shadow-lg'
           : 'opacity-100 scale-100 rotate-0 shadow-sm'

--- a/.claude/skills/impeccable/reference/juicy.md
+++ b/.claude/skills/impeccable/reference/juicy.md
@@ -1,0 +1,746 @@
+> **Additional context needed**: brand register (consumer SaaS vs institutional), input modality (touch vs mouse primary), whether audio is appropriate for this context.
+
+Add game-feel to interactions that already work. *Juicy*, in game design, means every action has multiple layers of feedback — the interface is generous in what it gives back. `finesse` makes interactions intentional; `juicy` makes them satisfying.
+
+The distinction matters: a well-timed button press is finesse. The same button press with a cursor that acknowledges the drag, a drop zone that glows when valid, and a micro-click sound on confirm — that's juicy. It's a layer above polish, not a replacement.
+
+**Context gate**: before applying any pattern from this command, assess:
+- Is this SaaS / consumer product or institutional / financial / medical?
+- Is the primary modality touch or mouse?
+- Does the brand brief mention sound or haptics?
+
+Institutional contexts (government portals, banking, medical records, legal software) should default to `/impeccable finesse` only. Do not add sound, custom cursors, or drag choreography without an explicit brief that invites it.
+
+---
+
+## Register
+
+**Brand**: juicy is at home here — cursor customization, sound design, scroll choreography, and ambient awareness all contribute to brand voice. Apply broadly.
+
+**Product**: apply juicy at specific high-value moments, not globally. Completion states, drag-and-drop flows, interactive data visualizations. Productivity tools should be fast and quiet everywhere else.
+
+---
+
+## Soft Pre-requisite
+
+Run `/impeccable finesse` before `/impeccable juicy`. Juicy layers *on top of* correct timing and easing — adding drag choreography to a button that still uses `transition-all` creates an incoherent experience. Fix the foundation first.
+
+---
+
+## Hard Blocks
+
+1. **prefers-reduced-motion**: any pattern adding spatial motion requires a fallback (same rule as finesse).
+2. **Sound**: all audio patterns require: (a) user opt-in or system sound setting check, (b) AudioContext not `<audio>`, (c) volume ≤ -18dBFS, (d) global mute path.
+3. **Custom cursor**: never override cursor on text content, inputs, or textareas — this breaks UX.
+
+---
+
+## Phase 1: Audit
+
+Catalog gaps in the following categories before applying anything:
+
+| Area | What to look for |
+|------|-----------------|
+| Cursor | Draggable elements without `cursor-grab`, resizable panels without `cursor-col-resize`, copyable elements without `cursor-copy`, disabled elements with `cursor-default` instead of `cursor-not-allowed` |
+| Drag | Drag handlers using browser-default ghost image, no drop zone visual feedback, no reorder animation on list sort |
+| Scroll | Carousels without `scroll-snap`, long horizontal lists without snap, scroll-behavior not set, sticky headers that change height without transition |
+| Awareness | Missing `prefers-color-scheme` theme transition (flash instead of crossfade), missing `prefers-contrast` handling, hover states not guarded by `@media (hover: hover)` |
+| Selection | `::selection` using browser default (blue), range inputs with default thumb, search results without highlight animation |
+| Keyboard | Missing shortcut echo, focus ring that's correct but visually generic, no tab indicator on complex nav |
+| Sound | High-value interactions (toggle, confirm, delete) with no audio layer — note only if consumer/SaaS context |
+
+Produce a prioritized list, same P0–P3 format as finesse.
+
+---
+
+## Phase 2: Apply
+
+---
+
+### Family 1: Cursor
+
+#### Chain-of-thought: cursor decisions
+
+1. **What is the user about to do?**
+   - Grab and drag → `cursor-grab`, `cursor-grabbing` on active.
+   - Resize a panel → `cursor-col-resize` or `cursor-row-resize`.
+   - Click to zoom/expand → `cursor-zoom-in`.
+   - Copy content → `cursor-copy`.
+   - Interact with something currently unavailable → `cursor-not-allowed`.
+
+2. **Is this a text area, input, or selectable text?** → Do not override cursor. Browser defaults are correct here.
+
+3. **Is this a custom SVG cursor?** → Use only if it communicates something the system cursors can't (e.g., a canvas tool). Brand-logo cursors are noise.
+
+---
+
+#### Drag affordance cursors
+
+**When**: any draggable element — sortable list items, kanban cards, resize handles, panel splitters.
+
+**When not**: text, inputs, non-interactive elements.
+
+**After**:
+```tsx
+// Sortable list item
+<li
+  className="
+    cursor-grab
+    active:cursor-grabbing
+    select-none
+  "
+  draggable
+>
+```
+
+```css
+/* Panel resize handle */
+.resize-handle {
+  cursor: col-resize;
+  user-select: none;
+}
+
+/* When resizing is active */
+body.resizing {
+  cursor: col-resize;
+  user-select: none;
+}
+```
+
+**Diff commentary**:
+- `select-none` prevents text selection during drag (the most common drag UX bug).
+- Set `cursor-grabbing` on `body` during active drag — not just on the element — so cursor stays consistent if pointer moves off the element.
+- `cursor-grab` on hover, `cursor-grabbing` on mousedown.
+
+**Signal**: user hovers a draggable item and their hand cursor changes to a grab. No need to read documentation to know it's draggable.
+
+---
+
+#### Context-aware cursor vocabulary
+
+```tsx
+// Zoom-able image or map
+<div className="cursor-zoom-in hover:cursor-zoom-in">
+
+// Copyable token / code block
+<code className="cursor-copy" onClick={handleCopy}>
+
+// Disabled but visible (not hidden) control
+<button disabled className="cursor-not-allowed opacity-50">
+
+// Active painting or drawing tool
+// cursor: url('./brush.svg') 8 8, crosshair;
+// (hotspot at 8,8 = center of 16px icon)
+```
+
+**Signal**: cursor changes communicate affordance without tooltips. Users know what's interactive before they click.
+
+---
+
+### Family 2: Drag Choreography
+
+#### Chain-of-thought: drag quality decisions
+
+1. **What is being dragged?**
+   - A sortable list item → ghost + drop preview + reorder animation.
+   - A file into a drop zone → drop zone activation feedback.
+   - A resizable panel splitter → cursor + no ghost (it's not detached).
+
+2. **What does the drop zone need to communicate?**
+   - Idle (nothing being dragged) → normal appearance.
+   - Hovering with valid item → positive highlight (ring, background tint).
+   - Hovering with invalid item → negative signal (different color, `cursor-no-drop`).
+   - Dropped successfully → brief flash, then reorder animation.
+
+3. **Is there a reorder animation?**
+   - Yes → use FLIP or `View Transitions API` so displaced items slide to new positions.
+   - No → items teleport — jarring.
+
+---
+
+#### Custom ghost element
+
+**When**: any HTML5 drag-and-drop implementation where the browser default ghost (a semi-transparent copy) looks wrong.
+
+**After** (suppress browser ghost, use custom):
+```ts
+const handleDragStart = (e: DragEvent, item: Item) => {
+  // Suppress browser ghost
+  const ghost = document.createElement('div');
+  ghost.style.cssText = 'position:fixed;top:-9999px;left:-9999px;';
+  document.body.appendChild(ghost);
+  e.dataTransfer!.setDragImage(ghost, 0, 0);
+  setTimeout(() => ghost.remove(), 0);
+
+  // Show custom ghost (your styled element, following cursor via JS)
+  setDragging(item);
+};
+```
+
+```tsx
+// Custom ghost follows pointer
+{dragging && (
+  <div
+    className="
+      fixed pointer-events-none z-50
+      bg-white shadow-xl rounded-lg border border-gray-200
+      scale-105 rotate-1 opacity-90
+      transition-none
+    "
+    style={{ top: pointerY - 8, left: pointerX - 8 }}
+  >
+    <DragPreview item={dragging} />
+  </div>
+)}
+```
+
+**Signal**: dragged item lifts from surface, tilts slightly, follows cursor. Looks intentional, not like a browser screenshot.
+
+---
+
+#### Drop zone progressive feedback
+
+**When**: any designated drop target (file upload, kanban column, list reorder zone).
+
+**After**:
+```tsx
+<div
+  className={`
+    rounded-lg border-2 border-dashed p-4
+    transition-[border-color,background-color] duration-150
+    ${dragState === 'idle'     ? 'border-gray-200 bg-transparent' : ''}
+    ${dragState === 'hovering' ? 'border-blue-400 bg-blue-50 scale-[1.01]' : ''}
+    ${dragState === 'invalid'  ? 'border-red-300 bg-red-50' : ''}
+    motion-reduce:transition-none
+    motion-reduce:scale-100
+  `}
+>
+```
+
+**Three states required**: idle, hovering-valid, hovering-invalid. A drop zone that only changes on valid hover misses the feedback opportunity on invalid items.
+
+---
+
+#### Reorder animation (FLIP)
+
+**When**: sortable lists where items slide to new positions when one is moved.
+
+**Reasoning**: without reorder animation, the list appears to teleport. With it, users see spatial continuity — where each item came from and where it's going.
+
+```ts
+// FLIP: First, Last, Invert, Play
+function animateReorder(listEl: HTMLElement) {
+  // First: snapshot positions
+  const first = new Map<string, DOMRect>();
+  listEl.querySelectorAll('[data-id]').forEach(el => {
+    first.set(el.getAttribute('data-id')!, el.getBoundingClientRect());
+  });
+
+  // (DOM update happens here — React re-renders with new order)
+  requestAnimationFrame(() => {
+    // Last: measure new positions
+    listEl.querySelectorAll('[data-id]').forEach(el => {
+      const id = el.getAttribute('data-id')!;
+      const last = el.getBoundingClientRect();
+      const prev = first.get(id);
+      if (!prev) return;
+
+      // Invert
+      const dy = prev.top - last.top;
+      if (dy === 0) return;
+
+      // Play
+      el.animate(
+        [{ transform: `translateY(${dy}px)` }, { transform: 'translateY(0)' }],
+        { duration: 250, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }
+      );
+    });
+  });
+}
+```
+
+**Reduced-motion**: check `matchMedia('(prefers-reduced-motion: reduce)')` — skip the animation, let items teleport.
+
+**Signal**: user drops item. Displaced items slide to their new positions. No teleport.
+
+---
+
+### Family 3: Scroll
+
+#### scroll-snap (for carousels and horizontal lists)
+
+**When**: image carousels, horizontal card strips, mobile-style navigation, tab bars that scroll.
+
+**When not**: long vertical lists, data tables, free-form scroll areas.
+
+**After**:
+```css
+.carousel {
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none; /* Firefox */
+  -webkit-overflow-scrolling: touch;
+}
+
+.carousel::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel-item {
+  scroll-snap-align: start;
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel { scroll-behavior: auto; }
+}
+```
+
+**Signal**: user swipes carousel. Items snap to grid. No partial views between items.
+
+---
+
+#### Sticky header with scroll transform
+
+**When**: app headers or nav bars that should compress or change character on scroll.
+
+**When not**: headers on content pages where the header should remain fully visible.
+
+**After**:
+```tsx
+const { scrollY } = useScroll();
+const headerHeight = useTransform(scrollY, [0, 80], ['5rem', '3rem']);
+const shadowOpacity = useTransform(scrollY, [0, 40], [0, 1]);
+
+<motion.header
+  style={{ height: headerHeight }}
+  className="sticky top-0 z-10 bg-white transition-shadow"
+>
+  <motion.div
+    style={{ opacity: shadowOpacity }}
+    className="absolute inset-x-0 bottom-0 h-px bg-black/10"
+  />
+```
+
+**Reduced-motion**: use a single `ScrollObserver` to add a class when scrolled past threshold — apply shadow only, no height change.
+
+**Signal**: page scrolls. Header compresses. Shadow appears. User knows they're no longer at the top without looking for a scroll indicator.
+
+---
+
+### Family 4: Awareness
+
+#### Hover guard (touch devices)
+
+**When**: any component with `:hover` styles.
+
+**Reasoning**: touch devices fire `mouseover` on tap, then linger. A card that hover-lifts on touch stays lifted permanently. This is the most common cross-device polishing miss.
+
+**After**:
+```css
+/* Only apply hover effects when hover is the primary input */
+@media (hover: hover) {
+  .card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+  }
+}
+
+/* Touch-specific tap feedback instead */
+@media (hover: none) {
+  .card:active {
+    transform: scale(0.98);
+    transition: transform 80ms;
+  }
+}
+```
+
+**Signal**: card hover works on desktop. On mobile, tap gives press feedback instead of a stuck hover state.
+
+---
+
+#### Theme crossfade (no flash on color-scheme change)
+
+**When**: any app supporting both light and dark mode via `prefers-color-scheme` or a user toggle.
+
+**Reasoning**: switching themes without a transition causes an abrupt flash. A 200ms crossfade turns a jarring moment into a smooth state change.
+
+**After** (user-toggled theme):
+```css
+:root {
+  /* All color tokens go here */
+  transition: background-color 200ms ease-out, color 200ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root { transition: none; }
+}
+```
+
+**For system-level changes** (`prefers-color-scheme`): CSS transitions don't fire on media query changes — use a brief JS-added class to enable transitions only when theme toggle is triggered by user.
+
+**Signal**: user switches theme. Colors dissolve to new palette. No flash. No jank.
+
+---
+
+#### prefers-contrast awareness
+
+**When**: any app that should be usable by high-contrast users.
+
+**What changes** at high contrast:
+- Borders become more defined (increase border opacity or width).
+- Shadows become borders (drop shadows are invisible in forced colors mode; replace with solid borders).
+- Subtle backgrounds get removed (transparent surfaces become opaque).
+
+```css
+@media (forced-colors: active) {
+  .card {
+    border: 1px solid ButtonText;
+    box-shadow: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .muted-text { color: var(--color-text-primary); }
+  .border-subtle { border-color: var(--color-border-strong); }
+}
+```
+
+---
+
+### Family 5: Selection and Text
+
+#### Brand ::selection color
+
+**When**: always — this is one of the most overlooked details in every codebase.
+
+**Reasoning**: browser default blue selection doesn't match most brands. A selection in brand accent color costs one CSS rule and signals extreme attention to detail.
+
+**After**:
+```css
+::selection {
+  background-color: oklch(85% 0.15 var(--brand-hue) / 40%);
+  color: inherit;
+}
+```
+
+**Notes**:
+- Keep opacity low (30–50%) so text contrast isn't affected.
+- Use brand hue from design tokens, not a hardcoded hex.
+- `color: inherit` prevents selection from changing text color.
+
+**Signal**: user selects text. Selection is brand-colored. Nobody will say "nice selection color" — but they'll feel the product is made with intent.
+
+---
+
+#### Range input thumb
+
+**When**: any `<input type="range">` that uses browser default styling.
+
+**Reasoning**: browser-default range thumbs look like OS controls, not branded UI. Restyling them with consistent shape and animation signals ownership.
+
+**After**:
+```css
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--color-surface-3);
+  outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  cursor: pointer;
+  transition: transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 150ms;
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+input[type="range"]::-webkit-slider-thumb:active {
+  transform: scale(1.1);
+  box-shadow: 0 0 0 6px oklch(60% 0.2 var(--brand-hue) / 20%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  input[type="range"]::-webkit-slider-thumb { transition: none; }
+}
+```
+
+---
+
+### Family 6: Keyboard Feedback
+
+#### Shortcut echo
+
+**When**: any keyboard shortcut that triggers an action without obvious visual confirmation.
+
+**Reasoning**: sighted users who trigger shortcuts need feedback. Without it, they repeat the shortcut assuming it failed.
+
+**After**:
+```tsx
+// Show a brief badge near the triggered element or globally
+const [shortcutEcho, setShortcutEcho] = useState<string | null>(null);
+
+const echo = (label: string) => {
+  setShortcutEcho(label);
+  setTimeout(() => setShortcutEcho(null), 600);
+};
+
+// On shortcut trigger:
+echo('⌘K');
+
+// Echo badge
+{shortcutEcho && (
+  <div className="
+    fixed bottom-4 right-4
+    bg-gray-900 text-white text-xs
+    px-2 py-1 rounded
+    font-mono
+    animate-fade-in
+    motion-reduce:animate-none
+  ">
+    {shortcutEcho}
+  </div>
+)}
+```
+
+---
+
+#### Polished focus ring
+
+**When**: any interactive element that currently has a generic browser focus ring or `outline: none`.
+
+**Reasoning**: accessible focus ring ≠ beautiful focus ring. Both requirements can be satisfied simultaneously.
+
+**After**:
+```css
+/* Global polished focus-visible */
+:focus-visible {
+  outline: none;
+}
+
+/* Components set their own ring */
+.interactive:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--color-background),   /* gap */
+    0 0 0 4px var(--color-accent);       /* ring */
+}
+
+/* Inverse for dark surfaces */
+.inverse .interactive:focus-visible {
+  box-shadow:
+    0 0 0 2px var(--color-surface-dark),
+    0 0 0 4px oklch(90% 0.05 var(--brand-hue));
+}
+```
+
+**Signal**: keyboard user tabs through UI. Every interactive element has a clean, brand-consistent ring. No generic blue, no invisible outline.
+
+---
+
+### Family 7: Sound (opt-in, contextual only)
+
+**Context gate**: only apply this family when:
+- Register is consumer SaaS, creative tool, productivity tool with brand permission for audio.
+- Product brief mentions or implies sound as part of UX.
+- NOT: institutional, financial, medical, government, enterprise admin, customer service tooling.
+
+If unsure: ask. Default to no sound.
+
+#### Architecture
+
+```ts
+// sound-manager.ts
+class SoundManager {
+  private context: AudioContext | null = null;
+  private enabled: boolean;
+
+  constructor() {
+    // Respect OS sound setting
+    this.enabled = !matchMedia('(prefers-reduced-motion: reduce)').matches;
+    // Note: no direct OS "mute" API — rely on app-level toggle
+  }
+
+  private getContext() {
+    if (!this.context) {
+      this.context = new AudioContext();
+    }
+    return this.context;
+  }
+
+  play(buffer: AudioBuffer, volume = 0.15) {
+    if (!this.enabled) return;
+    const ctx = this.getContext();
+    const source = ctx.createBufferSource();
+    const gain = ctx.createGain();
+    gain.gain.value = volume;
+    source.buffer = buffer;
+    source.connect(gain).connect(ctx.destination);
+    source.start();
+  }
+
+  setEnabled(v: boolean) { this.enabled = v; }
+}
+
+export const sounds = new SoundManager();
+```
+
+#### Sound vocabulary
+
+| Interaction | Duration | Character |
+|-------------|----------|-----------|
+| Toggle on | 10–20ms | Short, bright, +pitch |
+| Toggle off | 10–20ms | Short, muted, -pitch |
+| Item confirmed/checked | 15–25ms | Soft click, resolved |
+| Item removed/deleted | 20–30ms | Short descending |
+| Notification arrive | 30–50ms | Distinct, not harsh |
+| Error | 20–30ms | Low, brief |
+| Success (major) | 80–150ms | Ascending, resolved |
+
+**Volume target**: -18 to -24 dBFS. This is quiet — background noise level of a quiet room, not a notification.
+
+```ts
+// Generate a micro-sound with Web Audio API (no file needed)
+function createClick(ctx: AudioContext, freq = 800, dur = 0.015): AudioBuffer {
+  const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * dur), ctx.sampleRate);
+  const data = buf.getChannelData(0);
+  for (let i = 0; i < data.length; i++) {
+    const t = i / ctx.sampleRate;
+    const env = Math.exp(-t * 300); // fast decay
+    data[i] = Math.sin(2 * Math.PI * freq * t) * env * 0.15;
+  }
+  return buf;
+}
+```
+
+**Signal**: user toggles a switch. A brief, soft click confirms the action. Remove it and the toggle feels slightly less physical. Users who notice it usually describe it as "snappy" — not "sounds."
+
+---
+
+## Worked Example
+
+A full audit-to-application walkthrough on a Kanban board card with drag-and-drop.
+
+### Starting point
+
+```tsx
+// KanbanCard.tsx — before juicy
+export function KanbanCard({ card, onDrag }: Props) {
+  return (
+    <div
+      className="bg-white rounded border p-3 mb-2 cursor-pointer"
+      draggable
+      onDragStart={() => onDrag(card.id)}
+    >
+      <h3 className="text-sm font-medium">{card.title}</h3>
+      <p className="text-xs text-gray-500">{card.assignee}</p>
+    </div>
+  );
+}
+```
+
+### Phase 1 Audit
+
+```
+JUICY AUDIT — KanbanCard / KanbanColumn
+
+P0: cursor-pointer on draggable element (should be cursor-grab)
+P0: no cursor:grabbing on active drag state
+P1: browser-default drag ghost (screenshot of card, semi-transparent)
+P1: drop zone has no visual feedback on hover-with-item
+P1: reorder has no animation — cards teleport to new positions
+P2: select-none missing — text gets selected during drag
+P3: ::selection color is browser default
+```
+
+### After juicy
+
+```tsx
+// KanbanCard.tsx — after juicy
+export function KanbanCard({ card, isDragging, onDragStart }: Props) {
+  return (
+    <div
+      className={`
+        bg-white rounded border p-3 mb-2
+        cursor-grab active:cursor-grabbing
+        select-none
+        transition-[transform,opacity,shadow] duration-150
+        ${isDragging
+          ? 'opacity-40 scale-95 rotate-1 shadow-lg'
+          : 'opacity-100 scale-100 rotate-0 shadow-sm'
+        }
+        motion-reduce:transition-none
+        motion-reduce:scale-100
+        motion-reduce:rotate-0
+      `}
+      draggable
+      onDragStart={onDragStart}
+    >
+      <h3 className="text-sm font-medium">{card.title}</h3>
+      <p className="text-xs text-gray-500">{card.assignee}</p>
+    </div>
+  );
+}
+
+// KanbanColumn.tsx — after juicy
+export function KanbanColumn({ cards, isDragOver, isInvalidTarget }: Props) {
+  return (
+    <div
+      className={`
+        flex flex-col gap-2 p-2 rounded-lg border-2 border-dashed min-h-[120px]
+        transition-[border-color,background-color] duration-150
+        ${isDragOver && !isInvalidTarget ? 'border-blue-400 bg-blue-50' : ''}
+        ${isInvalidTarget ? 'border-red-300 bg-red-50' : ''}
+        ${!isDragOver ? 'border-gray-200 bg-transparent' : ''}
+        motion-reduce:transition-none
+      `}
+    >
+      {cards.map((card, i) => (
+        <KanbanCard
+          key={card.id}
+          card={card}
+          data-id={card.id}
+          isDragging={false}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+### Verification checklist
+
+- [ ] Hover card: cursor is a grab hand.
+- [ ] Click-hold card: cursor becomes closed fist.
+- [ ] Drag card: source card fades and scales slightly (still visible, but receded).
+- [ ] Drag over valid column: column gets blue highlight.
+- [ ] Drag over invalid column: column gets red highlight.
+- [ ] Drop: displaced cards animate to new positions (FLIP).
+- [ ] Select text in card on desktop: `select-none` prevents accidental selection.
+- [ ] Touch device: no hover states; active feedback on tap.
+- [ ] OS reduced-motion: cursor changes work, but no scale/rotate on drag source, no reorder animation.
+
+---
+
+## NEVER
+
+- Add sound without user opt-in and volume control.
+- Add sound in institutional, financial, medical, or enterprise contexts without an explicit brief.
+- Override cursor on text, inputs, or textareas.
+- Use scroll-snap on long vertical lists (traps users).
+- Use custom SVG cursors as decoration (brand logo as cursor = noise, not craft).
+- Apply juicy to a codebase that still has `transition-all` (fix finesse first).
+- Assume touch users should see hover states — guard with `@media (hover: hover)`.
+- Use `<audio>` for UI sounds — use AudioContext API for microsounds.
+
+When game-feel layers on top of intentional motion, hand off to `/impeccable polish` for the final pass.

--- a/.claude/skills/impeccable/reference/juicy.md
+++ b/.claude/skills/impeccable/reference/juicy.md
@@ -308,6 +308,7 @@ function animateReorder(listEl: HTMLElement) {
 
 **After**:
 ```tsx
+// import { useScroll, useTransform, motion } from 'framer-motion';
 const { scrollY } = useScroll();
 const headerHeight = useTransform(scrollY, [0, 80], ['5rem', '3rem']);
 const shadowOpacity = useTransform(scrollY, [0, 40], [0, 1]);
@@ -566,9 +567,9 @@ class SoundManager {
   private enabled: boolean;
 
   constructor() {
-    // Respect OS sound setting
-    this.enabled = !matchMedia('(prefers-reduced-motion: reduce)').matches;
-    // Note: no direct OS "mute" API — rely on app-level toggle
+    // prefers-reduced-motion ≠ mute. Sound and motion are independent preferences.
+    // Use an app-level flag; give users a dedicated sound toggle, not a motion toggle proxy.
+    this.enabled = localStorage.getItem('ui-sounds') !== 'disabled';
   }
 
   private getContext() {
@@ -578,7 +579,8 @@ class SoundManager {
     return this.context;
   }
 
-  play(buffer: AudioBuffer, volume = 0.15) {
+  // volume: linear gain — 0.08 ≈ -22 dBFS (within -18 to -24 dBFS target)
+  play(buffer: AudioBuffer, volume = 0.08) {
     if (!this.enabled) return;
     const ctx = this.getContext();
     const source = ctx.createBufferSource();
@@ -610,14 +612,15 @@ export const sounds = new SoundManager();
 **Volume target**: -18 to -24 dBFS. This is quiet — background noise level of a quiet room, not a notification.
 
 ```ts
-// Generate a micro-sound with Web Audio API (no file needed)
+// Buffer samples are normalized (peak ~1.0); volume is controlled by play()'s gain node.
+// Do NOT multiply by a gain factor here — that compounds with play()'s volume param.
 function createClick(ctx: AudioContext, freq = 800, dur = 0.015): AudioBuffer {
   const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * dur), ctx.sampleRate);
   const data = buf.getChannelData(0);
   for (let i = 0; i < data.length; i++) {
     const t = i / ctx.sampleRate;
     const env = Math.exp(-t * 300); // fast decay
-    data[i] = Math.sin(2 * Math.PI * freq * t) * env * 0.15;
+    data[i] = Math.sin(2 * Math.PI * freq * t) * env;
   }
   return buf;
 }
@@ -693,7 +696,10 @@ export function KanbanCard({ card, isDragging, onDragStart }: Props) {
 }
 
 // KanbanColumn.tsx — after juicy
-export function KanbanColumn({ cards, isDragOver, isInvalidTarget }: Props) {
+// isDragOver and isInvalidTarget must be wired to your DnD library's drag events.
+// dnd-kit: use useDroppable() + useDndMonitor(); react-dnd: use useDrop().
+// This example shows the visual logic; wire the boolean props to your library.
+export function KanbanColumn({ cards, activeCardId, isDragOver, isInvalidTarget }: Props) {
   return (
     <div
       className={`
@@ -705,12 +711,13 @@ export function KanbanColumn({ cards, isDragOver, isInvalidTarget }: Props) {
         motion-reduce:transition-none
       `}
     >
-      {cards.map((card, i) => (
+      {cards.map((card) => (
         <KanbanCard
           key={card.id}
           card={card}
           data-id={card.id}
-          isDragging={false}
+          isDragging={activeCardId === card.id} // wire to DnD library active item id
+          onDragStart={/* wire to library's drag-start handler */ undefined}
         />
       ))}
     </div>


### PR DESCRIPTION
> [!IMPORTANT]
> **RFC — looking for maintainer feedback before this merges.**
> Three open questions at the bottom. Happy to adjust or close without merge based on your direction.

## Motivation

There's a gap between `animate` (adds new motion) and `polish` (fixes visual alignment and design-system drift) that no current command covers: refining the quality of interactions that *already exist*.

The Japanese concept of *kodawari* — meticulous attention to things that don't need to be there, that most users won't consciously notice, but whose absence you always feel — fits this gap exactly.

## Commands added

### `finesse [target]` (Enhance)

Refines existing interactions without adding new animation. Covers:

- **Exits**: choreographed exit for flow elements, fade for overlays, collapse vertical, directional slide-out
- **Entries**: stagger, snap-in, expand vertical, fade-in
- **Feedback**: press feedback (`active:scale-[0.97]`), toggle snap, hover lift, focus ring, confirmation ripple
- **Coordinated sequences**: backdrop-before-content for modals, skeleton→content crossfade, loading inline, error shake
- **Data transitions**: animated numbers, content swap, empty-state transition
- **Easing quality**: audit for `transition-all` / bad defaults, asymmetric enter/exit curves, duration-by-distance table

Hard block: won't proceed without `prefers-reduced-motion` coverage.

### `juicy [target]` (Enhance)

Adds game-feel on top of finesse (recommended to run finesse first):

- **Cursor**: `cursor-grab/grabbing`, `cursor-col-resize`, `cursor-zoom-in`, `cursor-copy`, `cursor-not-allowed`
- **Drag choreography**: custom ghost element, drop zone progressive feedback (idle/valid/invalid), FLIP reorder animation
- **Scroll**: `scroll-snap`, sticky header transforms
- **Awareness**: hover guard `@media (hover: hover)`, theme crossfade without flash, `prefers-contrast` handling
- **Selection and text**: brand `::selection` color, range input thumb, search highlight
- **Keyboard**: shortcut echo, polished focus ring
- **Sound** (opt-in, consumer/SaaS only): AudioContext micro-sounds, volume targets (-18 to -24 dBFS), mute path

Context gate: explicit institutional/financial/medical block on sound. Default no sound when context unclear.

## Pedagogy

Both files go beyond the imperative style of neighbors (`animate.md`, `polish.md`):

- **Chain-of-thought** decision guides before each pattern family
- **Few-shots** with before/after diffs and diff commentary per pattern
- **Worked examples**: `NotificationBanner` (finesse), `KanbanCard` with drag (juicy)

~3× longer than neighbors — see RFC question #3 on whether to trim.

## Files changed

| File | Change |
|------|--------|
| `.agents/skills/impeccable/reference/finesse.md` | New |
| `.agents/skills/impeccable/reference/juicy.md` | New |
| `.claude/skills/impeccable/reference/finesse.md` | New (mirror) |
| `.claude/skills/impeccable/reference/juicy.md` | New (mirror) |
| `.agents/skills/impeccable/SKILL.md` | +2 rows in Enhance |
| `.claude/skills/impeccable/SKILL.md` | +2 rows + argument-hint updated |
| `.agents/skills/impeccable/scripts/command-metadata.json` | +2 entries |
| `.agents/skills/impeccable/scripts/pin.mjs` | `finesse` + `juicy` in VALID_COMMANDS |
| `.claude-plugin/plugin.json` | 3.0.7 → 3.1.0, "23 commands" → "25 commands" |

## Testing

- `pin finesse` / `unpin finesse` — works in all 10 harnesses
- `pin juicy` / `unpin juicy` — works in all 10 harnesses
- Voice consistent with `animate.md`, `polish.md`, `delight.md`

---

## RFC: open questions

1. **Category**: placed under Enhance alongside `animate`, `delight`, `overdrive`. Would a new "Feel" or "Refine" category make more sense to you?

2. **Naming**: `finesse` (refine existing interactions) and `juicy` (game-feel layer). `juicy` is borrowed from game design — let me know if that reads as too niche for this audience.

3. **Pedagogy weight**: few-shots + worked examples make these files ~3× longer than neighbors (~900 lines vs ~250). Happy to trim to the leaner style if you prefer consistency over depth.