### PR TITLE
docs(skill): add ## Examples section to SKILL.md

### DIFF
--- a/.agents/skills/impeccable/SKILL.md
+++ b/.agents/skills/impeccable/SKILL.md
@@ -165,6 +165,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+$impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+$impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+$impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+$impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `$<command>` invokes `$impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.claude/skills/impeccable/SKILL.md
+++ b/.claude/skills/impeccable/SKILL.md
@@ -171,6 +171,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.cursor/skills/impeccable/SKILL.md
+++ b/.cursor/skills/impeccable/SKILL.md
@@ -167,6 +167,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.gemini/skills/impeccable/SKILL.md
+++ b/.gemini/skills/impeccable/SKILL.md
@@ -166,6 +166,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.github/skills/impeccable/SKILL.md
+++ b/.github/skills/impeccable/SKILL.md
@@ -169,6 +169,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.kiro/skills/impeccable/SKILL.md
+++ b/.kiro/skills/impeccable/SKILL.md
@@ -167,6 +167,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.opencode/skills/impeccable/SKILL.md
+++ b/.opencode/skills/impeccable/SKILL.md
@@ -171,6 +171,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.pi/skills/impeccable/SKILL.md
+++ b/.pi/skills/impeccable/SKILL.md
@@ -169,6 +169,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.qoder/skills/impeccable/SKILL.md
+++ b/.qoder/skills/impeccable/SKILL.md
@@ -171,6 +171,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.rovodev/skills/impeccable/SKILL.md
+++ b/.rovodev/skills/impeccable/SKILL.md
@@ -171,6 +171,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.trae-cn/skills/impeccable/SKILL.md
+++ b/.trae-cn/skills/impeccable/SKILL.md
@@ -169,6 +169,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/.trae/skills/impeccable/SKILL.md
+++ b/.trae/skills/impeccable/SKILL.md
@@ -169,6 +169,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/plugin/skills/impeccable/SKILL.md
+++ b/plugin/skills/impeccable/SKILL.md
@@ -171,6 +171,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+/impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+/impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+/impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+/impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `/<command>` invokes `/impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -170,6 +170,30 @@ Setup (context gathering, register) is already loaded by then; sub-commands don'
 
 If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `teach` as a blocker, finish teach, refresh context, then resume the original command and target.
 
+## Examples
+
+Each example shows the user's invocation, what the skill loads, and the expected first move. Targets are optional; without one, the skill operates on whatever surface is in focus.
+
+```
+{{command_prefix}}impeccable audit blog
+```
+Loads [reference/audit.md](reference/audit.md) plus the brand or product register inferred from PRODUCT.md. First move: run accessibility, performance, and responsive checks on the blog hub and post pages, then list findings ranked by impact.
+
+```
+{{command_prefix}}impeccable polish settings
+```
+Loads [reference/polish.md](reference/polish.md). First move: walk the settings page top to bottom, flag spacing inconsistencies, weak hierarchy, and any patterns from the absolute bans list above. Apply fixes in place.
+
+```
+{{command_prefix}}impeccable craft pricing
+```
+Triggers the full shape-then-build flow. Setup runs first; if PRODUCT.md is missing the skill blocks on `teach`. Once setup passes, [reference/craft.md](reference/craft.md) owns the shape brief, image gate, and implementation steps.
+
+```
+{{command_prefix}}impeccable redo this hero section
+```
+No first-word command match, so the skill applies the shared design laws and the loaded register reference using the full string as context. First move: identify the surface, run the category-reflex check, propose a direction, then implement.
+
 ## Pin / Unpin
 
 **Pin** creates a standalone shortcut so `{{command_prefix}}<command>` invokes `{{command_prefix}}impeccable <command>` directly. **Unpin** removes it. The script writes to every harness directory present in the project.


### PR DESCRIPTION
## Summary

Adds an explicit `## Examples` heading to `skill/SKILL.md` so the file matches the structure recommended in Anthropic's skill authoring guide. The README has a "Usage Examples" subsection, but the SKILL.md itself did not, which means agents that fall back to scanning the SKILL.md head for examples would not find them.

The added section sits between `## Commands` (which now includes the routing rules) and `## Pin / Unpin`. It contains four examples that cover the same patterns the routing rules describe:

- A sub-command with a target (`audit blog`)
- A refine sub-command (`polish settings`)
- The shape-then-build flow (`craft pricing`), including the setup blocker behaviour
- A no-command general invocation (`redo this hero section`), exercising the fallback rule

## What I did NOT change

I did not add a separate `## Error Handling` section. The existing `## Setup (non-optional)` table on lines 17-32 already documents what to do on every failure mode it cares about (Context, Product, Command, Craft, Image, Mutation gates). Renaming or duplicating that into an `## Error Handling` section would either drop the gate framing that the rest of the skill is built around, or create two parallel doctrines on the same topic.

If you'd prefer an explicit `## Error Handling` heading anyway (perhaps with a one-line cross-reference to the Setup gates), happy to add it in a follow-up. Just let me know how you'd like the relationship between gates and error handling expressed.

## Build evidence

I ran `bun run build:skills` (via `node scripts/build.js` since bun isn't on this machine; deps installed via `npm install`):

```
✓ Cursor: 1 skill (35 reference files) (22 script files)
... (13 providers built)
✓ Generated counts: 23 commands, 27 detection rules
✓ Prose validator: no AI tells in user-facing copy
✓ Skill prose validator: skill/ is clean
✨ Build complete!
```

The harness output dirs (`.claude/`, `.cursor/`, etc.) were regenerated by the build per the existing convention; both prose validators pass clean.

## Test plan

- [ ] Maintainer runs `bun run build:skills` locally and confirms validators pass on their machine
- [ ] Maintainer reviews the four example commands match how they'd describe the skill
- [ ] Maintainer decides whether to add an explicit `## Error Handling` heading or accept that `## Setup (non-optional)` covers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds usage examples; no runtime logic or scripts are modified.
> 
> **Overview**
> Adds a new **`## Examples`** section to the `impeccable` skill docs (source `skill/SKILL.md` and generated harness copies like `.claude/`, `.cursor/`, `.agents/`, etc.).
> 
> The section provides four concrete invocations (`audit`, `polish`, `craft`, and a no-command fallback) and briefly states what references are loaded and what the agent should do first, placed between the routing rules and `## Pin / Unpin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d45e42c509db4d54dec65b30d8f44cfa8502c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->