### PR TITLE
Fix Windows skill bundle extraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "css-select": "^5.2.2",
         "css-tree": "^3.2.1",
         "domutils": "^3.2.2",
+        "extract-zip": "^2.0.1",
         "htmlparser2": "^10.0.0",
         "marked": "^16.4.2",
       },

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { get } from 'node:https';
 import { createHash } from 'node:crypto';
 import { tmpdir, homedir } from 'node:os';
+import extract from 'extract-zip';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const API_BASE = 'https://impeccable.style';
@@ -116,7 +117,7 @@ async function downloadAndExtractBundle() {
   const tmpDir = join(tmpdir(), `impeccable-update-${Date.now()}`);
   await downloadFile(`${API_BASE}/api/download/bundle/universal`, tmpZip);
   mkdirSync(tmpDir, { recursive: true });
-  execSync(`unzip -qo "${tmpZip}" -d "${tmpDir}"`, { encoding: 'utf8' });
+  await extract(tmpZip, { dir: tmpDir });
   rmSync(tmpZip, { force: true });
   return tmpDir;
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "css-select": "^5.2.2",
     "css-tree": "^3.2.1",
     "domutils": "^3.2.2",
+    "extract-zip": "^2.0.1",
     "htmlparser2": "^10.0.0",
     "marked": "^16.4.2"
   },


### PR DESCRIPTION
## Summary
- Replace the CLI host `unzip` call with `extract-zip` when unpacking the universal skills bundle.
- Promote `extract-zip` to a direct runtime dependency because `skills install`, `skills update`, and `skills check` now rely on bundle extraction.
- Keep the change surgical: no docs changes, generated output changes, or new tests.

## Regression context
- The user-facing `skills install` failure is a regression introduced in CLI `2.2.0`, when `skills install` switched from `npx skills add pbakaus/impeccable --copy` to direct universal bundle download/extraction.
- `skills check` and `skills update` already used the same `unzip`-based extraction helper before CLI `2.2.0`, so the exact `Could not check for updates: Command failed: unzip` failure was a pre-existing latent issue for those commands.
- This PR fixes all affected commands by extracting the ZIP in JavaScript instead of depending on a Unix `unzip` binary being available on `PATH`.

## Dependency note
- `extract-zip` is a well-known ZIP extraction package already present transitively through Puppeteer browser tooling.
- This PR makes it explicit because the CLI now imports and uses it directly.

Fixes #195.

## Validation
- `bun test ./tests/skills-cli.test.js`
- `IMPECCABLE_CLI_E2E=1 bun test ./tests/skills-cli.test.js`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI change to ZIP extraction with a well-known dependency; no auth, data, or architectural impact.
> 
> **Overview**
> Fixes **Windows** (and other environments without a Unix `unzip` on `PATH`) by unpacking the universal skills bundle in Node instead of shelling out to `unzip`.
> 
> `downloadAndExtractBundle` in `skills.mjs` now uses **`extract-zip`**; **`skills install`**, **`skills update`**, and **`skills check`** all share that helper, so they benefit from the same change. **`extract-zip`** is added as a direct runtime dependency in `package.json` / `bun.lock` (it was already available transitively via Puppeteer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3644347dc74cdb3368b3f1c96b6d05b11dae01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->