### PR TITLE
fix(cli): pass --copy to npx skills add to avoid symlinking provider dirs

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -336,7 +336,12 @@ async function install(flags) {
 
   console.log('Installing impeccable skills via npx skills...\n');
   try {
-    execSync(`npx skills add pbakaus/impeccable${yes ? ' -y' : ''}`, { stdio: 'inherit' });
+    // --copy forces npx skills to install each provider's variant separately
+    // instead of symlinking .claude/skills/ to .agents/skills/. The two
+    // directories have meaningfully different per-provider content (frontmatter,
+    // command prefix, paths), and the default symlink also fails silently when
+    // .claude/ doesn't exist yet or on Windows without elevated privileges (#140).
+    execSync(`npx skills add pbakaus/impeccable --copy${yes ? ' -y' : ''}`, { stdio: 'inherit' });
   } catch (e) {
     process.exit(e.status ?? 1);
   }


### PR DESCRIPTION
## What broke and why

After running `npx impeccable skills install` (or `npx skills add pbakaus/impeccable`), Claude Code would fail to load the skill's scripts with:

```
Error: Cannot find module '.../.claude/skills/impeccable/scripts/load-context.mjs'
```

By default, `npx skills add` installs everything to `.agents/skills/impeccable/` and creates a symlink at `.claude/skills/impeccable/` pointing to it. Two things cause the symlink to be silently skipped:

1. **No `.claude/` directory yet** — fresh projects don't have one until you use Claude Code in them
2. **Windows symlink permissions** — on Windows, creating symlinks requires elevated privileges or Developer Mode enabled

Claude Code looks in `.claude/skills/`, not `.agents/skills/`, so when the symlink is missing the scripts are unreachable.

Fixes #140.

## The fix

`npx skills add` already has a `--copy` flag that installs each provider's variant separately instead of symlinking. We now pass it through from `impeccable skills install`.

```diff
-    execSync(`npx skills add pbakaus/impeccable${yes ? ' -y' : ''}`, { stdio: 'inherit' });
+    execSync(`npx skills add pbakaus/impeccable --copy${yes ? ' -y' : ''}`, { stdio: 'inherit' });
```

This also addresses @pbakaus's review feedback that the `.claude/` and `.agents/` directories have meaningfully different per-provider content (frontmatter, command prefix, paths), so symlinking is the wrong shape regardless of platform. `--copy` keeps those differences intact.

One line summary: we tell `npx skills` to copy per-provider variants instead of symlinking them.

## How we replicated on macOS

```bash
# Fresh project with no .claude/ directory
mkdir /tmp/impeccable-repro && cd /tmp/impeccable-repro
npx skills add pbakaus/impeccable -y

# .claude/ was never created — only .agents/ exists
ls .claude/  # → No such file or directory

# Reproduce the exact error from #140
node .claude/skills/impeccable/scripts/load-context.mjs
# Error: Cannot find module '/private/tmp/impeccable-repro/.claude/skills/impeccable/scripts/load-context.mjs'
```

## How we verified the fix

```bash
rm -rf /tmp/impeccable-repro && mkdir /tmp/impeccable-repro && cd /tmp/impeccable-repro
node /path/to/local/impeccable/cli/bin/cli.js skills install -y

# Both provider dirs exist as real directories (not symlinks)
ls -la .claude/  # drwxr-xr-x  .claude/
ls -la .agents/  # drwxr-xr-x  .agents/

# Script runs without error
node .claude/skills/impeccable/scripts/load-context.mjs
# → {"hasProduct":false,"product":null,...}  ✓
```

## Test plan

- [ ] `npx impeccable skills install` in a fresh project with no `.claude/` directory — confirm both `.claude/skills/impeccable/` and `.agents/skills/impeccable/` are created as real directories
- [ ] Confirm `node .claude/skills/impeccable/scripts/load-context.mjs` runs without error after install
- [ ] Confirm `--force` reinstall still works
- [ ] Windows: confirm install works without elevated privileges (no symlink required anymore)

## Related

- #126 — same family of bug (skill script path resolution after install) on a different path, not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the install flow to force per-provider copies instead of symlinks, which could affect disk layout and behavior across providers/platforms. Risk is moderate because it impacts the primary installation path but is a small, well-scoped change.
> 
> **Overview**
> `impeccable skills install` now invokes `npx skills add pbakaus/impeccable --copy` (with `-y` passthrough) to force separate per-provider installs rather than relying on `.claude/skills` being symlinked to `.agents/skills`.
> 
> This aims to prevent silent install failures when `.claude/` doesn’t exist yet or when symlink creation fails on Windows, and documents why provider-specific variants must not be symlinked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4171ba6079a17e9cfdb13405601c7ea3b9d5ac26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->