### PR TITLE
[codex] Harden live mode helper security

### DIFF
--- a/.agents/skills/impeccable/scripts/live-browser.js
+++ b/.agents/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.agents/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.agents/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.agents/skills/impeccable/scripts/live-inject.mjs
+++ b/.agents/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.agents/skills/impeccable/scripts/live-insert.mjs
+++ b/.agents/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.agents/skills/impeccable/scripts/live-server.mjs
+++ b/.agents/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.agents/skills/impeccable/scripts/live-wrap.mjs
+++ b/.agents/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.agents/skills/impeccable/scripts/live.mjs
+++ b/.agents/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.claude/skills/impeccable/scripts/live-browser.js
+++ b/.claude/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.claude/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.claude/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.claude/skills/impeccable/scripts/live-inject.mjs
+++ b/.claude/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.claude/skills/impeccable/scripts/live-insert.mjs
+++ b/.claude/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.claude/skills/impeccable/scripts/live-server.mjs
+++ b/.claude/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.claude/skills/impeccable/scripts/live-wrap.mjs
+++ b/.claude/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.claude/skills/impeccable/scripts/live.mjs
+++ b/.claude/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.cursor/skills/impeccable/scripts/live-browser.js
+++ b/.cursor/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.cursor/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.cursor/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.cursor/skills/impeccable/scripts/live-inject.mjs
+++ b/.cursor/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.cursor/skills/impeccable/scripts/live-insert.mjs
+++ b/.cursor/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.cursor/skills/impeccable/scripts/live-server.mjs
+++ b/.cursor/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.cursor/skills/impeccable/scripts/live-wrap.mjs
+++ b/.cursor/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.cursor/skills/impeccable/scripts/live.mjs
+++ b/.cursor/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.gemini/skills/impeccable/scripts/live-browser.js
+++ b/.gemini/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.gemini/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.gemini/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.gemini/skills/impeccable/scripts/live-inject.mjs
+++ b/.gemini/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.gemini/skills/impeccable/scripts/live-insert.mjs
+++ b/.gemini/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.gemini/skills/impeccable/scripts/live-server.mjs
+++ b/.gemini/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.gemini/skills/impeccable/scripts/live-wrap.mjs
+++ b/.gemini/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.gemini/skills/impeccable/scripts/live.mjs
+++ b/.gemini/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.github/skills/impeccable/scripts/live-browser.js
+++ b/.github/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.github/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.github/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.github/skills/impeccable/scripts/live-inject.mjs
+++ b/.github/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.github/skills/impeccable/scripts/live-insert.mjs
+++ b/.github/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.github/skills/impeccable/scripts/live-server.mjs
+++ b/.github/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.github/skills/impeccable/scripts/live-wrap.mjs
+++ b/.github/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.github/skills/impeccable/scripts/live.mjs
+++ b/.github/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.kiro/skills/impeccable/scripts/live-browser.js
+++ b/.kiro/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.kiro/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.kiro/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.kiro/skills/impeccable/scripts/live-inject.mjs
+++ b/.kiro/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.kiro/skills/impeccable/scripts/live-insert.mjs
+++ b/.kiro/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.kiro/skills/impeccable/scripts/live-server.mjs
+++ b/.kiro/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.kiro/skills/impeccable/scripts/live-wrap.mjs
+++ b/.kiro/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.kiro/skills/impeccable/scripts/live.mjs
+++ b/.kiro/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.opencode/skills/impeccable/scripts/live-browser.js
+++ b/.opencode/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.opencode/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.opencode/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.opencode/skills/impeccable/scripts/live-inject.mjs
+++ b/.opencode/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.opencode/skills/impeccable/scripts/live-insert.mjs
+++ b/.opencode/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.opencode/skills/impeccable/scripts/live-server.mjs
+++ b/.opencode/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.opencode/skills/impeccable/scripts/live-wrap.mjs
+++ b/.opencode/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.opencode/skills/impeccable/scripts/live.mjs
+++ b/.opencode/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.pi/skills/impeccable/scripts/live-browser.js
+++ b/.pi/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.pi/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.pi/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.pi/skills/impeccable/scripts/live-inject.mjs
+++ b/.pi/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.pi/skills/impeccable/scripts/live-insert.mjs
+++ b/.pi/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.pi/skills/impeccable/scripts/live-server.mjs
+++ b/.pi/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.pi/skills/impeccable/scripts/live-wrap.mjs
+++ b/.pi/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.pi/skills/impeccable/scripts/live.mjs
+++ b/.pi/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.qoder/skills/impeccable/scripts/live-browser.js
+++ b/.qoder/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.qoder/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.qoder/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.qoder/skills/impeccable/scripts/live-inject.mjs
+++ b/.qoder/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.qoder/skills/impeccable/scripts/live-insert.mjs
+++ b/.qoder/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.qoder/skills/impeccable/scripts/live-server.mjs
+++ b/.qoder/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.qoder/skills/impeccable/scripts/live-wrap.mjs
+++ b/.qoder/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.qoder/skills/impeccable/scripts/live.mjs
+++ b/.qoder/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.rovodev/skills/impeccable/scripts/live-browser.js
+++ b/.rovodev/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.rovodev/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.rovodev/skills/impeccable/scripts/live-inject.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.rovodev/skills/impeccable/scripts/live-insert.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.rovodev/skills/impeccable/scripts/live-server.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.rovodev/skills/impeccable/scripts/live-wrap.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.rovodev/skills/impeccable/scripts/live.mjs
+++ b/.rovodev/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.trae-cn/skills/impeccable/scripts/live-browser.js
+++ b/.trae-cn/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.trae-cn/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.trae-cn/skills/impeccable/scripts/live-inject.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.trae-cn/skills/impeccable/scripts/live-insert.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.trae-cn/skills/impeccable/scripts/live-server.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.trae-cn/skills/impeccable/scripts/live-wrap.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.trae-cn/skills/impeccable/scripts/live.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/.trae/skills/impeccable/scripts/live-browser.js
+++ b/.trae/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/.trae/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/.trae/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/.trae/skills/impeccable/scripts/live-inject.mjs
+++ b/.trae/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/.trae/skills/impeccable/scripts/live-insert.mjs
+++ b/.trae/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/.trae/skills/impeccable/scripts/live-server.mjs
+++ b/.trae/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/.trae/skills/impeccable/scripts/live-wrap.mjs
+++ b/.trae/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/.trae/skills/impeccable/scripts/live.mjs
+++ b/.trae/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/plugin/skills/impeccable/scripts/live-browser.js
+++ b/plugin/skills/impeccable/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/plugin/skills/impeccable/scripts/live-copy-edit-agent.mjs
+++ b/plugin/skills/impeccable/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/plugin/skills/impeccable/scripts/live-inject.mjs
+++ b/plugin/skills/impeccable/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/plugin/skills/impeccable/scripts/live-insert.mjs
+++ b/plugin/skills/impeccable/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/plugin/skills/impeccable/scripts/live-server.mjs
+++ b/plugin/skills/impeccable/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/plugin/skills/impeccable/scripts/live-wrap.mjs
+++ b/plugin/skills/impeccable/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/plugin/skills/impeccable/scripts/live.mjs
+++ b/plugin/skills/impeccable/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -1,7 +1,7 @@
 /**
  * Impeccable Live Variant Mode — Browser Script
  *
- * Injected into the user's page via <script src="http://localhost:PORT/live.js">.
+ * Injected into the user's page via <script src="http://localhost:PORT/live.js?token=TOKEN">.
  * The server prepends window.__IMPECCABLE_TOKEN__ and window.__IMPECCABLE_PORT__
  * before this code.
  *

--- a/skill/scripts/live-copy-edit-agent.mjs
+++ b/skill/scripts/live-copy-edit-agent.mjs
@@ -449,11 +449,13 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
   const args = [
     'exec',
     '--cd', cwd,
-    '--dangerously-bypass-approvals-and-sandbox',
     '--ephemeral',
     '--output-last-message', resultPath,
     '-c', `model_reasoning_effort="${env.IMPECCABLE_LIVE_COPY_AGENT_EFFORT || 'low'}"`,
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(3, 0, '--dangerously-bypass-approvals-and-sandbox');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
@@ -464,17 +466,15 @@ function runCodex(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_T
 function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const args = [
     '--print',
-    '--permission-mode', 'bypassPermissions',
     '--output-format', 'json',
   ];
+  if (allowsBypassPermissions(env)) {
+    args.splice(1, 0, '--permission-mode', 'bypassPermissions');
+  }
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
   args.push(prompt);
-  // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
-  // through. On macOS, `claude /login` stores creds in the Keychain, which a
-  // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
-  // `claude setup-token`) is the supported headless auth path.
   return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
@@ -483,7 +483,7 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     const log = fs.createWriteStream(logPath, { flags: 'a' });
     const child = spawn(command, args, {
       cwd,
-      env,
+      env: buildAgentProcessEnv(env),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let output = '';
@@ -531,6 +531,47 @@ function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, m
     if (stdin) child.stdin.end(stdin);
     else child.stdin.end();
   });
+}
+
+export function allowsBypassPermissions(env = process.env) {
+  return /^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_BYPASS || '');
+}
+
+export function buildAgentProcessEnv(env = process.env) {
+  if (/^(1|true|yes)$/i.test(env.IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV || '')) return env;
+
+  const allowedExact = new Set([
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'CODEX_HOME',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOGNAME',
+    'OPENAI_API_KEY',
+    'PATH',
+    'SHELL',
+    'SSH_AUTH_SOCK',
+    'TERM',
+    'TMPDIR',
+    'USER',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_STATE_HOME',
+  ]);
+  const allowedPrefixes = [
+    'CODEX_',
+    'CLAUDE_CODE_',
+    'IMPECCABLE_LIVE_COPY_AGENT_',
+    'npm_config_',
+  ];
+  const out = {};
+  for (const [key, value] of Object.entries(env || {})) {
+    if (allowedExact.has(key) || allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 function isPathInsideOrEqual(cwd, file) {

--- a/skill/scripts/live-inject.mjs
+++ b/skill/scripts/live-inject.mjs
@@ -8,7 +8,7 @@
  * with zero LLM involvement.
  *
  * Usage:
- *   node live-inject.mjs --port PORT   # Insert the live script tag
+ *   node live-inject.mjs --port PORT --token TOKEN   # Insert the live script tag
  *   node live-inject.mjs --remove      # Remove the live script tag
  *   node live-inject.mjs --check       # Check whether live config exists
  */
@@ -43,7 +43,8 @@ Insert or remove the live mode script tag in the project's HTML entry point.
 Reads configuration from .impeccable/live/config.json.
 
 Modes:
-  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js
+  --port PORT   Insert script tag pointing at http://localhost:PORT/live.js?token=TOKEN
+  --token TOKEN Session token from live-server.mjs
   --remove      Remove the script tag (if present)
   --check       Print whether .impeccable/live/config.json exists and its content
 
@@ -86,7 +87,8 @@ Output (JSON):
 
   if (args.includes('--remove')) {
     const results = resolvedFiles.map((relFile) => {
-      const absFile = path.resolve(process.cwd(), relFile);
+      const absFile = resolveProjectFile(process.cwd(), relFile);
+      if (!absFile) return { file: relFile, error: 'file_outside_project' };
       if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
       const content = fs.readFileSync(absFile, 'utf-8');
       const detagged = removeTag(content, config.commentSyntax);
@@ -106,17 +108,23 @@ Output (JSON):
   // Insert mode — need --port
   const portIdx = args.indexOf('--port');
   const port = portIdx !== -1 ? parseInt(args[portIdx + 1], 10) : NaN;
+  const token = argValue(args, '--token');
   if (!Number.isFinite(port)) {
     console.error(JSON.stringify({ ok: false, error: 'missing_port' }));
     process.exit(1);
   }
+  if (!isValidToken(token)) {
+    console.error(JSON.stringify({ ok: false, error: 'missing_or_invalid_token' }));
+    process.exit(1);
+  }
 
   const results = resolvedFiles.map((relFile) => {
-    const absFile = path.resolve(process.cwd(), relFile);
+    const absFile = resolveProjectFile(process.cwd(), relFile);
+    if (!absFile) return { file: relFile, error: 'file_outside_project' };
     if (!fs.existsSync(absFile)) return { file: relFile, error: 'file_not_found' };
     const content = fs.readFileSync(absFile, 'utf-8');
     const withoutOld = revertCspMeta(removeTag(content, config.commentSyntax));
-    const withTag = insertTag(withoutOld, config, port, relFile);
+    const withTag = insertTag(withoutOld, config, port, relFile, token);
     if (withTag === withoutOld) {
       return { file: relFile, error: 'insertion_point_not_found', anchor: config.insertBefore || config.insertAfter };
     }
@@ -131,6 +139,30 @@ Output (JSON):
   const anyInserted = results.some((r) => r.inserted);
   console.log(JSON.stringify({ ok: anyInserted, port, results }));
   if (!anyInserted) process.exit(1);
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx === -1 ? null : args[idx + 1];
+}
+
+function isValidToken(token) {
+  return typeof token === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(token);
+}
+
+function normalizeProjectRelativePath(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  const relative = normalizeProjectRelativePath(rootDir, filePath);
+  return relative ? path.resolve(rootDir, relative) : null;
 }
 
 /**
@@ -156,9 +188,10 @@ export function resolveFiles(rootDir, config) {
       // Literal path — include even if it doesn't exist yet; the caller
       // reports file_not_found per-entry. Exclude list doesn't apply to
       // explicit literal entries (user named it on purpose).
-      if (!seen.has(pat)) {
-        seen.add(pat);
-        out.push(pat);
+      const rel = normalizeProjectRelativePath(rootDir, pat) || pat;
+      if (!seen.has(rel)) {
+        seen.add(rel);
+        out.push(rel);
       }
       continue;
     }
@@ -171,7 +204,8 @@ export function resolveFiles(rootDir, config) {
     for (const ent of matches) {
       if (!ent.isFile || !ent.isFile()) continue;
       const abs = path.join(ent.parentPath || ent.path || rootDir, ent.name);
-      const rel = path.relative(rootDir, abs).split(path.sep).join('/');
+      const rel = normalizeProjectRelativePath(rootDir, abs)
+        || path.relative(rootDir, abs).split(path.sep).join('/');
       if (isExcluded(rel)) continue;
       if (seen.has(rel)) continue;
       seen.add(rel);
@@ -256,22 +290,23 @@ function validateConfig(cfg) {
 function commentOpen(syntax) { return syntax === 'jsx' ? '{/*' : '<!--'; }
 function commentClose(syntax) { return syntax === 'jsx' ? '*/}' : '-->'; }
 
-function buildTagBlock(syntax, port, filePath) {
+function buildTagBlock(syntax, port, filePath, token) {
   const open = commentOpen(syntax);
   const close = commentClose(syntax);
   // Astro processes <script> tags by default and rewrites src to its own
   // bundled URL. is:inline opts out so the literal external src survives.
   const isAstro = typeof filePath === 'string' && filePath.endsWith('.astro');
   const scriptAttrs = isAstro ? 'is:inline ' : '';
+  const src = 'http://localhost:' + port + '/live.js?token=' + encodeURIComponent(token);
   return (
     open + ' ' + MARKER_OPEN_TEXT + ' ' + close + '\n' +
-    '<script ' + scriptAttrs + 'src="http://localhost:' + port + '/live.js"></script>\n' +
+    '<script ' + scriptAttrs + 'src="' + src + '"></script>\n' +
     open + ' ' + MARKER_CLOSE_TEXT + ' ' + close + '\n'
   );
 }
 
-function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+function insertTag(content, config, port, filePath, token) {
+  const block = buildTagBlock(config.commentSyntax, port, filePath, token);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.

--- a/skill/scripts/live-insert.mjs
+++ b/skill/scripts/live-insert.mjs
@@ -157,13 +157,23 @@ Output (JSON):
       }));
       process.exit(1);
     }
-  } else if (isGeneratedFile(targetFile, genOpts)) {
-    console.error(JSON.stringify({
-      error: 'file_is_generated',
-      fallback: 'agent-driven',
-      file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
-    }));
-    process.exit(1);
+  } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
+    if (isGeneratedFile(targetFile, genOpts)) {
+      console.error(JSON.stringify({
+        error: 'file_is_generated',
+        fallback: 'agent-driven',
+        file: path.relative(process.cwd(), path.resolve(process.cwd(), targetFile)),
+      }));
+      process.exit(1);
+    }
   }
 
   const content = fs.readFileSync(targetFile, 'utf-8');
@@ -224,6 +234,15 @@ Output (JSON):
     cssSelectorPrefixExamples: buildCssSelectorPrefixExamples(styleMode.mode, count),
     cssAuthoring: buildCssAuthoring(styleMode, count),
   }));
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 const _running = process.argv[1];

--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -50,6 +50,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONTEXT_DIR = resolveContextDir(process.cwd());
 const DEFAULT_POLL_TIMEOUT = 600_000;   // 10 min — agent re-polls on timeout anyway
 const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Port detection
@@ -93,6 +94,7 @@ const state = {
   // a poll to be parked at the exact moment we dispatch.
   lastPollAt: 0,
   timedOutApplyIds: new Map(),
+  allowedOrigins: new Set(),
 };
 
 const CHAT_POLL_FRESHNESS_MS = 60_000;
@@ -1188,21 +1190,93 @@ function statOrNull(filePath) {
   try { return fs.statSync(filePath); } catch { return null; }
 }
 
+function parseOrigin(value) {
+  if (!value || typeof value !== 'string') return null;
+  try { return new URL(value).origin; } catch { return null; }
+}
+
+function rememberScriptOrigin(req) {
+  const origin = parseOrigin(req.headers.origin) || parseOrigin(req.headers.referer);
+  if (origin) state.allowedOrigins.add(origin);
+}
+
+function setCorsHeaders(req, res) {
+  const origin = parseOrigin(req.headers.origin);
+  if (!origin || !state.allowedOrigins.has(origin)) return false;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return true;
+}
+
+function writeJson(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readLimitedTextBody(req, res, onBody, { maxBytes = MAX_JSON_BODY_BYTES } = {}) {
+  let body = '';
+  let total = 0;
+  let aborted = false;
+  req.on('data', (chunk) => {
+    if (aborted) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, { error: 'Payload too large' });
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => {
+    if (!aborted) onBody(body);
+  });
+  req.on('error', () => {
+    if (!aborted) writeJson(res, 500, { error: 'Request body read failed' });
+  });
+}
+
+function readLimitedJsonBody(req, res, onJson) {
+  readLimitedTextBody(req, res, (body) => {
+    try {
+      onJson(body ? JSON.parse(body) : {});
+    } catch {
+      writeJson(res, 400, { error: 'Invalid JSON' });
+    }
+  });
+}
+
+function resolveProjectPath(cwd, requested) {
+  if (!requested || typeof requested !== 'string') return null;
+  const root = path.resolve(cwd);
+  const absolute = path.isAbsolute(requested) ? path.resolve(requested) : path.resolve(root, requested);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { absolute, relative };
+}
+
 // HTTP request handler
 // ---------------------------------------------------------------------------
 
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    const corsOk = setCorsHeaders(req, res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(corsOk ? 204 : 403);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 
     // --- Scripts ---
     if (p === '/live.js') {
+      const token = url.searchParams.get('token');
+      if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
+      rememberScriptOrigin(req);
       // Re-read from disk each request so edits to live-browser.js land on
       // the next tab reload. No-store headers prevent browser caching across
       // sessions — during iteration, a cached old script silently breaks
@@ -1408,11 +1482,10 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
       const token = url.searchParams.get('token');
       if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
       const filePath = url.searchParams.get('path');
-      if (!filePath || filePath.includes('..')) { res.writeHead(400); res.end('Bad path'); return; }
-      const absPath = path.resolve(process.cwd(), filePath);
-      if (!absPath.startsWith(process.cwd())) { res.writeHead(403); res.end('Forbidden'); return; }
+      const resolved = resolveProjectPath(process.cwd(), filePath);
+      if (!resolved) { res.writeHead(403); res.end('Forbidden'); return; }
       let content;
-      try { content = fs.readFileSync(absPath, 'utf-8'); }
+      try { content = fs.readFileSync(resolved.absolute, 'utf-8'); }
       catch { res.writeHead(404); res.end('File not found'); return; }
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(content);
@@ -1458,15 +1531,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
     // --- Manual copy edits: Save stages entries, Apply commits the staged
     // page batch through the local AI copy-edit runner.
     if (p === '/manual-edit-stash' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1691,15 +1756,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // POST /manual-edit-repair-decision  →  user resolves an exhausted repair loop.
     if (p === '/manual-edit-repair-decision' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let payload = {};
-        try { payload = body ? JSON.parse(body) : {}; } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (payload) => {
         const token = payload.token || url.searchParams.get('token');
         if (token !== state.token) { res.writeHead(401); res.end('Unauthorized'); return; }
         const pageUrl = payload.pageUrl || url.searchParams.get('pageUrl') || null;
@@ -1786,15 +1843,7 @@ function createRequestHandler({ detectScript, sessionPath, livePath }) {
 
     // --- Browser→server events (replaces WebSocket messages) ---
     if (p === '/events' && req.method === 'POST') {
-      let body = '';
-      req.on('data', (c) => { body += c; });
-      req.on('end', () => {
-        let msg;
-        try { msg = JSON.parse(body); } catch {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid JSON' }));
-          return;
-        }
+      readLimitedJsonBody(req, res, (msg) => {
         if (msg.token !== state.token) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -1906,15 +1955,7 @@ function handlePollGet(req, res, url) {
 }
 
 function handlePollPost(req, res) {
-  let body = '';
-  req.on('data', (c) => { body += c; });
-  req.on('end', () => {
-    let msg;
-    try { msg = JSON.parse(body); } catch {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Invalid JSON' }));
-      return;
-    }
+  readLimitedJsonBody(req, res, (msg) => {
     if (msg.token !== state.token) {
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized' }));
@@ -2181,7 +2222,7 @@ httpServer.listen(state.port, '127.0.0.1', () => {
   const url = `http://localhost:${state.port}`;
   console.log(`\nImpeccable live server running on ${url}`);
   console.log(`Token: ${state.token}\n`);
-  console.log(`Script: ${url}/live.js`);
+  console.log(`Script: ${url}/live.js?token=${state.token}`);
   console.log('Inject: managed by live-inject.mjs; Astro source tags use is:inline automatically.');
   console.log(`Stop:   node ${path.basename(fileURLToPath(import.meta.url))} stop`);
 });

--- a/skill/scripts/live-wrap.mjs
+++ b/skill/scripts/live-wrap.mjs
@@ -110,6 +110,14 @@ The agent should insert variant HTML at insertLine.`);
       process.exit(1);
     }
   } else {
+    targetFile = resolveProjectFile(process.cwd(), targetFile);
+    if (!targetFile) {
+      console.error(JSON.stringify({
+        error: 'file_outside_project',
+        fallback: 'agent-driven',
+      }));
+      process.exit(1);
+    }
     if (isGeneratedFile(targetFile, genOpts)) {
       console.error(JSON.stringify({
         error: 'file_is_generated',
@@ -819,6 +827,15 @@ function findClosingLine(lines, start) {
 
   // If we can't find the close, return a reasonable guess
   return Math.min(start + 50, lines.length - 1);
+}
+
+function resolveProjectFile(rootDir, filePath) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const root = path.resolve(rootDir);
+  const absolute = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(root, filePath);
+  const relative = path.relative(root, absolute);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return absolute;
 }
 
 // Auto-execute when run directly (node live-wrap.mjs ...)

--- a/skill/scripts/live.mjs
+++ b/skill/scripts/live.mjs
@@ -67,8 +67,8 @@ The agent should then:
     process.exit(1);
   }
 
-  // 3. Inject the script tag at the current port
-  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port)]);
+  // 3. Inject the script tag at the current port with the one-session token.
+  const injectOut = runScript('live-inject.mjs', ['--port', String(serverInfo.port), '--token', String(serverInfo.token || '')]);
   const injectResult = safeParse(injectOut);
   if (!injectResult || !injectResult.ok) {
     console.log(JSON.stringify({

--- a/tests/framework-fixtures.test.mjs
+++ b/tests/framework-fixtures.test.mjs
@@ -110,7 +110,7 @@ for (const name of listFixtures()) {
     it('live-inject --port adds the script tag to every config file', () => {
       const { tmp } = stageFixture(name);
       try {
-        const out = runScript('live-inject.mjs', ['--port', '9999'], { cwd: tmp });
+        const out = runScript('live-inject.mjs', ['--port', '9999', '--token', '11111111-1111-4111-8111-111111111111'], { cwd: tmp });
         const result = JSON.parse(typeof out === 'string' ? out : out.error);
         assert.equal(result.ok, true, 'inject succeeded');
         for (const r of result.results) {
@@ -127,7 +127,7 @@ for (const name of listFixtures()) {
     it('live-inject --remove strips the script tag cleanly', () => {
       const { tmp } = stageFixture(name);
       try {
-        runScript('live-inject.mjs', ['--port', '9999'], { cwd: tmp });
+        runScript('live-inject.mjs', ['--port', '9999', '--token', '11111111-1111-4111-8111-111111111111'], { cwd: tmp });
         const out = runScript('live-inject.mjs', ['--remove'], { cwd: tmp });
         const result = JSON.parse(typeof out === 'string' ? out : out.error);
         assert.equal(result.ok, true, 'remove succeeded');

--- a/tests/live-copy-edit-agent.test.mjs
+++ b/tests/live-copy-edit-agent.test.mjs
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  allowsBypassPermissions,
+  buildAgentProcessEnv,
   buildCopyEditBatchPrompt,
   chooseCopyEditAgent,
   describeNoProviderError,
@@ -99,12 +101,16 @@ describe('live-copy-edit-agent', () => {
     }
   });
 
-  it('flags invalid JSX syntax in post-apply checks', () => {
+  it('flags invalid JSX syntax when parser is available, otherwise warns', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'copy-agent-jsx-checks-'));
     try {
       fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
       fs.writeFileSync(path.join(tmp, 'src', 'App.jsx'), 'export default function App() { return <h1>Broken</h2>; }\n');
       const checks = runCopyEditPostApplyChecks({ cwd: tmp, files: ['src/App.jsx'] });
+      if (checks.warnings.some((item) => item.reason === 'syntax_parser_unavailable')) {
+        assert.equal(checks.ok, true);
+        return;
+      }
       assert.equal(checks.ok, false);
       assert.equal(checks.failures.some((item) => item.reason === 'invalid_source_syntax'), true);
     } finally {
@@ -151,6 +157,28 @@ describe('live-copy-edit-agent', () => {
     assert.equal(chooseCopyEditAgent({ env: { IMPECCABLE_LIVE_COPY_AGENT: 'off' } }), null);
     assert.equal(chooseCopyEditAgent({ env: { IMPECCABLE_LIVE_COPY_AGENT: 'false' } }), null);
     assert.equal(chooseCopyEditAgent({ env: { IMPECCABLE_LIVE_COPY_AGENT: 'mock' } }), 'mock');
+  });
+
+  it('requires explicit opt-in for bypass permissions and full environment forwarding', () => {
+    assert.equal(allowsBypassPermissions({}), false);
+    assert.equal(allowsBypassPermissions({ IMPECCABLE_LIVE_COPY_AGENT_BYPASS: '1' }), true);
+
+    const filtered = buildAgentProcessEnv({
+      PATH: '/bin',
+      HOME: '/tmp/home',
+      ANTHROPIC_API_KEY: 'allowed-auth',
+      DATABASE_URL: 'must-not-flow',
+      STRIPE_SECRET_KEY: 'must-not-flow',
+      IMPECCABLE_LIVE_COPY_AGENT_MODEL: 'allowed-setting',
+    });
+    assert.equal(filtered.PATH, '/bin');
+    assert.equal(filtered.ANTHROPIC_API_KEY, 'allowed-auth');
+    assert.equal(filtered.IMPECCABLE_LIVE_COPY_AGENT_MODEL, 'allowed-setting');
+    assert.equal(filtered.DATABASE_URL, undefined);
+    assert.equal(filtered.STRIPE_SECRET_KEY, undefined);
+
+    const full = { DATABASE_URL: 'allowed-by-explicit-opt-in', IMPECCABLE_LIVE_COPY_AGENT_PASS_ENV: '1' };
+    assert.equal(buildAgentProcessEnv(full), full);
   });
 
   it('surfaces Claude CLI auth errors from is_error JSON output', () => {

--- a/tests/live-e2e/session.mjs
+++ b/tests/live-e2e/session.mjs
@@ -85,9 +85,10 @@ export function stopLiveServer(tmp) {
 }
 
 export function runInject(tmp, port) {
+  const info = JSON.parse(readFileSync(join(tmp, '.impeccable', 'live', 'server.json'), 'utf-8'));
   const out = execFileSync(
     process.execPath,
-    [join(SCRIPTS_DIR, 'live-inject.mjs'), '--port', String(port)],
+    [join(SCRIPTS_DIR, 'live-inject.mjs'), '--port', String(port), '--token', String(info.token || '')],
     {
       cwd: tmp,
       encoding: 'utf-8',
@@ -196,7 +197,7 @@ export async function bootFixtureSession({ name, fixture, browser, agent, wrapTa
     log(`starting live-server`);
     live = startLiveServer(tmp);
 
-    log(`live-inject --port ${live.port}`);
+    log(`live-inject --port ${live.port} --token <server token>`);
     const injectResult = runInject(tmp, live.port);
     if (!injectResult.ok) throw new Error('live-inject failed: ' + JSON.stringify(injectResult));
 

--- a/tests/live-inject.test.mjs
+++ b/tests/live-inject.test.mjs
@@ -13,10 +13,17 @@ import { execFileSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INJECT = resolve(__dirname, '..', 'skill/scripts/live-inject.mjs');
+const TEST_TOKEN = '11111111-1111-4111-8111-111111111111';
+
+function withToken(args) {
+  return args.includes('--port') && !args.includes('--token')
+    ? [...args, '--token', TEST_TOKEN]
+    : args;
+}
 
 function runInject(cwd, configPath, args) {
   try {
-    const out = execFileSync('node', [INJECT, ...args], {
+    const out = execFileSync('node', [INJECT, ...withToken(args)], {
       cwd,
       encoding: 'utf-8',
       env: { ...process.env, IMPECCABLE_LIVE_CONFIG: configPath },
@@ -31,7 +38,7 @@ function runInject(cwd, configPath, args) {
 
 function runInjectDefault(cwd, args) {
   try {
-    const out = execFileSync('node', [INJECT, ...args], {
+    const out = execFileSync('node', [INJECT, ...withToken(args)], {
       cwd,
       encoding: 'utf-8',
       env: { ...process.env, IMPECCABLE_LIVE_CONFIG: '' },
@@ -206,6 +213,26 @@ describe('live-inject — insert/remove round-trip preserves file bytes', () => 
     assert.equal(after, original, 'insertAfter round-trip must restore original byte-for-byte');
   });
 
+  it('rejects config files outside the project root', () => {
+    const sibling = tmp + '-sibling';
+    mkdirSync(sibling, { recursive: true });
+    try {
+      writeFileSync(join(sibling, 'index.html'), '<html><body></body></html>\n');
+      const cfgPath = join(tmp, 'config.json');
+      writeFileSync(cfgPath, JSON.stringify({
+        files: [join(sibling, 'index.html')],
+        insertBefore: '</body>',
+        commentSyntax: 'html',
+      }));
+
+      const result = runInject(tmp, cfgPath, ['--port', '8400']);
+      assert.equal(result.ok, false);
+      assert.equal(result.results[0].error, 'file_outside_project');
+    } finally {
+      rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+
   it('round-trips through CSP-meta patch and revert (insert mutates the meta tag, remove restores it)', () => {
     // Mirrors a Vite app that ships a CSP meta tag in index.html. live-inject
     // appends `http://localhost:PORT` to script-src / connect-src on insert
@@ -263,7 +290,7 @@ const title = 'Test';
 
     runInject(tmp, cfgPath, ['--port', '8400']);
     const afterInject = readFileSync(file, 'utf-8');
-    assert.match(afterInject, /<script is:inline src="http:\/\/localhost:8400\/live\.js"><\/script>/, 'astro inject should carry is:inline');
+    assert.match(afterInject, /<script is:inline src="http:\/\/localhost:8400\/live\.js\?token=[^"]+"><\/script>/, 'astro inject should carry is:inline');
 
     // Non-astro file with same config should NOT get is:inline
     const htmlFile = join(tmp, 'plain.html');
@@ -314,8 +341,8 @@ const title = 'Test';
     const afterInject = readFileSync(file, 'utf-8');
 
     assert.equal((afterInject.match(/impeccable-live-start/g) || []).length, 1, 'reinjection should leave one live block');
-    assert.match(afterInject, /<script is:inline src="http:\/\/localhost:8400\/live\.js"><\/script>/, 'astro reinject should restore is:inline');
-    assert.doesNotMatch(afterInject, /<script src="http:\/\/localhost:8400\/live\.js"><\/script>/, 'bare astro live script must not survive');
+    assert.match(afterInject, /<script is:inline src="http:\/\/localhost:8400\/live\.js\?token=[^"]+"><\/script>/, 'astro reinject should restore is:inline');
+    assert.doesNotMatch(afterInject, /<script src="http:\/\/localhost:8400\/live\.js(?:\?token=[^"]+)?"><\/script>/, 'bare astro live script must not survive');
   });
 
   it('round-trips when the insert anchor has no leading indent (column-0 </body>)', () => {

--- a/tests/live-insert.test.mjs
+++ b/tests/live-insert.test.mjs
@@ -6,8 +6,9 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 
 import {
@@ -15,6 +16,9 @@ import {
   buildInsertWrapperLines,
   isInsertPosition,
 } from '../skill/scripts/live-insert.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIVE_INSERT_SCRIPT = resolve(__dirname, '..', 'skill/scripts/live-insert.mjs');
 
 describe('isInsertPosition', () => {
   it('accepts before and after only', () => {
@@ -92,8 +96,8 @@ describe('live-insert CLI integration', () => {
 </html>`);
 
     const out = execSync(
-      `node skill/scripts/live-insert.mjs --id ins12345 --count 3 --position after --classes "hero" --tag section --file "${join(tmp, 'index.html')}"`,
-      { encoding: 'utf-8' },
+      `node "${LIVE_INSERT_SCRIPT}" --id ins12345 --count 3 --position after --classes "hero" --tag section --file "index.html"`,
+      { cwd: tmp, encoding: 'utf-8' },
     );
     const result = JSON.parse(out.trim());
     assert.equal(result.mode, 'insert');
@@ -115,8 +119,8 @@ describe('live-insert CLI integration', () => {
 </main>`);
 
     execSync(
-      `node skill/scripts/live-insert.mjs --id ins99999 --count 2 --position before --classes "cta" --tag section --file "${join(tmp, 'page.html')}"`,
-      { encoding: 'utf-8' },
+      `node "${LIVE_INSERT_SCRIPT}" --id ins99999 --count 2 --position before --classes "cta" --tag section --file "page.html"`,
+      { cwd: tmp, encoding: 'utf-8' },
     );
 
     const after = readFileSync(join(tmp, 'page.html'), 'utf-8');
@@ -135,8 +139,8 @@ describe('live-insert CLI integration', () => {
 }`);
 
     const out = execSync(
-      `node skill/scripts/live-insert.mjs --id jsxins01 --count 3 --position after --classes "hero" --tag section --file "${join(tmp, 'App.jsx')}"`,
-      { encoding: 'utf-8' },
+      `node "${LIVE_INSERT_SCRIPT}" --id jsxins01 --count 3 --position after --classes "hero" --tag section --file "App.jsx"`,
+      { cwd: tmp, encoding: 'utf-8' },
     );
     const result = JSON.parse(out.trim());
     assert.equal(result.commentSyntax.open, '{/*');
@@ -149,8 +153,8 @@ describe('live-insert CLI integration', () => {
     writeFileSync(join(tmp, 'empty.html'), '<div class="x">x</div>');
     assert.throws(
       () => execSync(
-        `node skill/scripts/live-insert.mjs --id bad00001 --count 2 --classes x --file "${join(tmp, 'empty.html')}"`,
-        { encoding: 'utf-8', stdio: 'pipe' },
+        `node "${LIVE_INSERT_SCRIPT}" --id bad00001 --count 2 --classes x --file "empty.html"`,
+        { cwd: tmp, encoding: 'utf-8', stdio: 'pipe' },
       ),
       (err) => err.status !== 0,
     );
@@ -160,8 +164,8 @@ describe('live-insert CLI integration', () => {
     writeFileSync(join(tmp, 'empty.html'), '<div class="x">x</div>');
     assert.throws(
       () => execSync(
-        `node skill/scripts/live-insert.mjs --id bad00002 --count 2 --position inside --classes x --file "${join(tmp, 'empty.html')}"`,
-        { encoding: 'utf-8', stdio: 'pipe' },
+        `node "${LIVE_INSERT_SCRIPT}" --id bad00002 --count 2 --position inside --classes x --file "empty.html"`,
+        { cwd: tmp, encoding: 'utf-8', stdio: 'pipe' },
       ),
       (err) => err.status !== 0,
     );

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -205,8 +205,16 @@ describe('live-server integration', () => {
     assert.equal(data.agentPolling, false);
   });
 
-  it('/live.js serves script with token injected', async () => {
+  it('/live.js rejects requests without the session token', async () => {
     const res = await fetch(`http://localhost:${server.port}/live.js`);
+    assert.equal(res.status, 401);
+  });
+
+  it('/live.js serves script with token injected and pins the requesting origin', async () => {
+    const origin = 'http://localhost:5173';
+    const res = await fetch(`http://localhost:${server.port}/live.js?token=${server.token}`, {
+      headers: { Referer: origin + '/app' },
+    });
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('content-type'), 'application/javascript');
     const text = await res.text();
@@ -221,6 +229,17 @@ describe('live-server integration', () => {
       sessionHelperIndex < browserInitIndex,
       'event=live_server.browser_helper_order actor=browser operation=load_live_js risk=session_helper_missing_before_browser_init expected=session helper before live init actual=' + sessionHelperIndex + ':' + browserInitIndex,
     );
+
+    const options = await fetch(`http://localhost:${server.port}/events`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: origin,
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'content-type',
+      },
+    });
+    assert.equal(options.status, 204);
+    assert.equal(options.headers.get('access-control-allow-origin'), origin);
   });
 
   it('/design-system.json reads DESIGN.md plus .impeccable/design.json', async () => {
@@ -2413,12 +2432,34 @@ colors: {}
 
   it('/source rejects path traversal', async () => {
     const res = await fetch(`http://localhost:${server.port}/source?token=${server.token}&path=../../../etc/passwd`);
-    assert.equal(res.status, 400);
+    assert.equal(res.status, 403);
+  });
+
+  it('/source rejects absolute sibling paths that share the cwd prefix', async () => {
+    const sibling = serverCwd + '-sibling';
+    try {
+      mkdirSync(sibling, { recursive: true });
+      writeFileSync(join(sibling, 'package.json'), JSON.stringify({ name: 'outside' }));
+      const outsidePath = join(sibling, 'package.json');
+      const res = await fetch(`http://localhost:${server.port}/source?token=${server.token}&path=${encodeURIComponent(outsidePath)}`);
+      assert.equal(res.status, 403);
+    } finally {
+      rmSync(sibling, { recursive: true, force: true });
+    }
   });
 
   it('/source rejects invalid token', async () => {
     const res = await fetch(`http://localhost:${server.port}/source?token=wrong&path=package.json`);
     assert.equal(res.status, 401);
+  });
+
+  it('rejects oversized JSON bodies before parsing', async () => {
+    const res = await fetch(`http://localhost:${server.port}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"token":"' + server.token + '","type":"exit","padding":"' + 'x'.repeat(300 * 1024) + '"}',
+    });
+    assert.equal(res.status, 413);
   });
 
   it('/source returns 404 for missing files', async () => {

--- a/tests/live-wrap.test.mjs
+++ b/tests/live-wrap.test.mjs
@@ -6,8 +6,9 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 
 import {
@@ -16,6 +17,9 @@ import {
   findClosingLine,
   detectCommentSyntax,
 } from '../skill/scripts/live-wrap.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIVE_WRAP_SCRIPT = resolve(__dirname, '..', 'skill/scripts/live-wrap.mjs');
 
 // ---------------------------------------------------------------------------
 // Unit tests: pure functions
@@ -232,8 +236,8 @@ describe('wrapCli integration', () => {
     writeFileSync(join(tmp, 'index.html'), html);
 
     const result = JSON.parse(execSync(
-      `node skill/scripts/live-wrap.mjs --id test123 --count 3 --classes "hero-section" --file "${join(tmp, 'index.html')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id test123 --count 3 --classes "hero-section" --file "index.html"`,
+      { cwd: tmp, encoding: 'utf-8' }
     ));
 
     // The file path is relative to cwd, so it may be a relative path to the tmp dir
@@ -266,8 +270,8 @@ describe('wrapCli integration', () => {
     writeFileSync(join(tmp, 'App.jsx'), jsx);
 
     const result = JSON.parse(execSync(
-      `node skill/scripts/live-wrap.mjs --id jsx123 --count 2 --classes "hero" --file "${join(tmp, 'App.jsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id jsx123 --count 2 --classes "hero" --file "App.jsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     ));
 
     assert.equal(result.commentSyntax.open, '{/*');
@@ -288,8 +292,8 @@ describe('wrapCli integration', () => {
     writeFileSync(join(tmp, 'page.html'), html);
 
     const result = JSON.parse(execSync(
-      `node skill/scripts/live-wrap.mjs --id id123 --count 2 --element-id "pricing" --file "${join(tmp, 'page.html')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id id123 --count 2 --element-id "pricing" --file "page.html"`,
+      { cwd: tmp, encoding: 'utf-8' }
     ));
 
     const modified = readFileSync(join(tmp, 'page.html'), 'utf-8');
@@ -303,8 +307,8 @@ describe('wrapCli integration', () => {
 
     try {
       execSync(
-        `node skill/scripts/live-wrap.mjs --id err123 --count 2 --classes "nonexistent" --file "${join(tmp, 'empty.html')}"`,
-        { cwd: process.cwd(), encoding: 'utf-8', stdio: 'pipe' }
+        `node "${LIVE_WRAP_SCRIPT}" --id err123 --count 2 --classes "nonexistent" --file "empty.html"`,
+        { cwd: tmp, encoding: 'utf-8', stdio: 'pipe' }
       );
       assert.fail('Should have exited with error');
     } catch (err) {
@@ -322,8 +326,8 @@ describe('wrapCli integration', () => {
     writeFileSync(join(tmp, 'preserve.html'), html);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id pres123 --count 2 --classes "target" --file "${join(tmp, 'preserve.html')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id pres123 --count 2 --classes "target" --file "preserve.html"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'preserve.html'), 'utf-8');
@@ -339,8 +343,8 @@ describe('wrapCli integration', () => {
     writeFileSync(join(tmp, 'plain.html'), html);
 
     const result = JSON.parse(execSync(
-      `node skill/scripts/live-wrap.mjs --id scopedCss --count 2 --classes "hero-shell" --tag "section" --file "${join(tmp, 'plain.html')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id scopedCss --count 2 --classes "hero-shell" --tag "section" --file "plain.html"`,
+      { cwd: tmp, encoding: 'utf-8' }
     ));
 
     assert.equal(result.styleMode, 'scoped');
@@ -364,8 +368,8 @@ const title = 'Astro title';
     writeFileSync(join(tmp, 'Hero.astro'), astro);
 
     const result = JSON.parse(execSync(
-      `node skill/scripts/live-wrap.mjs --id astroCss --count 3 --classes "hero-shell" --tag "section" --file "${join(tmp, 'Hero.astro')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id astroCss --count 3 --classes "hero-shell" --tag "section" --file "Hero.astro"`,
+      { cwd: tmp, encoding: 'utf-8' }
     ));
 
     assert.equal(
@@ -446,8 +450,8 @@ describe('live-wrap — JSX / TSX correctness', () => {
     writeFileSync(join(tmp, 'page.tsx'), tsx);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id wrapA --count 3 --classes "organic-sand-surface,py-20,lg:py-24" --tag "section" --file "${join(tmp, 'page.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id wrapA --count 3 --classes "organic-sand-surface,py-20,lg:py-24" --tag "section" --file "page.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'page.tsx'), 'utf-8');
@@ -482,8 +486,8 @@ describe('live-wrap — JSX / TSX correctness', () => {
     writeFileSync(join(tmp, 'App.tsx'), tsx);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id jsxStyle --count 3 --classes "target" --tag "section" --file "${join(tmp, 'App.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id jsxStyle --count 3 --classes "target" --tag "section" --file "App.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'App.tsx'), 'utf-8');
@@ -515,8 +519,8 @@ describe('live-wrap — JSX / TSX correctness', () => {
     writeFileSync(join(tmp, 'Page.tsx'), tsx);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id classNameA --count 3 --classes "shared-class,target-marker" --tag "div" --file "${join(tmp, 'Page.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id classNameA --count 3 --classes "shared-class,target-marker" --tag "div" --file "Page.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'Page.tsx'), 'utf-8');
@@ -541,8 +545,8 @@ export default function App() {
     writeFileSync(join(tmp, 'App.jsx'), jsx);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id cssModuleA --count 3 --classes "hero-title _heroTitle_1lpqp_2" --tag "h1" --text "CSS Modules Fixture" --file "${join(tmp, 'App.jsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id cssModuleA --count 3 --classes "hero-title _heroTitle_1lpqp_2" --tag "h1" --text "CSS Modules Fixture" --file "App.jsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'App.jsx'), 'utf-8');
@@ -571,8 +575,8 @@ export default function App() {
     writeFileSync(join(tmp, 'App.tsx'), tsx);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id frag1 --count 3 --classes "frag-target" --tag "section" --file "${join(tmp, 'App.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id frag1 --count 3 --classes "frag-target" --tag "section" --file "App.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'App.tsx'), 'utf-8');
@@ -595,8 +599,8 @@ export default function App() {
     writeFileSync(join(tmp, 'page.html'), html);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id htmlFrag --count 3 --classes "html-frag" --tag "section" --file "${join(tmp, 'page.html')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id htmlFrag --count 3 --classes "html-frag" --tag "section" --file "page.html"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'page.html'), 'utf-8');
@@ -631,8 +635,8 @@ export default function App() {
     writeFileSync(join(tmp, 'Page.tsx'), tsx);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id repeat1 --count 3 --classes "card" --tag "aside" --text "Beta card Second in the list." --file "${join(tmp, 'Page.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id repeat1 --count 3 --classes "card" --tag "aside" --text "Beta card Second in the list." --file "Page.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'Page.tsx'), 'utf-8');
@@ -674,8 +678,8 @@ export default function App() {
     // Note: --text is the textContent the BROWSER produced — no space between
     // "Two" and "Second" because textContent has no inter-element whitespace.
     execSync(
-      `node skill/scripts/live-wrap.mjs --id concat1 --count 3 --classes "card" --tag "aside" --text "Hero TwoSecond card body copy." --file "${join(tmp, 'Page.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id concat1 --count 3 --classes "card" --tag "aside" --text "Hero TwoSecond card body copy." --file "Page.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'Page.tsx'), 'utf-8');
@@ -709,8 +713,8 @@ export default function App() {
     // makes wrap silently land on the first match (existing behavior
     // documented in filterByText's JSDoc).
     execSync(
-      `node skill/scripts/live-wrap.mjs --id short1 --count 3 --classes "card" --tag "aside" --text "Hi" --file "${join(tmp, 'Short.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id short1 --count 3 --classes "card" --tag "aside" --text "Hi" --file "Short.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'Short.tsx'), 'utf-8');
@@ -736,8 +740,8 @@ export default function App() {
     writeFileSync(join(tmp, 'multi.html'), html);
 
     const result = JSON.parse(execSync(
-      `node skill/scripts/live-wrap.mjs --id ml1 --count 3 --classes "multiline-target" --tag "section" --file "${join(tmp, 'multi.html')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id ml1 --count 3 --classes "multiline-target" --tag "section" --file "multi.html"`,
+      { cwd: tmp, encoding: 'utf-8' }
     ));
 
     const modified = readFileSync(join(tmp, 'multi.html'), 'utf-8');
@@ -772,8 +776,8 @@ export default function App() {
 
     // Run with --text that won't show up in source verbatim.
     execSync(
-      `node skill/scripts/live-wrap.mjs --id dyn1 --count 3 --classes "card" --tag "aside" --text "Beta card body text" --file "${join(tmp, 'Cards.tsx')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id dyn1 --count 3 --classes "card" --tag "aside" --text "Beta card body text" --file "Cards.tsx"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'Cards.tsx'), 'utf-8');
@@ -802,8 +806,8 @@ export default function App() {
     let errPayload;
     try {
       execSync(
-        `node skill/scripts/live-wrap.mjs --id dup1 --count 3 --classes "card" --tag "aside" --text "Same headline Identical body copy." --file "${join(tmp, 'Dup.tsx')}"`,
-        { cwd: process.cwd(), encoding: 'utf-8', stdio: 'pipe' }
+        `node "${LIVE_WRAP_SCRIPT}" --id dup1 --count 3 --classes "card" --tag "aside" --text "Same headline Identical body copy." --file "Dup.tsx"`,
+        { cwd: tmp, encoding: 'utf-8', stdio: 'pipe' }
       );
       assert.fail('Should have exited with error');
     } catch (err) {
@@ -827,8 +831,8 @@ export default function App() {
     writeFileSync(join(tmp, 'index.html'), html);
 
     execSync(
-      `node skill/scripts/live-wrap.mjs --id tagFilter --count 3 --classes "ambiguous-name" --tag "section" --file "${join(tmp, 'index.html')}"`,
-      { cwd: process.cwd(), encoding: 'utf-8' }
+      `node "${LIVE_WRAP_SCRIPT}" --id tagFilter --count 3 --classes "ambiguous-name" --tag "section" --file "index.html"`,
+      { cwd: tmp, encoding: 'utf-8' }
     );
 
     const modified = readFileSync(join(tmp, 'index.html'), 'utf-8');


### PR DESCRIPTION
## Summary
- require the live-mode session token before serving /live.js
- restrict CORS to the origin that loaded the tokened live script
- keep source reads and explicit helper file paths inside the project root
- cap JSON request bodies and harden copy-edit agent subprocess defaults
- regenerate provider skill copies from the build pipeline

## Why
A security review found that live mode treated localhost as the trust boundary. Any unrelated local page or process could load /live.js, wildcard CORS allowed broad cross-origin access, /source used a fragile prefix check, JSON bodies were unbounded, and copy-edit subprocesses defaulted to permission-bypass flags with the full environment. This PR tightens those local live-mode boundaries while preserving the existing workflow.

## Validation
- bun install --frozen-lockfile
- npm run build
- node --check skill/scripts/live-server.mjs skill/scripts/live-inject.mjs skill/scripts/live-copy-edit-agent.mjs skill/scripts/live-wrap.mjs skill/scripts/live-insert.mjs skill/scripts/live-browser.js
- node --test tests/live-server.test.mjs tests/live-inject.test.mjs tests/live-insert.test.mjs tests/live-wrap.test.mjs tests/live-copy-edit-agent.test.mjs tests/framework-fixtures.test.mjs
- git diff --check