### PR TITLE
Fix stdin dash target in detector CLI

### DIFF
--- a/.agents/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.agents/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.claude/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.claude/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.cursor/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.cursor/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.gemini/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.gemini/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.github/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.github/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.kiro/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.kiro/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.opencode/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.opencode/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.pi/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.pi/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.qoder/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.qoder/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.rovodev/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.rovodev/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.trae-cn/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.trae-cn/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/.trae/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/.trae/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/cli/engine/cli/main.mjs
+++ b/cli/engine/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/plugin/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/plugin/skills/impeccable/scripts/detector/cli/main.mjs
@@ -93,6 +93,7 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  cat index.html | impeccable detect -
   impeccable detect --fast --json .`);
 }
 
@@ -121,6 +122,11 @@ async function detectCli() {
 
     try {
       for (const target of paths) {
+        if (target === '-') {
+          allFindings.push(...await handleStdin());
+          continue;
+        }
+
         if (/^https?:\/\//i.test(target)) {
           try {
             const scanner = browserDetector

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -688,6 +688,11 @@ describe('CLI', () => {
     return { stdout: result.stdout || '', stderr: result.stderr || '', code: result.status };
   }
 
+  function runWithInput(input, ...args) {
+    const result = spawnSync('node', [SCRIPT, ...args], { encoding: 'utf-8', input, timeout: 15000 });
+    return { stdout: result.stdout || '', stderr: result.stderr || '', code: result.status };
+  }
+
   test('--help exits 0', () => {
     const { stdout, code } = run('--help');
     expect(code).toBe(0);
@@ -737,6 +742,19 @@ describe('CLI', () => {
   test('--fast mode works', () => {
     const { code } = run('--fast', path.join(FIXTURES, 'should-flag.html'));
     expect(code).toBe(2);
+  });
+
+  test('dash target reads stdin', () => {
+    const { stdout, stderr, code } = runWithInput(
+      '<div class="border-l-4 border-blue-500 rounded-lg">Card</div>',
+      '--fast',
+      '--json',
+      '-',
+    );
+    expect(code).toBe(2);
+    expect(stderr).not.toContain('cannot access -');
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.some(f => f.file === '<stdin>' && f.antipattern === 'side-tab')).toBe(true);
   });
 
   test('linked stylesheet detected (static HTML/CSS default)', () => {


### PR DESCRIPTION
## Summary\n- Treat `-` as an explicit stdin target for `impeccable detect`\n- Document the pipe usage in detector CLI help\n- Add a CLI regression test for `--fast --json -`\n- Regenerate provider skill copies\n\n## Verification\n- `bun test tests/detect-antipatterns.test.js --timeout 30000`\n- `bun run build:skills`\n- `codex review --uncommitted`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI input-routing fix with mirrored copies and a focused integration test; no auth, data, or security-sensitive paths.
> 
> **Overview**
> **`impeccable detect`** now treats **`-`** as an explicit stdin target in the target loop, so piped input is scanned via **`handleStdin()`** instead of failing with “cannot access -” when a target is present on the command line.
> 
> Help text adds an example: **`cat index.html | impeccable detect -`**. The same CLI change is mirrored across provider skill copies and **`cli/engine/cli/main.mjs`**.
> 
> A CLI regression test pipes HTML into **`--fast --json -`** and asserts JSON findings use **`file: '<stdin>'`** with expected anti-patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18874983f6b3f5666a3df743c7880780f67d7e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->