### PR TITLE
Fix: ignore hook cache artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Thumbs.db
 .impeccable/live/manual-edit-events.jsonl
 .impeccable/live/manual-edit-evidence/
 .impeccable/live/pending-manual-edits.json
+.impeccable/hook.cache.json
 .impeccable/history/
 # Per-run critique snapshots are local artifacts. ignore.md (also under
 # this dir) carries deferrals the user may want to share, so it's

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -93,14 +93,16 @@ async function stashManualEdit(server, entry) {
   return res.json();
 }
 
-it('gitignores local manual Apply runtime artifacts', () => {
+it('gitignores local Impeccable runtime artifacts', () => {
   const ignored = execFileSync('git', [
     'check-ignore',
     '.impeccable/live/manual-edit-apply-transaction.json',
     '.impeccable/live/manual-edit-evidence/example.json',
+    '.impeccable/hook.cache.json',
   ], { cwd: REPO_ROOT, encoding: 'utf-8' });
   assert.match(ignored, /\.impeccable\/live\/manual-edit-apply-transaction\.json/);
   assert.match(ignored, /\.impeccable\/live\/manual-edit-evidence\/example\.json/);
+  assert.match(ignored, /\.impeccable\/hook\.cache\.json/);
 });
 
 async function readSseUntil(reader, decoder, needle, maxReads = 12) {


### PR DESCRIPTION
## Summary
- Ignore the local .impeccable/hook.cache.json runtime cache file
- Extend the existing gitignore regression test to cover the hook cache artifact

## Validation
- node --test tests/live-server.test.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.gitignore` and a test assertion change; no runtime or security behavior.
> 
> **Overview**
> Treats **`.impeccable/hook.cache.json`** as a local Impeccable runtime artifact by adding it to **`.gitignore`** alongside the other `.impeccable/live/` recovery files, so hook cache state is not committed.
> 
> The existing **`git check-ignore`** regression test in **`tests/live-server.test.mjs`** is renamed to cover “Impeccable runtime artifacts” generally and now asserts that **`.impeccable/hook.cache.json`** is ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf21b5da518a684bef47533061cfafc6d14aeb40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->