### PR TITLE
Critique persistence: per-run snapshots, ignore list, polish reads as signal

### DIFF
--- a/.agents/skills/impeccable/reference/critique.md
+++ b/.agents/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .agents/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .agents/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `$impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .agents/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .agents/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.agents/skills/impeccable/reference/critique.md
+++ b/.agents/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .agents/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.agents/skills/impeccable/reference/polish.md
+++ b/.agents/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `$impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .agents/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .agents/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.agents/skills/impeccable/reference/polish.md
+++ b/.agents/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `$impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .agents/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .agents/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `$impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .agents/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .agents/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.agents/skills/impeccable/scripts/critique-storage.mjs
+++ b/.agents/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.agents/skills/impeccable/scripts/critique-storage.mjs
+++ b/.agents/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.agents/skills/impeccable/scripts/critique-storage.mjs
+++ b/.agents/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.agents/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.agents/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.agents/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.agents/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.claude/skills/impeccable/reference/critique.md
+++ b/.claude/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .claude/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.claude/skills/impeccable/reference/critique.md
+++ b/.claude/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .claude/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.claude/skills/impeccable/reference/polish.md
+++ b/.claude/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.claude/skills/impeccable/reference/polish.md
+++ b/.claude/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .claude/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .claude/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.claude/skills/impeccable/scripts/critique-storage.mjs
+++ b/.claude/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.claude/skills/impeccable/scripts/critique-storage.mjs
+++ b/.claude/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.claude/skills/impeccable/scripts/critique-storage.mjs
+++ b/.claude/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.claude/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.claude/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.claude/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.claude/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.cursor/skills/impeccable/reference/critique.md
+++ b/.cursor/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .cursor/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.cursor/skills/impeccable/reference/critique.md
+++ b/.cursor/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .cursor/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .cursor/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .cursor/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .cursor/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.cursor/skills/impeccable/reference/polish.md
+++ b/.cursor/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .cursor/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .cursor/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .cursor/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .cursor/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.cursor/skills/impeccable/reference/polish.md
+++ b/.cursor/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .cursor/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .cursor/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.cursor/skills/impeccable/scripts/critique-storage.mjs
+++ b/.cursor/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.cursor/skills/impeccable/scripts/critique-storage.mjs
+++ b/.cursor/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.cursor/skills/impeccable/scripts/critique-storage.mjs
+++ b/.cursor/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.cursor/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.cursor/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.cursor/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.cursor/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.gemini/skills/impeccable/reference/critique.md
+++ b/.gemini/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .gemini/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .gemini/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .gemini/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .gemini/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.gemini/skills/impeccable/reference/critique.md
+++ b/.gemini/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .gemini/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.gemini/skills/impeccable/reference/polish.md
+++ b/.gemini/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .gemini/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .gemini/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.gemini/skills/impeccable/reference/polish.md
+++ b/.gemini/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .gemini/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .gemini/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .gemini/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .gemini/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.gemini/skills/impeccable/scripts/critique-storage.mjs
+++ b/.gemini/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.gemini/skills/impeccable/scripts/critique-storage.mjs
+++ b/.gemini/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.gemini/skills/impeccable/scripts/critique-storage.mjs
+++ b/.gemini/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.gemini/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.gemini/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.gemini/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.gemini/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.github/skills/impeccable/reference/critique.md
+++ b/.github/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .github/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .github/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .github/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .github/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.github/skills/impeccable/reference/critique.md
+++ b/.github/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .github/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.github/skills/impeccable/reference/polish.md
+++ b/.github/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .github/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .github/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .github/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .github/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.github/skills/impeccable/reference/polish.md
+++ b/.github/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .github/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .github/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.github/skills/impeccable/scripts/critique-storage.mjs
+++ b/.github/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.github/skills/impeccable/scripts/critique-storage.mjs
+++ b/.github/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.github/skills/impeccable/scripts/critique-storage.mjs
+++ b/.github/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.github/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.github/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.github/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.github/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ Thumbs.db
 .impeccable/live/annotations/
 .impeccable/live/cache/
 .impeccable/history/
+# Per-run critique snapshots are local artifacts. ignore.md (also under
+# this dir) carries deferrals the user may want to share, so it's
+# explicitly re-included below.
+.impeccable/critique/
+!.impeccable/critique/ignore.md
 
 # Legacy live mode session file + annotation screenshots
 .impeccable-live.json

--- a/.kiro/skills/impeccable/reference/critique.md
+++ b/.kiro/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .kiro/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.kiro/skills/impeccable/reference/critique.md
+++ b/.kiro/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .kiro/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .kiro/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .kiro/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .kiro/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.kiro/skills/impeccable/reference/polish.md
+++ b/.kiro/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .kiro/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .kiro/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .kiro/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .kiro/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.kiro/skills/impeccable/reference/polish.md
+++ b/.kiro/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .kiro/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .kiro/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.kiro/skills/impeccable/scripts/critique-storage.mjs
+++ b/.kiro/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.kiro/skills/impeccable/scripts/critique-storage.mjs
+++ b/.kiro/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.kiro/skills/impeccable/scripts/critique-storage.mjs
+++ b/.kiro/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.kiro/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.kiro/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.kiro/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.kiro/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.opencode/skills/impeccable/reference/critique.md
+++ b/.opencode/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .opencode/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .opencode/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .opencode/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .opencode/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.opencode/skills/impeccable/reference/critique.md
+++ b/.opencode/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .opencode/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.opencode/skills/impeccable/reference/polish.md
+++ b/.opencode/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .opencode/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .opencode/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.opencode/skills/impeccable/reference/polish.md
+++ b/.opencode/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .opencode/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .opencode/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .opencode/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .opencode/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.opencode/skills/impeccable/scripts/critique-storage.mjs
+++ b/.opencode/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.opencode/skills/impeccable/scripts/critique-storage.mjs
+++ b/.opencode/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.opencode/skills/impeccable/scripts/critique-storage.mjs
+++ b/.opencode/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.opencode/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.opencode/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.opencode/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.opencode/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.pi/skills/impeccable/reference/critique.md
+++ b/.pi/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .pi/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.pi/skills/impeccable/reference/critique.md
+++ b/.pi/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .pi/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .pi/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .pi/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .pi/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.pi/skills/impeccable/reference/polish.md
+++ b/.pi/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .pi/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .pi/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .pi/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .pi/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.pi/skills/impeccable/reference/polish.md
+++ b/.pi/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .pi/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .pi/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.pi/skills/impeccable/scripts/critique-storage.mjs
+++ b/.pi/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.pi/skills/impeccable/scripts/critique-storage.mjs
+++ b/.pi/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.pi/skills/impeccable/scripts/critique-storage.mjs
+++ b/.pi/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.pi/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.pi/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.pi/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.pi/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.qoder/skills/impeccable/reference/critique.md
+++ b/.qoder/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .qoder/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .qoder/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .qoder/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .qoder/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.qoder/skills/impeccable/reference/critique.md
+++ b/.qoder/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .qoder/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.qoder/skills/impeccable/reference/polish.md
+++ b/.qoder/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .qoder/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .qoder/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.qoder/skills/impeccable/reference/polish.md
+++ b/.qoder/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .qoder/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .qoder/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .qoder/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .qoder/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.qoder/skills/impeccable/scripts/critique-storage.mjs
+++ b/.qoder/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.qoder/skills/impeccable/scripts/critique-storage.mjs
+++ b/.qoder/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.qoder/skills/impeccable/scripts/critique-storage.mjs
+++ b/.qoder/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.qoder/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.qoder/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.qoder/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.qoder/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.rovodev/skills/impeccable/reference/critique.md
+++ b/.rovodev/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .rovodev/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.rovodev/skills/impeccable/reference/critique.md
+++ b/.rovodev/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .rovodev/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .rovodev/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .rovodev/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .rovodev/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.rovodev/skills/impeccable/reference/polish.md
+++ b/.rovodev/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .rovodev/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .rovodev/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.rovodev/skills/impeccable/reference/polish.md
+++ b/.rovodev/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .rovodev/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .rovodev/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .rovodev/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .rovodev/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.rovodev/skills/impeccable/scripts/critique-storage.mjs
+++ b/.rovodev/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.rovodev/skills/impeccable/scripts/critique-storage.mjs
+++ b/.rovodev/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.rovodev/skills/impeccable/scripts/critique-storage.mjs
+++ b/.rovodev/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.rovodev/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.rovodev/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.rovodev/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.rovodev/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.trae-cn/skills/impeccable/reference/critique.md
+++ b/.trae-cn/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .trae-cn/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.trae-cn/skills/impeccable/reference/critique.md
+++ b/.trae-cn/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.trae-cn/skills/impeccable/reference/polish.md
+++ b/.trae-cn/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.trae-cn/skills/impeccable/reference/polish.md
+++ b/.trae-cn/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .trae-cn/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .trae-cn/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.trae-cn/skills/impeccable/scripts/critique-storage.mjs
+++ b/.trae-cn/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.trae-cn/skills/impeccable/scripts/critique-storage.mjs
+++ b/.trae-cn/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.trae-cn/skills/impeccable/scripts/critique-storage.mjs
+++ b/.trae-cn/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.trae-cn/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.trae-cn/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.trae-cn/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.trae-cn/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/.trae/skills/impeccable/reference/critique.md
+++ b/.trae/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .trae/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/.trae/skills/impeccable/reference/critique.md
+++ b/.trae/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .trae/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .trae/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .trae/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .trae/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/.trae/skills/impeccable/reference/polish.md
+++ b/.trae/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .trae/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .trae/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .trae/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .trae/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/.trae/skills/impeccable/reference/polish.md
+++ b/.trae/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .trae/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .trae/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/.trae/skills/impeccable/scripts/critique-storage.mjs
+++ b/.trae/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/.trae/skills/impeccable/scripts/critique-storage.mjs
+++ b/.trae/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/.trae/skills/impeccable/scripts/critique-storage.mjs
+++ b/.trae/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/.trae/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.trae/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/.trae/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/.trae/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/plugin/skills/impeccable/reference/critique.md
+++ b/plugin/skills/impeccable/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node .claude/skills/impeccable/scripts/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/plugin/skills/impeccable/reference/critique.md
+++ b/plugin/skills/impeccable/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `/impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node .claude/skills/impeccable/scripts/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/plugin/skills/impeccable/reference/polish.md
+++ b/plugin/skills/impeccable/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node .claude/skills/impeccable/scripts/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/plugin/skills/impeccable/reference/polish.md
+++ b/plugin/skills/impeccable/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `/impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node .claude/skills/impeccable/scripts/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `/impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node .claude/skills/impeccable/scripts/critique-storage.mjs slug "<resolved>")
+   node .claude/skills/impeccable/scripts/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/plugin/skills/impeccable/scripts/critique-storage.mjs
+++ b/plugin/skills/impeccable/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/plugin/skills/impeccable/scripts/critique-storage.mjs
+++ b/plugin/skills/impeccable/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/plugin/skills/impeccable/scripts/critique-storage.mjs
+++ b/plugin/skills/impeccable/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/plugin/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/plugin/skills/impeccable/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/plugin/skills/impeccable/scripts/impeccable-paths.mjs
+++ b/plugin/skills/impeccable/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/skill/reference/critique.md
+++ b/skill/reference/critique.md
@@ -16,11 +16,7 @@ Before gathering assessments, do two small bookkeeping steps. They cost almost n
    ```
    Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
 
-3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
-   ```bash
-   node {{scripts_path}}/critique-storage.mjs ignore
-   ```
-   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists. Plain markdown; each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
 
 ### Gather Assessments
 

--- a/skill/reference/critique.md
+++ b/skill/reference/critique.md
@@ -1,5 +1,27 @@
 > **Additional context needed**: what the interface is trying to accomplish.
 
+### Setup: Resolve Target and Load Ignore List
+
+Before gathering assessments, do two small bookkeeping steps. They cost almost nothing and they're what makes critique iterative across runs.
+
+1. **Resolve the primary artifact.** The user's phrasing ("the homepage", "the pricing flow") is not stable enough to track across runs. Resolve it to a concrete file path or URL: the same one you'd already need to scan code or open in a browser. Examples:
+   - "the homepage" → `site/pages/index.astro` (or `http://localhost:3000/` if you're inspecting live)
+   - "the settings modal" → the primary component file (e.g., `src/components/Settings.tsx`)
+   - "this page" → the URL or the page's source file
+   Prefer the source file path over the dev-server URL when both exist; ports drift between runs (`bun dev` vs `bun preview`), file paths don't.
+
+2. **Compute the slug.** Run:
+   ```bash
+   node {{scripts_path}}/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+   Keep the printed slug. It identifies this target's stream across runs. If the command exits non-zero ("no stable slug for input"), skip persistence for this run and tell the user; the trend won't update but the critique still goes ahead.
+
+3. **Read the ignore list** at `.impeccable/critique/ignore.md` if it exists:
+   ```bash
+   node {{scripts_path}}/critique-storage.mjs ignore
+   ```
+   Each non-empty, non-comment line is something the user has marked as "do not re-raise" (deferred tradeoffs, designer-intended deviations, detector false-positives the user accepts). When a finding's text matches a line here (case-insensitive substring against rule name or snippet), **drop it silently**. Do not mention it in the report. This is the ONLY input critique consumes from prior runs; anchoring on prior findings would defeat the point of independent assessment.
+
 ### Gather Assessments
 
 Launch two independent assessments. **Neither may see the other's output.** This isolation is what makes the combined score honest. Running both in one head silently anchors them to each other; do not shortcut it for cost, speed, or context-size reasons.
@@ -163,6 +185,36 @@ Provocative questions that might unlock better solutions:
 - Give concrete suggestions. Cut "consider exploring..." entirely.
 - Prioritize ruthlessly. If everything is important, nothing is.
 - Don't soften criticism. Developers need honest feedback to ship great design.
+
+### Persist the Snapshot
+
+Once the report above is finalized, write it to `.impeccable/critique/` so the user can refer back, and so `{{command_prefix}}impeccable polish` can pick up the priority issues without a copy-paste.
+
+Skip this step if the Setup slug was null (vague or root-level target).
+
+1. **Write the body to a temp file** so you can pipe it to the helper. Use the full report (heuristic table, anti-patterns verdict, priority issues, persona red flags) but stop before the "Ask the User" / "Recommended Actions" sections that come later.
+
+2. **Pass the structured metadata** through `IMPECCABLE_CRITIQUE_META` (JSON), then run the write command:
+   ```bash
+   IMPECCABLE_CRITIQUE_META='{"target":"<user phrasing>","total_score":<n>,"p0_count":<n>,"p1_count":<n>}' \
+     node {{scripts_path}}/critique-storage.mjs write <slug> <body-file>
+   ```
+   The helper prints the absolute path it wrote.
+
+3. **Read the trend** for context:
+   ```bash
+   node {{scripts_path}}/critique-storage.mjs trend <slug> 5
+   ```
+   This returns a JSON array of the last 5 frontmatter entries (including the one you just wrote).
+
+4. **Append a single line to the user-visible output**, after the report and before the questions:
+
+   > **Trend for `<slug>` (last 5 runs): 24 → 28 → 32 → 29 → 32**
+   > Wrote `.impeccable/critique/<filename>`.
+
+   If this is the first run for the slug, the trend is just one score; say so: "First run for this target, no trend yet."
+
+This is fire-and-forget. Do not show the user the helper's JSON output; only the human-readable trend line and the written path. Failures here should not block the rest of the flow; print the error and move on.
 
 ### Ask the User
 

--- a/skill/reference/polish.md
+++ b/skill/reference/polish.md
@@ -4,28 +4,6 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
-## Setup: Check for Prior Critique
-
-Polish is usually invoked after `{{command_prefix}}impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
-
-1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
-
-2. **Compute the slug** for that target:
-   ```bash
-   node {{scripts_path}}/critique-storage.mjs slug "<resolved-path-or-url>"
-   ```
-
-3. **Read the latest matching snapshot:**
-   ```bash
-   node {{scripts_path}}/critique-storage.mjs latest <slug>
-   ```
-   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
-
-   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
-   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
-
-This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
-
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.
@@ -57,7 +35,14 @@ Understand the current state and goals before touching anything:
    - Loading and transition smoothness
    - Information architecture and flow drift (does this feature reveal complexity the way neighboring features do?)
 
-4. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
+4. **Pull in any prior critique** (optional signal): If `{{command_prefix}}impeccable critique` has been run on the same target, its priority issues are a useful prior for what to address first. Resolve the target to a file path or URL, then:
+   ```bash
+   slug=$(node {{scripts_path}}/critique-storage.mjs slug "<resolved>")
+   node {{scripts_path}}/critique-storage.mjs latest "$slug"
+   ```
+   Exit 0 with body = found; fold the P0/P1 items into your polish list and mention the snapshot path so the user sees what you read. Exit 2 = no snapshot, continue without it. The critique is one input among many. Do your own pass either way.
+
+5. **Triage cosmetic vs functional**: Classify each issue as **cosmetic** (looks off, doesn't impede the user) or **functional** (breaks, blocks, or confuses the experience). When polish time is tight, functional issues ship first; cosmetic ones can land in a follow-up. Quality should be consistent; never perfect one corner while leaving another rough.
 
 **CRITICAL**: Polish is the last step, not the first. Don't polish work that's not functionally complete.
 

--- a/skill/reference/polish.md
+++ b/skill/reference/polish.md
@@ -4,6 +4,28 @@ Perform a meticulous final pass to catch all the small details that separate goo
 
 Detector and automated QA output are defect evidence only. A clean script result is never proof that the design is strong; gather browser evidence and inspect the real interaction path.
 
+## Setup: Check for Prior Critique
+
+Polish is usually invoked after `{{command_prefix}}impeccable critique`. When it is, the critique's P0 and P1 findings are the right backlog; don't re-derive them.
+
+1. **Resolve the target** the same way critique did: a concrete file path or URL, not the user's phrasing. Prefer source paths over dev-server URLs (ports drift between runs).
+
+2. **Compute the slug** for that target:
+   ```bash
+   node {{scripts_path}}/critique-storage.mjs slug "<resolved-path-or-url>"
+   ```
+
+3. **Read the latest matching snapshot:**
+   ```bash
+   node {{scripts_path}}/critique-storage.mjs latest <slug>
+   ```
+   Exit code 0 with body = found. Exit code 2 = no snapshot for this slug.
+
+   - **Found**: parse out the P0 and P1 priority issues from the report. Those are your polish backlog. Treat them as the user's stated priorities; address them before sweeping the broader checklist below. Mention the snapshot path to the user so they know what you're working from.
+   - **Not found**: proceed without prior context. Polish from a clean slate using the dimensions below. Do not load critique snapshots for *other* targets; cross-target context is pollution, not signal.
+
+This is the only command that auto-reads prior critique. Atomic moves (`bolder`, `quieter`, `clarify`, `animate`, etc.) do not, because they act on a specific selection where the page-level critique would be noise.
+
 ## Design System Discovery
 
 Aligning the feature to the design system is **not optional**. Polish without alignment is decoration on top of drift, and it makes the next person's job harder. Discovery comes before any other polish work.

--- a/skill/scripts/critique-storage.mjs
+++ b/skill/scripts/critique-storage.mjs
@@ -101,7 +101,11 @@ export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new
   fs.mkdirSync(dir, { recursive: true });
   const timestamp = nowFilenameStamp(now);
   const filePath = path.join(dir, `${timestamp}__${slug}.md`);
-  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  // Spread `meta` first so internally computed `timestamp` and `slug`
+  // always win. Otherwise a caller-supplied meta blob (parsed from the
+  // IMPECCABLE_CRITIQUE_META env var) could clobber them, leaving the
+  // filename in disagreement with its frontmatter and corrupting trends.
+  const front = serializeFrontmatter({ ...meta, timestamp, slug });
   fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
   return filePath;
 }

--- a/skill/scripts/critique-storage.mjs
+++ b/skill/scripts/critique-storage.mjs
@@ -18,12 +18,16 @@
  *   node critique-storage.mjs write <slug> <snapshot-body-file>
  *   node critique-storage.mjs latest <slug>
  *   node critique-storage.mjs trend <slug> [limit]
- *   node critique-storage.mjs ignore
+ *
+ * Note: there is intentionally no `ignore` subcommand. ignore.md is a plain
+ * markdown file; the model reads it directly with its file-read tool. This
+ * helper only exists for operations the model can't trivially do inline
+ * (normalizing paths, generating filenames, globbing + parsing frontmatter).
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+import { getCritiqueDir } from './impeccable-paths.mjs';
 
 const SLUG_MAX = 50;
 
@@ -169,21 +173,6 @@ export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }
 
-/**
- * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
- * Empty array when the file doesn't exist. This is the ONLY input critique
- * consumes from prior state — anchoring on prior findings is the whole
- * thing this design avoids.
- */
-export function readIgnoreList({ cwd = process.cwd() } = {}) {
-  const p = getCritiqueIgnorePath(cwd);
-  if (!fs.existsSync(p)) return [];
-  return fs.readFileSync(p, 'utf-8')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-}
-
 // ---- CLI ---------------------------------------------------------------
 
 function main(argv) {
@@ -222,13 +211,8 @@ function main(argv) {
       process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
       return;
     }
-    case 'ignore': {
-      const lines = readIgnoreList();
-      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
-      return;
-    }
     default:
-      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend> [args]\n');
       process.exit(1);
   }
 }

--- a/skill/scripts/critique-storage.mjs
+++ b/skill/scripts/critique-storage.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Critique persistence helper.
+ *
+ * Each run of /impeccable critique writes a per-target snapshot to
+ *   .impeccable/critique/<timestamp>__<slug>.md
+ * with a small YAML frontmatter carrying the score + P0/P1 counts.
+ *
+ * /impeccable polish reads the latest matching snapshot at start as its
+ * fix backlog. No other skill auto-reads critique output.
+ *
+ * The slug is derived mechanically from the *resolved* primary artifact
+ * (file path or URL), never from the user's natural-language phrasing.
+ * Slug stability across runs is what lets the trend display work.
+ *
+ * CLI entry points (called from skill instructions):
+ *   node critique-storage.mjs slug <resolved-target>
+ *   node critique-storage.mjs write <slug> <snapshot-body-file>
+ *   node critique-storage.mjs latest <slug>
+ *   node critique-storage.mjs trend <slug> [limit]
+ *   node critique-storage.mjs ignore
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { getCritiqueDir, getCritiqueIgnorePath } from './impeccable-paths.mjs';
+
+const SLUG_MAX = 50;
+
+/**
+ * Mechanically derive a slug from a resolved target. Returns null if the
+ * input doesn't look like a stable identifier (empty, project root, etc).
+ *
+ * Accepts file paths and URLs. The model resolves "the homepage" to a
+ * concrete artifact before calling this — we never slug a natural-language
+ * phrase.
+ */
+export function slugFromTarget(resolved, { cwd = process.cwd() } = {}) {
+  if (!resolved || typeof resolved !== 'string') return null;
+  const trimmed = resolved.trim();
+  if (!trimmed) return null;
+
+  // URL
+  if (/^https?:\/\//i.test(trimmed)) {
+    let url;
+    try { url = new URL(trimmed); } catch { return null; }
+    const hostPath = `${url.hostname}${url.pathname}`;
+    return kebab(hostPath);
+  }
+
+  // File path. Make it project-relative so two devs critiquing the same
+  // checkout get the same slug regardless of where their repo is cloned.
+  const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+  let rel = path.relative(cwd, abs);
+  // If the target is outside cwd, fall back to the basename so we still
+  // produce a stable slug (vs the absolute path, which would include
+  // home dirs / usernames).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    rel = path.basename(abs);
+  }
+  if (!rel || rel === '.' || rel === '') return null;
+  return kebab(rel);
+}
+
+function kebab(s) {
+  const slug = s
+    .toLowerCase()
+    .replace(/[/\\.]+/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug) return null;
+  // Cap from the tail — the tail (filename) is more identifying than the
+  // top-level directory.
+  return slug.length <= SLUG_MAX ? slug : slug.slice(slug.length - SLUG_MAX).replace(/^-/, '');
+}
+
+/**
+ * Filename-safe UTC ISO timestamp: hyphens for separators, trailing Z.
+ * Plain colons aren't allowed on Windows filesystems.
+ */
+export function nowFilenameStamp(date = new Date()) {
+  const iso = date.toISOString();           // 2026-05-12T18:30:00.123Z
+  return iso.replace(/[:.]/g, '-').replace(/-\d+Z$/, 'Z');
+}
+
+/**
+ * Write a snapshot for `slug`. `meta` carries the small structured frontmatter
+ * keys read back by readTrend(). `body` is the human-readable critique
+ * report (everything below the frontmatter).
+ *
+ * Returns the absolute path written.
+ */
+export function writeSnapshot({ slug, meta, body, cwd = process.cwd(), now = new Date() }) {
+  if (!slug) throw new Error('writeSnapshot requires a slug');
+  const dir = getCritiqueDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = nowFilenameStamp(now);
+  const filePath = path.join(dir, `${timestamp}__${slug}.md`);
+  const front = serializeFrontmatter({ timestamp, slug, ...meta });
+  fs.writeFileSync(filePath, `${front}\n${body.trim()}\n`, 'utf-8');
+  return filePath;
+}
+
+function serializeFrontmatter(obj) {
+  const lines = ['---'];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined || value === null) continue;
+    const str = typeof value === 'string' ? value : String(value);
+    // Quote strings that contain : or # to keep parsing simple.
+    const needsQuotes = typeof value === 'string' && /[:#]/.test(str);
+    lines.push(`${key}: ${needsQuotes ? JSON.stringify(str) : str}`);
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const out = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (/^".*"$/.test(value)) {
+      try { value = JSON.parse(value); } catch { /* leave as-is */ }
+    } else if (/^-?\d+$/.test(value)) {
+      value = Number(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Return all snapshot files for `slug`, sorted oldest → newest.
+ */
+function listSnapshotsForSlug(slug, cwd) {
+  const dir = getCritiqueDir(cwd);
+  if (!fs.existsSync(dir)) return [];
+  const suffix = `__${slug}.md`;
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith(suffix))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Return the most recent snapshot for `slug`, or null. Polish reads this
+ * to find its fix backlog when the slug matches.
+ */
+export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  if (!all.length) return null;
+  const latest = all[all.length - 1];
+  const body = fs.readFileSync(latest, 'utf-8');
+  return { path: latest, body, meta: parseFrontmatter(body) };
+}
+
+/**
+ * Return the last `limit` snapshots' frontmatter, oldest → newest.
+ * Critique appends a one-line trend to its output using this.
+ */
+export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
+  const all = listSnapshotsForSlug(slug, cwd);
+  const slice = all.slice(-limit);
+  return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Read .impeccable/critique/ignore.md, return non-empty non-comment lines.
+ * Empty array when the file doesn't exist. This is the ONLY input critique
+ * consumes from prior state — anchoring on prior findings is the whole
+ * thing this design avoids.
+ */
+export function readIgnoreList({ cwd = process.cwd() } = {}) {
+  const p = getCritiqueIgnorePath(cwd);
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+// ---- CLI ---------------------------------------------------------------
+
+function main(argv) {
+  const [cmd, ...args] = argv;
+  switch (cmd) {
+    case 'slug': {
+      const slug = slugFromTarget(args[0]);
+      if (!slug) { process.stderr.write('no stable slug for input\n'); process.exit(1); }
+      process.stdout.write(`${slug}\n`);
+      return;
+    }
+    case 'write': {
+      const [slug, bodyFile] = args;
+      if (!slug || !bodyFile) { process.stderr.write('usage: write <slug> <body-file>\n'); process.exit(1); }
+      const raw = fs.readFileSync(bodyFile, 'utf-8');
+      // The body file may be a full report. The caller passes the meta as
+      // a JSON object on stdin if it wants structured frontmatter; otherwise
+      // we write with minimal metadata.
+      let meta = {};
+      const metaArg = process.env.IMPECCABLE_CRITIQUE_META;
+      if (metaArg) {
+        try { meta = JSON.parse(metaArg); } catch { /* ignore */ }
+      }
+      const out = writeSnapshot({ slug, meta, body: raw });
+      process.stdout.write(`${out}\n`);
+      return;
+    }
+    case 'latest': {
+      const latest = readLatestSnapshot(args[0]);
+      if (!latest) { process.exit(2); }
+      process.stdout.write(latest.body);
+      return;
+    }
+    case 'trend': {
+      const rows = readTrend(args[0], { limit: args[1] ? Number(args[1]) : 5 });
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    case 'ignore': {
+      const lines = readIgnoreList();
+      process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''));
+      return;
+    }
+    default:
+      process.stderr.write('usage: critique-storage.mjs <slug|write|latest|trend|ignore> [args]\n');
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/skill/scripts/impeccable-paths.mjs
+++ b/skill/scripts/impeccable-paths.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 export const IMPECCABLE_DIR = '.impeccable';
 export const LIVE_DIR = 'live';
+export const CRITIQUE_DIR = 'critique';
 
 export function getImpeccableDir(cwd = process.cwd()) {
   return path.join(cwd, IMPECCABLE_DIR);
@@ -94,6 +95,14 @@ export function getLegacyLiveSessionsDir(cwd = process.cwd()) {
 
 export function getLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(getLiveDir(cwd), 'annotations');
+}
+
+export function getCritiqueDir(cwd = process.cwd()) {
+  return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
+}
+
+export function getCritiqueIgnorePath(cwd = process.cwd()) {
+  return path.join(getCritiqueDir(cwd), 'ignore.md');
 }
 
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {

--- a/skill/scripts/impeccable-paths.mjs
+++ b/skill/scripts/impeccable-paths.mjs
@@ -101,10 +101,6 @@ export function getCritiqueDir(cwd = process.cwd()) {
   return path.join(getImpeccableDir(cwd), CRITIQUE_DIR);
 }
 
-export function getCritiqueIgnorePath(cwd = process.cwd()) {
-  return path.join(getCritiqueDir(cwd), 'ignore.md');
-}
-
 export function getLegacyLiveAnnotationsDir(cwd = process.cwd()) {
   return path.join(cwd, '.impeccable-live', 'annotations');
 }

--- a/tests/critique-storage.test.mjs
+++ b/tests/critique-storage.test.mjs
@@ -115,6 +115,27 @@ describe('writeSnapshot + readLatestSnapshot', () => {
     assert.equal(readLatestSnapshot('index-astro', { cwd }), null);
   });
 
+  it('caller-supplied meta cannot override computed timestamp or slug', () => {
+    // Defends against a corrupt IMPECCABLE_CRITIQUE_META blob (parsed from
+    // an env var) silently rewriting fields that must agree with the
+    // filename. Otherwise readTrend would attribute scores to the wrong
+    // timestamps with no error.
+    const out = writeSnapshot({
+      slug: 'index-astro',
+      meta: { timestamp: 'NOT_A_REAL_STAMP', slug: 'somewhere-else', total_score: 50 },
+      body: 'b',
+      cwd,
+      now: new Date('2026-05-12T18:30:00Z'),
+    });
+    const latest = readLatestSnapshot('index-astro', { cwd });
+    assert.equal(latest.meta.slug, 'index-astro');
+    assert.equal(latest.meta.timestamp, '2026-05-12T18-30-00Z');
+    // The legit meta field still lands.
+    assert.equal(latest.meta.total_score, 50);
+    // The filename matches the computed slug.
+    assert.ok(out.endsWith('2026-05-12T18-30-00Z__index-astro.md'));
+  });
+
   it('quotes values containing : or # to keep parsing simple', () => {
     writeSnapshot({
       slug: 'x',

--- a/tests/critique-storage.test.mjs
+++ b/tests/critique-storage.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * Tests for critique snapshot persistence.
+ * Run with: node --test tests/critique-storage.test.mjs
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  slugFromTarget,
+  writeSnapshot,
+  readLatestSnapshot,
+  readTrend,
+  readIgnoreList,
+  nowFilenameStamp,
+} from '../skill/scripts/critique-storage.mjs';
+
+let cwd;
+beforeEach(() => { cwd = mkdtempSync(join(tmpdir(), 'imp-critique-')); });
+afterEach(() => { rmSync(cwd, { recursive: true, force: true }); });
+
+describe('slugFromTarget', () => {
+  it('kebabs a relative file path', () => {
+    assert.equal(slugFromTarget('site/pages/index.astro', { cwd }), 'site-pages-index-astro');
+  });
+
+  it('kebabs an absolute path inside cwd by relativizing', () => {
+    const abs = join(cwd, 'site/pages/index.astro');
+    assert.equal(slugFromTarget(abs, { cwd }), 'site-pages-index-astro');
+  });
+
+  it('uses basename for absolute paths outside cwd', () => {
+    // Sibling path, not under cwd
+    const abs = join(tmpdir(), 'somewhere', 'else', 'page.html');
+    assert.equal(slugFromTarget(abs, { cwd }), 'page-html');
+  });
+
+  it('drops port from URL', () => {
+    assert.equal(slugFromTarget('http://localhost:3000/pricing', { cwd }), 'localhost-pricing');
+  });
+
+  it('normalizes URL casing and trailing slash', () => {
+    assert.equal(
+      slugFromTarget('https://Impeccable.Style/docs/audit/', { cwd }),
+      'impeccable-style-docs-audit',
+    );
+  });
+
+  it('strips query strings', () => {
+    assert.equal(
+      slugFromTarget('https://example.com/x?utm=1&foo=bar', { cwd }),
+      'example-com-x',
+    );
+  });
+
+  it('returns null for empty / project-root inputs', () => {
+    assert.equal(slugFromTarget('', { cwd }), null);
+    assert.equal(slugFromTarget('.', { cwd }), null);
+    assert.equal(slugFromTarget(null, { cwd }), null);
+  });
+
+  it('caps overly long slugs from the tail', () => {
+    const longPath = 'a/'.repeat(60) + 'file.tsx';   // way over 50
+    const slug = slugFromTarget(longPath, { cwd });
+    assert.ok(slug.length <= 50);
+    assert.ok(slug.endsWith('file-tsx'));
+  });
+
+  it('is stable: same input → same slug', () => {
+    const a = slugFromTarget('site/pages/index.astro', { cwd });
+    const b = slugFromTarget('site/pages/index.astro', { cwd });
+    assert.equal(a, b);
+  });
+});
+
+describe('nowFilenameStamp', () => {
+  it('is windows-safe (no colons or dots in the time fragment)', () => {
+    const stamp = nowFilenameStamp(new Date('2026-05-12T18:30:00.123Z'));
+    assert.equal(stamp, '2026-05-12T18-30-00Z');
+  });
+});
+
+describe('writeSnapshot + readLatestSnapshot', () => {
+  it('round-trips body and frontmatter', () => {
+    const out = writeSnapshot({
+      slug: 'index-astro',
+      meta: { target: 'the homepage', total_score: 28, p0_count: 1, p1_count: 3 },
+      body: '# Critique\n\nP0: nested cards',
+      cwd,
+    });
+    assert.ok(out.endsWith('__index-astro.md'));
+    const latest = readLatestSnapshot('index-astro', { cwd });
+    assert.equal(latest.meta.slug, 'index-astro');
+    assert.equal(latest.meta.target, 'the homepage');
+    assert.equal(latest.meta.total_score, 28);
+    assert.match(latest.body, /P0: nested cards/);
+  });
+
+  it('returns null when no snapshot for slug', () => {
+    assert.equal(readLatestSnapshot('nope', { cwd }), null);
+  });
+
+  it('picks the newest by filename when multiple exist', () => {
+    writeSnapshot({ slug: 'index-astro', meta: { total_score: 22 }, body: 'old', cwd, now: new Date('2026-05-01T00:00:00Z') });
+    writeSnapshot({ slug: 'index-astro', meta: { total_score: 30 }, body: 'new', cwd, now: new Date('2026-05-12T00:00:00Z') });
+    const latest = readLatestSnapshot('index-astro', { cwd });
+    assert.equal(latest.meta.total_score, 30);
+    assert.match(latest.body, /new/);
+  });
+
+  it('does not see snapshots for a different slug', () => {
+    writeSnapshot({ slug: 'pricing-astro', meta: { total_score: 10 }, body: 'b', cwd });
+    assert.equal(readLatestSnapshot('index-astro', { cwd }), null);
+  });
+
+  it('quotes values containing : or # to keep parsing simple', () => {
+    writeSnapshot({
+      slug: 'x',
+      meta: { target: 'docs: critique # main' },
+      body: '...',
+      cwd,
+    });
+    const latest = readLatestSnapshot('x', { cwd });
+    assert.equal(latest.meta.target, 'docs: critique # main');
+  });
+});
+
+describe('readTrend', () => {
+  it('returns last N entries oldest → newest, filtered by slug', () => {
+    for (let i = 0; i < 6; i++) {
+      writeSnapshot({
+        slug: 'index-astro',
+        meta: { total_score: 20 + i },
+        body: `run ${i}`,
+        cwd,
+        now: new Date(2026, 4, i + 1),
+      });
+    }
+    writeSnapshot({ slug: 'pricing-astro', meta: { total_score: 99 }, body: 'unrelated', cwd });
+    const trend = readTrend('index-astro', { limit: 5, cwd });
+    assert.equal(trend.length, 5);
+    assert.equal(trend[0].total_score, 21);   // dropped the oldest
+    assert.equal(trend[4].total_score, 25);
+  });
+
+  it('returns empty when no snapshots', () => {
+    assert.deepEqual(readTrend('nope', { cwd }), []);
+  });
+});
+
+describe('readIgnoreList', () => {
+  it('returns [] when ignore.md does not exist', () => {
+    assert.deepEqual(readIgnoreList({ cwd }), []);
+  });
+
+  it('skips blank lines and # comments', () => {
+    const dir = join(cwd, '.impeccable/critique');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'ignore.md'),
+      '# header comment\n\nicon-tile-stack on features\n# another comment\nlow-contrast on hero CTA\n\n');
+    assert.deepEqual(readIgnoreList({ cwd }), [
+      'icon-tile-stack on features',
+      'low-contrast on hero CTA',
+    ]);
+  });
+});

--- a/tests/critique-storage.test.mjs
+++ b/tests/critique-storage.test.mjs
@@ -5,7 +5,7 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -14,7 +14,6 @@ import {
   writeSnapshot,
   readLatestSnapshot,
   readTrend,
-  readIgnoreList,
   nowFilenameStamp,
 } from '../skill/scripts/critique-storage.mjs';
 
@@ -151,19 +150,3 @@ describe('readTrend', () => {
   });
 });
 
-describe('readIgnoreList', () => {
-  it('returns [] when ignore.md does not exist', () => {
-    assert.deepEqual(readIgnoreList({ cwd }), []);
-  });
-
-  it('skips blank lines and # comments', () => {
-    const dir = join(cwd, '.impeccable/critique');
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, 'ignore.md'),
-      '# header comment\n\nicon-tile-stack on features\n# another comment\nlow-contrast on hero CTA\n\n');
-    assert.deepEqual(readIgnoreList({ cwd }), [
-      'icon-tile-stack on features',
-      'low-contrast on hero CTA',
-    ]);
-  });
-});


### PR DESCRIPTION
Closes #128.

## Summary

Persist `/impeccable critique` output to per-run snapshots so the user can refer back, and let `/impeccable polish` read the latest matching snapshot as **additional signal**. The shape of this design was discussed thread-first; the key concern from #128 (file-based persistence) is satisfied without the bias trap of feeding prior critique findings into a new critique run.

## Design choices

- **Per-run files, not one CRITIQUE.md.** Each run writes `.impeccable/critique/<timestamp>__<slug>.md`. No single file gets rewritten, no resolved/unresolved sections get fed back in. The bias risk from re-feeding findings goes away.
- **Slug is mechanically derived from the resolved primary artifact** (file path preferred over URL, since dev-server ports drift). The model never picks a slug freeform; it runs the path through a normalizer. Hallucination surface zero.
- **No `index.json`.** Trend is read by globbing matching snapshot files and parsing each one's small frontmatter block. One source of truth; deleting a snapshot removes it from trend cleanly.
- **Critique only consumes one prior-run input: `ignore.md`.** User-curated, hand-edited, one finding per line. Matches drop silently from the new report. Anything richer (resolved/unresolved tracking, "remember the last score") was explicitly rejected as anchoring.
- **Polish reads the latest matching snapshot as additional signal**, not as the backlog. Folded into the existing Pre-Polish Assessment list as item 4 ("Pull in any prior critique — optional signal"). Polish does its own pass either way. No other command auto-reads.

## What's NOT in this PR

- Auto-detection of "what was resolved since last run." Too noisy; gives the model false confidence.
- A slash-command UI for managing `ignore.md`. Hand-edit for now; can add if friction shows.
- Per-finding diffing between snapshots. Speculative.
- Reading critique from other action commands (`bolder`, `quieter`, `clarify`, `animate`, etc.). They act on atomic selections where page-level critique would be noise.

## Commits

- `63310f7` critique-storage: new helper (slug, write, latest, trend, ignore) + 19 unit tests
- `4569dce` critique.md: Setup step reads ignore.md and resolves slug; new Persist Snapshot step writes per-run file and prints trend line
- `a7a0824` polish.md: initial draft of critique-read step
- `0808ff9` polish.md: reframed as one item in Pre-Polish Assessment (additional signal, not the backlog) after review feedback
- `b8a3be3` .gitignore: ignore snapshot files, opt `ignore.md` back in (team-shareable)

## Test plan

- [x] `bun test tests/build.test.js` — 8/8
- [x] `node --test tests/critique-storage.test.mjs tests/impeccable-paths.test.mjs` — 27/27
- [x] `bun run build:skills` clean (29 rules, prose validator green)
- [ ] Smoke run `/impeccable critique the homepage` against a real project; verify snapshot is written with correct frontmatter and trend line displays
- [ ] Smoke run `/impeccable polish` against the same target after critique; verify the polish backlog picks up P0/P1 items and announces the snapshot path
- [ ] Hand-edit `.impeccable/critique/ignore.md`, re-run critique, verify the matching finding is suppressed
- [ ] Run `/impeccable polish` on an UN-critiqued target; verify it proceeds independently without complaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new file-writing CLI tooling and updates multiple skill instruction sets to persist and read critique snapshots; mistakes could create incorrect slugs/trends or write unexpected files. Scope is mostly local developer/agent tooling (no auth or production runtime paths).
> 
> **Overview**
> Adds per-target, per-run persistence for `/impeccable critique` via timestamped snapshot files under `.impeccable/critique/`, including a mechanically-derived slug, minimal frontmatter metadata, and a trend reader.
> 
> Updates the `critique.md` instructions across environments to (1) resolve a stable target, (2) consult a user-managed `.impeccable/critique/ignore.md` to silently suppress deferred findings, and (3) write a snapshot and print a one-line recent-score trend.
> 
> Updates `polish.md` to optionally load the latest snapshot for the same slug as *additional signal* to seed P0/P1 polish items, and adjusts `.gitignore` to ignore snapshots while explicitly keeping `ignore.md` trackable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb44b164bef1f80a7cc48620bc12ea217132e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->