### PR TITLE
fix: add mandatory mechanical pre-scan to typeset and layout commands

### DIFF
--- a/skill/reference/layout.md
+++ b/skill/reference/layout.md
@@ -1,6 +1,23 @@
 Space is the most underused design tool. Find the layout's actual problem (monotone spacing, weak hierarchy, identical card grids, the centered-stack default) and fix the structure, not the surface.
 
 ---
+## Mechanical Pre-Scan (required before visual review)
+
+Run these greps on the target files before any visual analysis. Surface every hit in your response so the user can decide which to fix vs. accept as a scoped exception.
+
+
+# Arbitrary spacing values outside the scale (Tailwind arbitrary syntax)
+grep -rn '\(p\|m\|gap\|space\)-\[[0-9]*\.?[0-9]*\(px\|rem\|em\)\]' --include="*.tsx" --include="*.ts" --include="*.css" --include="*.jsx" --include="*.js" .
+
+# Orphan opacity values
+grep -rn 'opacity-\[' --include="*.tsx" --include="*.ts" --include="*.css" --include="*.jsx" --include="*.js" .
+
+# Hard-coded pixel spacing in raw CSS
+grep -rn '\(padding\|margin\|gap\):\s*[0-9]*\.?[0-9]*px' --include="*.css" --include="*.scss" .
+
+# Arbitrary z-index values (999, 9999, etc.)
+grep -rn 'z-\[9\{2,\}\]' --include="*.tsx" --include="*.ts" --include="*.css" --include="*.jsx" --include="*.js" .
+\
 
 ## Register
 

--- a/skill/reference/typeset.md
+++ b/skill/reference/typeset.md
@@ -1,6 +1,21 @@
 Typography carries most of the information on the page. Replace generic defaults (Inter, Roboto, system fallback at flat scale) with type that reflects the brand and scales with intentional contrast.
 
 ---
+## Mechanical Pre-Scan (required before visual review)
+
+Run these greps on the target files before any visual analysis. Surface every hit in your response so the user can decide which to fix vs. accept as a scoped exception.
+
+# Orphan pixel font sizes (off-ramp arbitrary values)
+grep -rn 'text-\[[0-9]*\.?[0-9]*px\]' --include="*.tsx" --include="*.ts" --include="*.css" --include="*.jsx" --include="*.js" .
+
+# Ad-hoc line heights
+grep -rn 'leading-\[' --include="*.tsx" --include="*.ts" --include="*.css" --include="*.jsx" --include="*.js" .
+
+# Hard-coded hex colors in component files
+grep -rn '#[0-9a-fA-F]\{3,6\}' --include="*.tsx" --include="*.ts" --include="*.css" --include="*.jsx" --include="*.js" .
+
+# px font sizes outside of Tailwind brackets (raw CSS)
+grep -rn 'font-size:\s*[0-9]*\.?[0-9]*px' --include="*.css" --include="*.scss" ./.
 
 ## Register
 


### PR DESCRIPTION
Resolves #149. Agents running /typeset or /layout now grep for
off-spec values (orphan px font sizes, ad-hoc leading, hard-coded
hex colors, arbitrary spacing) before visual review. This catches
values like 12.5px that slip past LLM visual passes.

Surfaces all hits in the response so the user can decide which to
fix vs. accept as scoped exceptions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds required pre-review grep checks; the main risk is minor confusion if the regexes or the stray trailing `\` in `layout.md` are incorrect.
> 
> **Overview**
> Adds a **mandatory “Mechanical Pre-Scan” step** to the `layout` and `typeset` reference guides, requiring reviewers to run predefined `grep` commands before visual analysis.
> 
> The new pre-scan checks surface off-spec values (e.g., Tailwind arbitrary spacing/typography, orphan `opacity`/`leading`, hard-coded `px` spacing/font sizes, hex colors, and extreme `z-index` values) and instructs agents to report all matches so users can choose fixes vs. scoped exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4f27cd1d5b5606018afa276ba242be12af49bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->