### PR TITLE
Fix DESIGN.md links

### DIFF
--- a/site/content/skills/document.md
+++ b/site/content/skills/document.md
@@ -71,7 +71,7 @@ tagline: "Generate a spec-compliant DESIGN.md that captures your visual system s
 
 ## When to use it
 
-Run `/impeccable document` once you have enough of a visual system to document: colors, typography, at least a button and a card. The command scans your codebase, extracts the tokens and component patterns it finds, and writes a `DESIGN.md` at the project root that follows the [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/format/), six sections in a fixed order, interoperable with every other DESIGN.md-aware tool.
+Run `/impeccable document` once you have enough of a visual system to document: colors, typography, at least a button and a card. The command scans your codebase, extracts the tokens and component patterns it finds, and writes a `DESIGN.md` at the project root that follows the [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/overview/), six sections in a fixed order, interoperable with every other DESIGN.md-aware tool.
 
 Reach for it when:
 

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -405,7 +405,7 @@ import '../styles/testimonials.css';
           <article class="ks-bento-tile ks-bento-tile--span-4" id="why-designmd">
             <span class="ks-bento-num" data-color="kinpaku">03</span>
             <h3 class="why-panel-title">Travels as DESIGN.md.</h3>
-            <p class="why-panel-body"><code>/impeccable document</code> writes one in the <a href="https://stitch.withgoogle.com/docs/design-md/format/" target="_blank" rel="noopener">Google Stitch format</a>. Your visual system becomes portable.</p>
+            <p class="why-panel-body"><code>/impeccable document</code> writes one in the <a href="https://stitch.withgoogle.com/docs/design-md/overview/" target="_blank" rel="noopener">Google Stitch format</a>. Your visual system becomes portable.</p>
             <div class="why-visual why-visual--designmd-v2">
               <div class="why-dm-header">
                 <span class="why-dm-filename">DESIGN.md</span>


### PR DESCRIPTION
## Summary

Fixes a broken homepage link

## Type of change

- [ ] New command
- [ ] New / updated skill reference
- [ ] New anti-pattern guidance
- [x] Bug fix
- [x] Documentation update
- [ ] Build system / tooling
- [ ] Other: 

## Checklist

- [ ] Source files updated in `source/`
- [ ] `bun run build` ran successfully
- [ ] `bun test` passes
- [ ] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Kiro / OpenCode / Qoder)
- [ ] README / DEVELOP.md updated if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL fixes with no runtime or build behavior changes.
> 
> **Overview**
> Updates **broken Google Stitch DESIGN.md documentation links** from `.../design-md/format/` to `.../design-md/overview/` in two places: the **`document` skill** page (`site/content/skills/document.md`) and the homepage bento tile **“Travels as DESIGN.md”** (`site/pages/index.astro`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a87756d08ded7e09f8bc79b1a636712b9670306c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->