### PR TITLE
Fix edit mode focus stealing

### DIFF
--- a/.agents/skills/impeccable/scripts/live-browser.js
+++ b/.agents/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.claude/skills/impeccable/scripts/live-browser.js
+++ b/.claude/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.cursor/skills/impeccable/scripts/live-browser.js
+++ b/.cursor/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.gemini/skills/impeccable/scripts/live-browser.js
+++ b/.gemini/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.github/skills/impeccable/scripts/live-browser.js
+++ b/.github/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.kiro/skills/impeccable/scripts/live-browser.js
+++ b/.kiro/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.opencode/skills/impeccable/scripts/live-browser.js
+++ b/.opencode/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.pi/skills/impeccable/scripts/live-browser.js
+++ b/.pi/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.qoder/skills/impeccable/scripts/live-browser.js
+++ b/.qoder/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.rovodev/skills/impeccable/scripts/live-browser.js
+++ b/.rovodev/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.trae-cn/skills/impeccable/scripts/live-browser.js
+++ b/.trae-cn/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/.trae/skills/impeccable/scripts/live-browser.js
+++ b/.trae/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/plugin/skills/impeccable/scripts/live-browser.js
+++ b/plugin/skills/impeccable/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6012,7 +6012,9 @@ void main() {
   }
 
   function shouldFocusSteerChat() {
-    return state !== 'CONFIGURING' && !steerLocked;
+    return state !== 'CONFIGURING'
+      && state !== 'EDITING'
+      && !steerLocked;
   }
 
   function pageHasHostTextSelection() {

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -90,6 +90,14 @@ describe('live-browser.js regression guards', () => {
     );
   });
 
+  it('does not autofocus the steering chat while inline editing', () => {
+    assert.match(
+      SOURCE,
+      /function shouldFocusSteerChat\(\) \{\s*return state !== 'CONFIGURING'\s*&& state !== 'EDITING'\s*&& !steerLocked;\s*\}/,
+      'edit-mode contenteditable focus must not be stolen by the global steering chat focus recovery',
+    );
+  });
+
   it('does not shadow the global live state when storing Apply state', () => {
     assert.doesNotMatch(
       SOURCE,


### PR DESCRIPTION
## Summary
- Prevent the global Steer bottom bar from auto-focusing while inline edit mode is active
- Add a regression guard for edit-mode focus stealing
- Regenerate provider skill copies

## Validation
- node --test tests/live-browser-regression.test.mjs
- bun run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/focus-guard change in client overlay code with a regression test; no auth, data, or API impact.
> 
> **Overview**
> Prevents the global **Steer** bottom bar from auto-focusing the page chat while **inline edit** mode is active, so focus stays on the host page’s contenteditable edits.
> 
> `shouldFocusSteerChat()` now treats `EDITING` like `CONFIGURING` (blocked when `steerLocked` is false). The same guard is applied across regenerated Impeccable skill copies of `live-browser.js`, with a regression test asserting the updated condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10619700a304f46fda2a838879bda60079e6dd77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->