### PR TITLE
fix(plugin): Add trailing slash to skills path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   },
   "homepage": "https://impeccable.style",
   "repository": "https://github.com/pbakaus/impeccable",
-  "skills": "./.claude/skills"
+  "skills": "./.claude/skills/"
 }

--- a/tests/plugin-json.test.mjs
+++ b/tests/plugin-json.test.mjs
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+test('plugin.json skills path ends with trailing slash', () => {
+  const plugin = JSON.parse(fs.readFileSync('.claude-plugin/plugin.json', 'utf8'));
+  assert.equal(plugin.skills, './.claude/skills/');
+});


### PR DESCRIPTION
## Summary

Updates `.claude-plugin/plugin.json` so the `skills` entry points to `./.claude/skills/` with a trailing slash, matching directory-style plugin paths.

Adds a focused regression test that parses the plugin manifest and verifies the skills path remains directory-formatted.

## Verification

- `node --test tests/plugin-json.test.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a plugin manifest path string and adds a small regression test; no runtime business logic changes.
> 
> **Overview**
> Updates `.claude-plugin/plugin.json` to ensure the `skills` path is directory-formatted by adding a trailing slash (`./.claude/skills/`).
> 
> Adds a focused Node test (`tests/plugin-json.test.mjs`) that parses the manifest and asserts the `skills` path retains the trailing slash to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025936aa5f31c41d5e23a786324021caeec369dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->