### PR TITLE
Add site copy feedback and command block fixes

### DIFF
--- a/site/components/Footer.astro
+++ b/site/components/Footer.astro
@@ -3,7 +3,7 @@
 
 <footer class="site-footer">
   <div class="footer-row">
-    <span class="footer-logo">Impeccable</span>
+    <a class="footer-logo" href="/">Impeccable</a>
     <nav class="footer-links" aria-label="Footer">
       <a href="/changelog">Changelog</a>
       <a href="/faq">FAQ</a>

--- a/site/pages/cases/neo-mirai.astro
+++ b/site/pages/cases/neo-mirai.astro
@@ -87,20 +87,52 @@ import '../../styles/sub-pages.css';
       <h2>Use craft when the output has to feel designed.</h2>
       <p><code>/impeccable craft</code> is the right command when a feature needs shaping, visual direction, implementation, and browser iteration in one run.</p>
     </div>
-    <div class="code-block-wrap"><pre class="code-block"><code>/impeccable craft retro-futurist AI design conference website</code></pre><button class="code-block-copy" type="button" data-copy="/impeccable craft retro-futurist AI design conference website" aria-label="Copy to clipboard"></button></div>
+    <div class="code-block-wrap"><pre class="code-block"><code>/impeccable craft retro-futurist AI design conference website</code></pre><button class="code-block-copy" type="button" data-copy="/impeccable craft retro-futurist AI design conference website" aria-label="Copy to clipboard">
+      <svg class="code-block-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+        <rect x="9" y="9" width="13" height="13" rx="2"></rect>
+        <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"></path>
+      </svg>
+      <svg class="code-block-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 6 9 17l-5-5"></path>
+      </svg>
+    </button></div>
   </section>
   </div>
 
   <script is:inline>
+    const copyResetTimers = new WeakMap();
+
+    function copyWithTextareaFallback(text) {
+      const ta = Object.assign(document.createElement('textarea'), { value: text, style: 'position:fixed;left:-9999px' });
+      document.body.appendChild(ta);
+      ta.select();
+      let copied = true;
+      try { document.execCommand('copy'); } catch { copied = false; }
+      ta.remove();
+      return copied;
+    }
+
     document.addEventListener('click', (event) => {
       const button = event.target.closest('[data-copy]');
       if (!button) return;
       const text = button.getAttribute('data-copy');
       if (!text) return;
-      navigator.clipboard.writeText(text).then(() => {
-        button.classList.add('is-copied');
-        setTimeout(() => button.classList.remove('is-copied'), 1500);
-      }).catch(() => {});
+
+      const onCopied = () => {
+        window.clearTimeout(copyResetTimers.get(button));
+        button.classList.remove('copied');
+        void button.offsetWidth;
+        button.classList.add('copied');
+        copyResetTimers.set(button, window.setTimeout(() => button.classList.remove('copied'), 1200));
+      };
+
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(text).then(onCopied).catch(() => {
+          if (copyWithTextareaFallback(text)) onCopied();
+        });
+      } else if (copyWithTextareaFallback(text)) {
+        onCopied();
+      }
     });
   </script>
 

--- a/site/pages/cases/neo-mirai.astro
+++ b/site/pages/cases/neo-mirai.astro
@@ -99,41 +99,10 @@ import '../../styles/sub-pages.css';
   </section>
   </div>
 
-  <script is:inline>
-    const copyResetTimers = new WeakMap();
+  <script>
+    import { initCopyFeedback } from "../../scripts/utils/copy-feedback.js";
 
-    function copyWithTextareaFallback(text) {
-      const ta = Object.assign(document.createElement('textarea'), { value: text, style: 'position:fixed;left:-9999px' });
-      document.body.appendChild(ta);
-      ta.select();
-      let copied = true;
-      try { document.execCommand('copy'); } catch { copied = false; }
-      ta.remove();
-      return copied;
-    }
-
-    document.addEventListener('click', (event) => {
-      const button = event.target.closest('[data-copy]');
-      if (!button) return;
-      const text = button.getAttribute('data-copy');
-      if (!text) return;
-
-      const onCopied = () => {
-        window.clearTimeout(copyResetTimers.get(button));
-        button.classList.remove('copied');
-        void button.offsetWidth;
-        button.classList.add('copied');
-        copyResetTimers.set(button, window.setTimeout(() => button.classList.remove('copied'), 1200));
-      };
-
-      if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(text).then(onCopied).catch(() => {
-          if (copyWithTextareaFallback(text)) onCopied();
-        });
-      } else if (copyWithTextareaFallback(text)) {
-        onCopied();
-      }
-    });
+    initCopyFeedback();
   </script>
 
 </Base>

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -595,9 +595,12 @@ import '../styles/testimonials.css';
             <span class="downloads-rebuild-prompt" aria-hidden="true">$</span>
             <code>npx impeccable skills install</code>
             <button class="downloads-rebuild-copy" type="button" aria-label="Copy install command" data-copy="npx impeccable skills install">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+              <svg class="downloads-rebuild-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <rect x="9" y="9" width="13" height="13" rx="2"/>
                 <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+              </svg>
+              <svg class="downloads-rebuild-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M20 6 9 17l-5-5"/>
               </svg>
               <span>Copy</span>
             </button>
@@ -610,9 +613,12 @@ import '../styles/testimonials.css';
             <span class="downloads-rebuild-prompt" aria-hidden="true">$</span>
             <code>npx impeccable skills update</code>
             <button class="downloads-rebuild-copy" type="button" aria-label="Copy update command" data-copy="npx impeccable skills update">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+              <svg class="downloads-rebuild-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <rect x="9" y="9" width="13" height="13" rx="2"/>
                 <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+              </svg>
+              <svg class="downloads-rebuild-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M20 6 9 17l-5-5"/>
               </svg>
               <span>Copy</span>
             </button>
@@ -632,9 +638,12 @@ import '../styles/testimonials.css';
             <div class="downloads-rebuild-cmd downloads-rebuild-cmd--alt">
               <code>/plugin marketplace add pbakaus/impeccable</code>
               <button class="downloads-rebuild-copy" type="button" aria-label="Copy Claude Code plugin command" data-copy="/plugin marketplace add pbakaus/impeccable">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+                <svg class="downloads-rebuild-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                   <rect x="9" y="9" width="13" height="13" rx="2"/>
                   <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                </svg>
+                <svg class="downloads-rebuild-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M20 6 9 17l-5-5"/>
                 </svg>
                 <span>Copy</span>
               </button>
@@ -647,9 +656,12 @@ import '../styles/testimonials.css';
             <div class="downloads-rebuild-cmd downloads-rebuild-cmd--alt">
               <code>npx skills add pbakaus/impeccable</code>
               <button class="downloads-rebuild-copy" type="button" aria-label="Copy npx skills command" data-copy="npx skills add pbakaus/impeccable">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+                <svg class="downloads-rebuild-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                   <rect x="9" y="9" width="13" height="13" rx="2"/>
                   <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                </svg>
+                <svg class="downloads-rebuild-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M20 6 9 17l-5-5"/>
                 </svg>
                 <span>Copy</span>
               </button>

--- a/site/pages/live-mode/index.astro
+++ b/site/pages/live-mode/index.astro
@@ -23,9 +23,12 @@ import '../../styles/live-mode-kinpaku.css';
       <span class="live-mode-start-prompt">$</span>
       <code class="live-mode-start-cmd">/impeccable live</code>
       <button class="live-mode-start-copy" type="button" aria-label="Copy command" data-copy="/impeccable live">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <svg class="live-mode-start-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
           <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
           <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"></path>
+        </svg>
+        <svg class="live-mode-start-check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20 6 9 17l-5-5"></path>
         </svg>
       </button>
     </div>
@@ -228,15 +231,39 @@ import '../../styles/live-mode-kinpaku.css';
 </script>
 
 <script is:inline>
+  const copyResetTimers = new WeakMap();
+
+  function copyWithTextareaFallback(text) {
+    const ta = Object.assign(document.createElement('textarea'), { value: text, style: 'position:fixed;left:-9999px' });
+    document.body.appendChild(ta);
+    ta.select();
+    let copied = true;
+    try { document.execCommand('copy'); } catch { copied = false; }
+    ta.remove();
+    return copied;
+  }
+
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('[data-copy]');
     if (!btn) return;
     const text = btn.getAttribute('data-copy');
     if (!text) return;
-    navigator.clipboard.writeText(text).then(() => {
-      btn.classList.add('is-copied');
-      setTimeout(() => btn.classList.remove('is-copied'), 1500);
-    }).catch(() => {});
+
+    const onCopied = () => {
+      window.clearTimeout(copyResetTimers.get(btn));
+      btn.classList.remove('copied');
+      void btn.offsetWidth;
+      btn.classList.add('copied');
+      copyResetTimers.set(btn, window.setTimeout(() => btn.classList.remove('copied'), 1200));
+    };
+
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(text).then(onCopied).catch(() => {
+        if (copyWithTextareaFallback(text)) onCopied();
+      });
+    } else if (copyWithTextareaFallback(text)) {
+      onCopied();
+    }
   });
 
   document.addEventListener('click', (e) => {

--- a/site/pages/live-mode/index.astro
+++ b/site/pages/live-mode/index.astro
@@ -224,48 +224,16 @@ import '../../styles/live-mode-kinpaku.css';
 
 <script>
   import { initLiveDemo, initGbarPageChat } from "../../scripts/components/live-demo.js";
+  import { initCopyFeedback } from "../../scripts/utils/copy-feedback.js";
+
   document.addEventListener("DOMContentLoaded", () => {
     initLiveDemo();
     initGbarPageChat();
+    initCopyFeedback();
   });
 </script>
 
 <script is:inline>
-  const copyResetTimers = new WeakMap();
-
-  function copyWithTextareaFallback(text) {
-    const ta = Object.assign(document.createElement('textarea'), { value: text, style: 'position:fixed;left:-9999px' });
-    document.body.appendChild(ta);
-    ta.select();
-    let copied = true;
-    try { document.execCommand('copy'); } catch { copied = false; }
-    ta.remove();
-    return copied;
-  }
-
-  document.addEventListener('click', (e) => {
-    const btn = e.target.closest('[data-copy]');
-    if (!btn) return;
-    const text = btn.getAttribute('data-copy');
-    if (!text) return;
-
-    const onCopied = () => {
-      window.clearTimeout(copyResetTimers.get(btn));
-      btn.classList.remove('copied');
-      void btn.offsetWidth;
-      btn.classList.add('copied');
-      copyResetTimers.set(btn, window.setTimeout(() => btn.classList.remove('copied'), 1200));
-    };
-
-    if (navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(text).then(onCopied).catch(() => {
-        if (copyWithTextareaFallback(text)) onCopied();
-      });
-    } else if (copyWithTextareaFallback(text)) {
-      onCopied();
-    }
-  });
-
   document.addEventListener('click', (e) => {
     const toggle = e.target.closest('.skills-sidebar-toggle');
     if (!toggle) return;

--- a/site/scripts/app.js
+++ b/site/scripts/app.js
@@ -5,6 +5,7 @@ import {
 import { initFrameworkViz } from "./components/framework-viz.js";
 import { initScrollReveal } from "./utils/reveal.js";
 import { initAnchorScroll, initHashTracking } from "./utils/scroll.js";
+import { initCopyFeedback } from "./utils/copy-feedback.js";
 import { initSectionNav } from "./components/section-nav.js";
 import { initFoundationGrid } from "./components/foundation-grid.js";
 import { initLiveDemo, initGbarPageChat } from "./components/live-demo.js";
@@ -199,18 +200,6 @@ function renderPatternsWithTabs(patterns, antipatterns) {
 // EVENT HANDLERS
 // ============================================
 
-const copyResetTimers = new WeakMap();
-
-function copyWithTextareaFallback(text) {
-	const ta = Object.assign(document.createElement('textarea'), { value: text, style: 'position:fixed;left:-9999px' });
-	document.body.appendChild(ta);
-	ta.select();
-	let copied = true;
-	try { document.execCommand('copy'); } catch { copied = false; }
-	ta.remove();
-	return copied;
-}
-
 // Handle bundle download clicks via event delegation.
 // Each download button carries the full bundle name in data-bundle
 // (currently just "universal") so the handler is just a redirect.
@@ -219,26 +208,6 @@ document.addEventListener("click", (e) => {
 	if (bundleBtn) {
 		const bundleName = bundleBtn.dataset.bundle;
 		window.location.href = `/api/download/bundle/${bundleName}`;
-	}
-
-	// Handle copy button clicks
-	const copyBtn = e.target.closest("[data-copy]");
-	if (copyBtn) {
-		const textToCopy = copyBtn.dataset.copy;
-		const onCopied = () => {
-			clearTimeout(copyResetTimers.get(copyBtn));
-			copyBtn.classList.remove('copied');
-			void copyBtn.offsetWidth;
-			copyBtn.classList.add('copied');
-			copyResetTimers.set(copyBtn, setTimeout(() => copyBtn.classList.remove('copied'), 1200));
-		};
-		if (navigator.clipboard?.writeText) {
-			navigator.clipboard.writeText(textToCopy).then(onCopied).catch(() => {
-				if (copyWithTextareaFallback(textToCopy)) onCopied();
-			});
-		} else if (copyWithTextareaFallback(textToCopy)) {
-			onCopied();
-		}
 	}
 });
 
@@ -273,6 +242,7 @@ function initHeaderScroll() {
 function init() {
 	initAnchorScroll();
 	initHashTracking();
+	initCopyFeedback();
 	initHeaderScroll();
 	initScrollReveal();
 	initGlassTerminal();

--- a/site/scripts/app.js
+++ b/site/scripts/app.js
@@ -199,6 +199,18 @@ function renderPatternsWithTabs(patterns, antipatterns) {
 // EVENT HANDLERS
 // ============================================
 
+const copyResetTimers = new WeakMap();
+
+function copyWithTextareaFallback(text) {
+	const ta = Object.assign(document.createElement('textarea'), { value: text, style: 'position:fixed;left:-9999px' });
+	document.body.appendChild(ta);
+	ta.select();
+	let copied = true;
+	try { document.execCommand('copy'); } catch { copied = false; }
+	ta.remove();
+	return copied;
+}
+
 // Handle bundle download clicks via event delegation.
 // Each download button carries the full bundle name in data-bundle
 // (currently just "universal") so the handler is just a redirect.
@@ -214,18 +226,18 @@ document.addEventListener("click", (e) => {
 	if (copyBtn) {
 		const textToCopy = copyBtn.dataset.copy;
 		const onCopied = () => {
+			clearTimeout(copyResetTimers.get(copyBtn));
+			copyBtn.classList.remove('copied');
+			void copyBtn.offsetWidth;
 			copyBtn.classList.add('copied');
-			setTimeout(() => copyBtn.classList.remove('copied'), 1500);
+			copyResetTimers.set(copyBtn, setTimeout(() => copyBtn.classList.remove('copied'), 1200));
 		};
 		if (navigator.clipboard?.writeText) {
-			navigator.clipboard.writeText(textToCopy).then(onCopied).catch(() => {});
-		} else {
-			// Fallback for non-HTTPS or older browsers
-			const ta = Object.assign(document.createElement('textarea'), { value: textToCopy, style: 'position:fixed;left:-9999px' });
-			document.body.appendChild(ta);
-			ta.select();
-			try { document.execCommand('copy'); onCopied(); } catch {}
-			ta.remove();
+			navigator.clipboard.writeText(textToCopy).then(onCopied).catch(() => {
+				if (copyWithTextareaFallback(textToCopy)) onCopied();
+			});
+		} else if (copyWithTextareaFallback(textToCopy)) {
+			onCopied();
 		}
 	}
 });

--- a/site/scripts/utils/copy-feedback.js
+++ b/site/scripts/utils/copy-feedback.js
@@ -1,0 +1,62 @@
+const copyResetTimers = new WeakMap();
+
+function copyWithTextareaFallback(text) {
+	const ta = Object.assign(document.createElement('textarea'), {
+		value: text,
+		style: 'position:fixed;left:-9999px',
+	});
+
+	document.body.appendChild(ta);
+	ta.focus();
+	ta.select();
+
+	try {
+		return document.execCommand('copy');
+	} catch {
+		return false;
+	} finally {
+		ta.remove();
+	}
+}
+
+function showCopiedState(button, { copiedClass = 'copied', resetMs = 1200 } = {}) {
+	window.clearTimeout(copyResetTimers.get(button));
+	button.classList.remove(copiedClass);
+	void button.offsetWidth;
+	button.classList.add(copiedClass);
+	copyResetTimers.set(
+		button,
+		window.setTimeout(() => button.classList.remove(copiedClass), resetMs),
+	);
+}
+
+async function copyText(text) {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {}
+	}
+
+	return copyWithTextareaFallback(text);
+}
+
+export function initCopyFeedback({
+	selector = '[data-copy]',
+	copiedClass = 'copied',
+	resetMs = 1200,
+} = {}) {
+	document.addEventListener('click', async (event) => {
+		if (!(event.target instanceof Element)) return;
+
+		const button = event.target.closest(selector);
+		if (!(button instanceof HTMLElement)) return;
+
+		const text = button.getAttribute('data-copy');
+		if (!text) return;
+
+		if (await copyText(text)) {
+			showCopiedState(button, { copiedClass, resetMs });
+		}
+	});
+}

--- a/site/styles/docs-visuals.css
+++ b/site/styles/docs-visuals.css
@@ -3341,12 +3341,25 @@
 }
 
 .neon-case-command .code-block-wrap {
+  position: relative;
   margin: 0;
+}
+
+.neon-case-command .code-block-wrap::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  bottom: 31px;
+  width: 142px;
+  pointer-events: none;
+  background: linear-gradient(90deg, transparent, var(--ks-code-block-bg) 74%);
+  z-index: 1;
 }
 
 .neon-case-command .code-block {
   margin: 0;
-  padding: var(--spacing-md);
+  padding: var(--spacing-md) 96px var(--spacing-md) var(--spacing-md);
   background: var(--ks-code-block-bg);
   color: var(--ks-code-block-fg);
   border: 1px solid var(--ks-code-block-border);
@@ -3365,10 +3378,101 @@
   font-size: inherit;
 }
 
-.neon-case-command .code-block-copy.is-copied {
-  background: var(--ks-kinpaku);
-  color: var(--ks-lacquer-deep);
-  border-color: var(--ks-kinpaku);
+.neon-case-command .code-block-copy {
+  top: 0;
+  right: 14px;
+  bottom: 17px;
+  margin: auto 0;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  opacity: 1;
+  background: oklch(5% 0.004 95 / 0.94);
+  border: 1px solid var(--ks-code-block-border);
+  border-radius: 3px;
+  color: var(--ks-kinpaku);
+  transform: none;
+  transition:
+    background 180ms var(--ks-ease),
+    border-color 180ms var(--ks-ease),
+    color 180ms var(--ks-ease),
+    transform 120ms var(--ks-ease);
+}
+
+.neon-case-command .code-block-copy::before {
+  content: none;
+}
+
+.neon-case-command .code-block-copy:hover {
+  background: oklch(8% 0.006 95);
+  border-color: currentColor;
+  color: var(--ks-kinpaku);
+}
+
+.neon-case-command .code-block-copy:active {
+  transform: scale(0.96);
+}
+
+.neon-case-command .code-block-copy-icon,
+.neon-case-command .code-block-check-icon {
+  grid-area: 1 / 1;
+  transition:
+    opacity 140ms var(--ks-ease),
+    transform 180ms var(--ks-ease);
+}
+
+.neon-case-command .code-block-copy-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.neon-case-command .code-block-check-icon {
+  opacity: 0;
+  transform: scale(0.86);
+}
+
+.neon-case-command .code-block-check-icon path {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+}
+
+.neon-case-command .code-block-copy.copied {
+  background: oklch(8% 0.006 95);
+  border-color: currentColor;
+}
+
+.neon-case-command .code-block-copy.copied .code-block-copy-icon {
+  opacity: 0;
+  transform: scale(0.82);
+}
+
+.neon-case-command .code-block-copy.copied .code-block-check-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.neon-case-command .code-block-copy.copied .code-block-check-icon path {
+  animation: neon-case-check-draw 260ms var(--ks-ease) forwards;
+}
+
+@keyframes neon-case-check-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neon-case-command .code-block-copy,
+  .neon-case-command .code-block-copy-icon,
+  .neon-case-command .code-block-check-icon {
+    transition: none;
+  }
+
+  .neon-case-command .code-block-copy.copied .code-block-check-icon path {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
 }
 
 @media (max-width: 980px) {

--- a/site/styles/docs-visuals.css
+++ b/site/styles/docs-visuals.css
@@ -3327,6 +3327,10 @@
   border-radius: 2px;
 }
 
+.neon-case-command > * {
+  min-width: 0;
+}
+
 .neon-case-command h2 {
   color: var(--ks-champagne);
 }
@@ -3343,6 +3347,8 @@
 .neon-case-command .code-block-wrap {
   position: relative;
   margin: 0;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .neon-case-command .code-block-wrap::after {
@@ -3358,6 +3364,7 @@
 }
 
 .neon-case-command .code-block {
+  max-width: 100%;
   margin: 0;
   padding: var(--spacing-md) 96px var(--spacing-md) var(--spacing-md);
   background: var(--ks-code-block-bg);

--- a/site/styles/home-rebuild.css
+++ b/site/styles/home-rebuild.css
@@ -735,6 +735,7 @@
 /* Compact icon-only copy button nested inside the cmd box, on the right. */
 .home-kinpaku .downloads-rebuild-copy {
   flex: none;
+  position: relative;
   display: inline-grid;
   place-items: center;
   width: 40px;
@@ -744,7 +745,74 @@
   color: var(--card-copy-fg);
   border-radius: 2px;
   cursor: pointer;
-  transition: background 180ms var(--ks-ease), border-color 180ms var(--ks-ease);
+  transition:
+    background 180ms var(--ks-ease),
+    border-color 180ms var(--ks-ease),
+    color 180ms var(--ks-ease),
+    transform 120ms var(--ks-ease);
+}
+
+.home-kinpaku .downloads-rebuild-copy:active {
+  transform: scale(0.96);
+}
+
+.home-kinpaku .downloads-rebuild-copy-icon,
+.home-kinpaku .downloads-rebuild-check-icon {
+  grid-area: 1 / 1;
+  transition:
+    opacity 140ms var(--ks-ease),
+    transform 180ms var(--ks-ease);
+}
+
+.home-kinpaku .downloads-rebuild-copy-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.home-kinpaku .downloads-rebuild-check-icon {
+  opacity: 0;
+  transform: scale(0.86);
+}
+
+.home-kinpaku .downloads-rebuild-check-icon path {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+}
+
+.home-kinpaku .downloads-rebuild-copy.copied {
+  background: var(--card-copy-hover-bg);
+  border-color: currentColor;
+}
+
+.home-kinpaku .downloads-rebuild-copy.copied .downloads-rebuild-copy-icon {
+  opacity: 0;
+  transform: scale(0.82);
+}
+
+.home-kinpaku .downloads-rebuild-copy.copied .downloads-rebuild-check-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.home-kinpaku .downloads-rebuild-copy.copied .downloads-rebuild-check-icon path {
+  animation: downloads-check-draw 260ms var(--ks-ease) forwards;
+}
+
+@keyframes downloads-check-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-kinpaku .downloads-rebuild-copy,
+  .home-kinpaku .downloads-rebuild-copy-icon,
+  .home-kinpaku .downloads-rebuild-check-icon {
+    transition: none;
+  }
+
+  .home-kinpaku .downloads-rebuild-copy.copied .downloads-rebuild-check-icon path {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
 }
 
 .home-kinpaku .downloads-rebuild-copy span {

--- a/site/styles/live-mode-kinpaku.css
+++ b/site/styles/live-mode-kinpaku.css
@@ -163,15 +163,75 @@
   place-items: center;
   padding: 4px;
   border-radius: 2px;
-  transition: color 160ms var(--ks-ease);
+  transition:
+    color 160ms var(--ks-ease),
+    transform 120ms var(--ks-ease);
 }
 
 .live-mode-kinpaku .live-mode-start-copy:hover {
   color: var(--ks-kinpaku);
 }
 
-.live-mode-kinpaku .live-mode-start-copy.is-copied {
+.live-mode-kinpaku .live-mode-start-copy:active {
+  transform: scale(0.96);
+}
+
+.live-mode-kinpaku .live-mode-start-copy-icon,
+.live-mode-kinpaku .live-mode-start-check-icon {
+  grid-area: 1 / 1;
+  transition:
+    opacity 140ms var(--ks-ease),
+    transform 180ms var(--ks-ease);
+}
+
+.live-mode-kinpaku .live-mode-start-copy-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.live-mode-kinpaku .live-mode-start-check-icon {
+  opacity: 0;
+  transform: scale(0.86);
+}
+
+.live-mode-kinpaku .live-mode-start-check-icon path {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+}
+
+.live-mode-kinpaku .live-mode-start-copy.copied {
   color: var(--ks-kinpaku);
+}
+
+.live-mode-kinpaku .live-mode-start-copy.copied .live-mode-start-copy-icon {
+  opacity: 0;
+  transform: scale(0.82);
+}
+
+.live-mode-kinpaku .live-mode-start-copy.copied .live-mode-start-check-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.live-mode-kinpaku .live-mode-start-copy.copied .live-mode-start-check-icon path {
+  animation: live-mode-check-draw 260ms var(--ks-ease) forwards;
+}
+
+@keyframes live-mode-check-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .live-mode-kinpaku .live-mode-start-copy,
+  .live-mode-kinpaku .live-mode-start-copy-icon,
+  .live-mode-kinpaku .live-mode-start-check-icon {
+    transition: none;
+  }
+
+  .live-mode-kinpaku .live-mode-start-copy.copied .live-mode-start-check-icon path {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
 }
 
 


### PR DESCRIPTION
## Summary

This PR adds copied feedback to command copy buttons across the marketing site.

It covers the homepage install/update buttons, the two alternate install-method buttons, the Live Mode command, and the Neo Mirai craft command. On copy, those buttons swap the copy icon for a drawn checkmark, then reset automatically. The clipboard handlers also add a fallback path when `navigator.clipboard.writeText` rejects, so local/non-standard clipboard contexts can still show feedback after a successful fallback copy.

This PR also links the footer wordmark back to `/` and updates the Neo Mirai command block so narrow viewports keep page overflow contained while preserving internal code scrolling where needed.

## Visual references

### Homepage downloads — `/#downloads`

This PR adds copy feedback to the install/update commands and the two collapsed alternate install methods.

https://github.com/user-attachments/assets/2644f394-8546-46cd-8566-3689355ea46a

### Live Mode command — `/live-mode`

This PR applies the same copy-to-check feedback pattern to the `/impeccable live` command.

![Live Mode copy confirmation](https://onyx-silence-wjnk.here.now/droppie-2026-06-03T04-08-16Z.png)

### Neo Mirai command — `/cases/neo-mirai`

For `/cases/neo-mirai`, this PR adds the copy-to-check feedback to the craft command and introduces a right-edge fade behind the new control. The command is wider than its code box and can scroll horizontally, so the fade keeps the control from visually sitting on top of the command text while matching the homepage copy-button pattern.

![Neo Mirai copy confirmation](https://crisp-karma-vgnn.here.now/droppie-2026-06-03T04-19-05Z.png)

### Neo Mirai narrow viewport — `/cases/neo-mirai`

The before capture shows the command box forcing horizontal page overflow on a narrow screen.

![Neo Mirai narrow command overflow before](https://supple-intent-c348.here.now/droppie-2026-06-03T04-25-09Z.png)

The after capture shows the page contained within the viewport, with the long command scrolling inside the code box instead.

![Neo Mirai narrow command overflow after](https://tawny-cobble-d6hv.here.now/droppie-2026-06-03T04-26-46Z.png)

## Type of change

- [ ] New command
- [ ] New / updated skill reference
- [ ] New anti-pattern guidance
- [ ] Bug fix
- [ ] Documentation update
- [ ] Build system / tooling
- [x] Other: site interaction additions

## Validation

- `bun install --frozen-lockfile`
- `bun run build:site`
- Browser check at `http://127.0.0.1:4321/#downloads`: install, update, Claude Code plugin, and npx skills copy buttons show the check state and reset.
- Browser check at `http://127.0.0.1:4321/live-mode`: the command copy button shows the check state and resets.
- Browser check at `http://127.0.0.1:4321/cases/neo-mirai`: the craft command copy button shows the check state and resets.
- Narrow viewport check at 390, 430, 581, and 768px: the Neo Mirai command block stays within the viewport while preserving internal code scrolling where needed.
- Static HTML check: the footer wordmark renders as `<a class="footer-logo" href="/">Impeccable</a>`.

## Checklist

- [ ] Source files updated in `source/` (not applicable; site JS/CSS/markup only)
- [ ] `bun run build` ran successfully (not run; scoped to `bun run build:site`)
- [ ] `bun test` passes (not run; no test-covered runtime logic changed)
- [ ] Tested with at least one provider (not applicable)
- [ ] README / DEVELOP.md updated if needed (not needed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-site UI and client-side clipboard only; no auth, APIs, or product runtime changes.
> 
> **Overview**
> Unifies marketing-site **copy-to-clipboard** behavior in a shared `initCopyFeedback` helper (clipboard API plus textarea fallback) and wires it from `app.js`, Live Mode, and Neo Mirai instead of duplicated inline click handlers.
> 
> **Copy buttons** on the homepage downloads section, `/live-mode`, and the Neo Mirai craft block now swap the copy icon for an animated checkmark via a `copied` class, with matching CSS in `home-rebuild.css`, `live-mode-kinpaku.css`, and `docs-visuals.css`. The footer **Impeccable** wordmark is now a link to `/`.
> 
> On **Neo Mirai**, the craft command row is constrained on narrow viewports (`min-width: 0`, extra padding, right-edge fade) so long commands scroll inside the code box without forcing horizontal page overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b712a630467d8dd236997a72ad4a5929836394d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

