### PR TITLE
Fix live copy edit paragraph resizing

### DIFF
--- a/.agents/skills/impeccable/scripts/live-browser.js
+++ b/.agents/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.claude/skills/impeccable/scripts/live-browser.js
+++ b/.claude/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.cursor/skills/impeccable/scripts/live-browser.js
+++ b/.cursor/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.gemini/skills/impeccable/scripts/live-browser.js
+++ b/.gemini/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.github/skills/impeccable/scripts/live-browser.js
+++ b/.github/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.kiro/skills/impeccable/scripts/live-browser.js
+++ b/.kiro/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.opencode/skills/impeccable/scripts/live-browser.js
+++ b/.opencode/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.pi/skills/impeccable/scripts/live-browser.js
+++ b/.pi/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.qoder/skills/impeccable/scripts/live-browser.js
+++ b/.qoder/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.rovodev/skills/impeccable/scripts/live-browser.js
+++ b/.rovodev/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.trae-cn/skills/impeccable/scripts/live-browser.js
+++ b/.trae-cn/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/.trae/skills/impeccable/scripts/live-browser.js
+++ b/.trae/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/plugin/skills/impeccable/scripts/live-browser.js
+++ b/plugin/skills/impeccable/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -2788,13 +2788,14 @@
     inlineEditRows = rows;
     inlineEditDrafts = new Map();
     for (const row of rows) {
+      row.inlineWhiteSpace = row.el.style.whiteSpace;
+      row.el.style.whiteSpace = getComputedStyle(row.el).whiteSpace;
       row.el.setAttribute('contenteditable', 'true');
       row.el.dataset.impeccableEditable = 'true';
       row.el.dataset.impeccableOriginalText = row.text;
       row.el.style.userSelect = 'text';
       row.el.style.cursor = 'text';
       row.el.style.outline = 'none';
-      row.el.style.webkitUserModify = 'read-write-plaintext-only';
       row.el.addEventListener('input', onInlineInput);
     }
   }
@@ -2805,10 +2806,10 @@
       row.el.removeAttribute('contenteditable');
       delete row.el.dataset.impeccableEditable;
       delete row.el.dataset.impeccableOriginalText;
+      row.el.style.whiteSpace = row.inlineWhiteSpace || '';
       row.el.style.userSelect = '';
       row.el.style.cursor = '';
       row.el.style.outline = '';
-      row.el.style.webkitUserModify = '';
       row.el.removeEventListener('input', onInlineInput);
     }
     inlineEditRows = [];


### PR DESCRIPTION
## Summary
- Preserve the selected text leaf's pre-edit white-space behavior while live Edit copy is active.
- Stop applying WebKit plaintext edit mode, which forces Chromium to render source newlines as visible line breaks and makes multi-line Astro copy grow.
- Regenerated provider skill copies from the source runtime script.

## Validation
- Temporary Playwright repro against the homepage: failed before the fix with p.hero-rebuild-body height 107.5px -> 188.125px, passed after the fix. The repro test was removed before commit per request.
- bun run build
- node --test tests/live-browser-regression.test.mjs tests/live-browser-source.test.mjs
- node --test tests/live-commit-manual-edits.test.mjs
- bun run test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized live-browser inline edit styling with restore on teardown; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **live inline copy editing** so multi-line paragraphs no longer **grow in height** while Edit copy is active.
> 
> During `enableInlineEdit`, each editable row now **snapshots** its inline `white-space`, then sets `style.whiteSpace` from **`getComputedStyle`** so wrapping matches the element’s normal layout. **`webkitUserModify: read-write-plaintext-only`** is **removed**; that WebKit mode was forcing Chromium to treat source newlines as visible breaks and inflate block height (e.g. hero body copy).
> 
> `disableInlineEdit` **restores** the saved `white-space` instead of clearing WebKit plaintext mode. The same logic is applied across **`live-browser.js`** in the canonical skill path and **regenerated provider skill copies**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee536be12a0a6edb8fc8fa8498d23588186d8107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->