### PR TITLE
Fix dark-glow text path to split multi-shadow box-shadow by comma

### DIFF
--- a/src/detect-antipatterns.mjs
+++ b/src/detect-antipatterns.mjs
@@ -677,6 +677,32 @@ function checkGlow(opts) {
 }
 
 /**
+ * Scan a CSS `box-shadow` value for a colored shadow with blur > 4px.
+ * Splits multi-shadow values on commas (ignoring commas inside parens) so
+ * each shadow is evaluated against its own color and its own blur — mirrors
+ * `checkGlow` in detect-antipatterns-browser.js.
+ * Returns the first matching `{r,g,b}` or null.
+ */
+function findDarkGlowShadow(boxShadowVal) {
+  for (const shadow of boxShadowVal.split(/,(?![^(]*\))/)) {
+    const colorMatch = shadow.match(/rgba?\([^)]*\)/);
+    if (!colorMatch) continue;
+    const rgb = colorMatch[0].match(/(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    if (!rgb) continue;
+    const [r, g, b] = [+rgb[1], +rgb[2], +rgb[3]];
+    if ((Math.max(r, g, b) - Math.min(r, g, b)) < 30) continue;
+    // Strip the color expression before scanning for lengths — its internal
+    // 0/decimal channels would otherwise be mistaken for offsets/blur.
+    const geometry = shadow.replace(colorMatch[0], ' ');
+    const pxVals = [...geometry.matchAll(/(\d+)px|(?<![.\d])\b(0)\b(?![.\d])/g)].map(p => +(p[1] || p[2]));
+    if (pxVals.length >= 3 && pxVals[2] > 4) {
+      return { r, g, b };
+    }
+  }
+  return null;
+}
+
+/**
  * Regex-on-HTML checks shared between browser and Node page-level detection.
  * These don't need DOM access, just the raw HTML string.
  */
@@ -794,14 +820,9 @@ function checkHtmlPatterns(html) {
     const shadowRe = /box-shadow\s*:\s*([^;{}]+)/gi;
     let shm;
     while ((shm = shadowRe.exec(html)) !== null) {
-      const val = shm[1];
-      const colorMatch = val.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
-      if (!colorMatch) continue;
-      const [r, g, b] = [+colorMatch[1], +colorMatch[2], +colorMatch[3]];
-      if ((Math.max(r, g, b) - Math.min(r, g, b)) < 30) continue;
-      const pxVals = [...val.matchAll(/(\d+)px|(?<![.\d])\b(0)\b(?![.\d])/g)].map(p => +(p[1] || p[2]));
-      if (pxVals.length >= 3 && pxVals[2] > 4) {
-        findings.push({ id: 'dark-glow', snippet: `Colored glow (rgb(${r},${g},${b})) on dark page` });
+      const glow = findDarkGlowShadow(shm[1]);
+      if (glow) {
+        findings.push({ id: 'dark-glow', snippet: `Colored glow (rgb(${glow.r},${glow.g},${glow.b})) on dark page` });
         break;
       }
     }
@@ -2935,20 +2956,14 @@ const REGEX_ANALYZERS = [
     const hasDarkBg = darkBgRe.test(content) || twDarkBg.test(content);
     if (!hasDarkBg) return [];
 
-    // Check for colored box-shadow with blur > 4px
+    // Check for colored box-shadow with blur > 4px (per-shadow within multi-shadow values)
     const shadowRe = /box-shadow\s*:\s*([^;{}]+)/gi;
     let m;
     while ((m = shadowRe.exec(content)) !== null) {
-      const val = m[1];
-      const colorMatch = val.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
-      if (!colorMatch) continue;
-      const [r, g, b] = [+colorMatch[1], +colorMatch[2], +colorMatch[3]];
-      if ((Math.max(r, g, b) - Math.min(r, g, b)) < 30) continue; // skip gray
-      // Check blur: look for pattern like "0 0 20px" (third number > 4)
-      const pxVals = [...val.matchAll(/(\d+)px|(?<![.\d])\b(0)\b(?![.\d])/g)].map(p => +(p[1] || p[2]));
-      if (pxVals.length >= 3 && pxVals[2] > 4) {
+      const glow = findDarkGlowShadow(m[1]);
+      if (glow) {
         const lines = content.substring(0, m.index).split('\n');
-        return [finding('dark-glow', filePath, `Colored glow (rgb(${r},${g},${b})) on dark page`, lines.length)];
+        return [finding('dark-glow', filePath, `Colored glow (rgb(${glow.r},${glow.g},${glow.b})) on dark page`, lines.length)];
       }
     }
     return [];

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -496,6 +496,27 @@ describe('detectText — dark glow', () => {
     const f = detectText(html, 'test.html');
     expect(f.filter(r => r.antipattern === 'dark-glow')).toHaveLength(0);
   });
+
+  // Multi-shadow values must be split by comma and evaluated per-shadow so
+  // each color is checked against its own blur — matches checkGlow() in the
+  // browser path. See issue ELS-73.
+  test('does not flag colored shadow with zero blur when a later gray shadow has blur', () => {
+    // Red shadow has zero blur (not a glow); gray shadow has blur (not colored).
+    // Pre-fix, this was a false positive because the gray shadow's 30px leaked
+    // into the px-vals list and was read as the red shadow's blur.
+    const html = '<!DOCTYPE html><html><body style="background: #111827;"><style>.x { box-shadow: rgba(255, 0, 0, 0.5) 0 0, rgba(0, 0, 0, 0.5) 30px 30px 30px; }</style></body></html>';
+    const f = detectText(html, 'test.html');
+    expect(f.filter(r => r.antipattern === 'dark-glow')).toHaveLength(0);
+  });
+
+  test('detects colored glow even when first shadow in list is gray', () => {
+    // Pre-fix, this was a false negative because only the first rgba() in the
+    // value was inspected — the gray match caused the loop to continue without
+    // ever reaching the red glow.
+    const html = '<!DOCTYPE html><html><body style="background: #111827;"><style>.x { box-shadow: rgba(0, 0, 0, 0.5) 0 0 1px, rgba(255, 0, 0, 0.5) 0 0 30px; }</style></body></html>';
+    const f = detectText(html, 'test.html');
+    expect(f.some(r => r.antipattern === 'dark-glow')).toBe(true);
+  });
 });
 
 


### PR DESCRIPTION
## Summary

The HTML/CSS-text `dark-glow` detector in `src/detect-antipatterns.mjs` evaluated only the **first** `rgba()` color and pulled px values from **all** comma-separated shadows into a single flat list. That produced both false positives and false negatives, and disagreed with the browser/DOM path (`detect-antipatterns-browser.js:checkGlow`), which already splits by comma.

- **False positive:** `box-shadow: rgba(255,0,0,0.5) 0 0, rgba(0,0,0,0.5) 30px 30px 30px` was flagged because blur from the later gray shadow leaked into `pxVals[2]`, even though the red shadow has zero blur.
- **False negative:** `box-shadow: rgba(0,0,0,0.5) 0 0 1px, rgba(255,0,0,0.5) 0 0 30px` was missed because the leading gray rgba failed the chroma check and the loop `continue`d before reaching the red glow.

This change extracts a shared `findDarkGlowShadow()` helper that splits on commas (ignoring commas inside parens) and evaluates each shadow against its own color/chroma and own blur, mirroring `checkGlow()`. It also strips the color expression before scanning lengths so channel digits can't be misread as shadow offsets. The helper is applied to both occurrences of the text-path logic in `src/detect-antipatterns.mjs`.

## Test plan

- [x] New regression test: `rgba(255,0,0,0.5) 0 0, rgba(0,0,0,0.5) 30px 30px 30px` → not flagged
- [x] New regression test: `rgba(0,0,0,0.5) 0 0 1px, rgba(255,0,0,0.5) 0 0 30px` → flagged
- [x] Existing `dark-glow` unit + fixture tests still pass
- [ ] Reviewer to confirm browser-path / text-path parity on real fixtures

Tracking issue: ELS-73 (Multica).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to anti-pattern heuristics with new unit tests; no auth, data, or production runtime paths beyond the detector.
> 
> **Overview**
> Fixes **dark-glow** detection on the HTML/CSS text path in `detect-antipatterns.mjs` by introducing **`findDarkGlowShadow()`**, which splits comma-separated **`box-shadow`** lists (ignoring commas inside parentheses), evaluates each shadow’s color and blur separately, and strips the color token before reading lengths so `rgba` channel values are not mistaken for blur.
> 
> The helper replaces duplicated inline logic in **`checkHtmlPatterns`** and the page-level regex analyzer so text/Node scanning matches the browser **`checkGlow`** behavior. **Two regression tests** cover a former false positive (colored zero-blur shadow + later gray blurred shadow) and a former false negative (gray shadow first, colored glow second).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec966ac31b0cc96ca7c11bca6651ce33334214a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->