### PR TITLE
fix(live-server): stop cross-origin token leak + add DNS-rebinding guard

### DIFF
--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -60,6 +60,18 @@ const SSE_HEARTBEAT_INTERVAL = 30_000;  // keepalive ping every 30s
 // Port detection
 // ---------------------------------------------------------------------------
 
+// Accept only loopback Host headers matching this server's port. Guards against
+// DNS-rebinding: the server binds 127.0.0.1, so a real request's Host is always
+// 127.0.0.1:<port> or localhost:<port>. A port-less Host (e.g. default :80) can
+// never legitimately reach us, so it is rejected too.
+function isAllowedLoopbackHost(hostHeader, port) {
+  if (!hostHeader || typeof hostHeader !== 'string') return false;
+  const host = hostHeader.toLowerCase();
+  return host === `127.0.0.1:${port}` ||
+         host === `localhost:${port}` ||
+         host === `[::1]:${port}`;
+}
+
 async function findOpenPort(start = 8400) {
   return new Promise((resolve) => {
     const srv = net.createServer();
@@ -1247,7 +1259,23 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, sessionPath, livePath }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+
+    // DNS-rebinding / cross-origin defense. The server binds loopback only, so
+    // a legitimate request always carries a loopback Host header. A page served
+    // from a rebound hostname (attacker.com -> 127.0.0.1) would carry that
+    // hostname here; reject it. This is what stops a hostile website from
+    // reaching the file-writing endpoints (or reading the token-bearing
+    // /live.js) via DNS rebinding.
+    if (!isAllowedLoopbackHost(req.headers.host, state.port)) {
+      res.writeHead(403); res.end('Forbidden host'); return;
+    }
+
+    // No `Access-Control-Allow-Origin: *`. The legitimate consumer loads
+    // /live.js via a <script> tag, which executes (and exposes the token to
+    // the page that requested it) WITHOUT needing CORS read permission. A
+    // wildcard ACAO would instead let any cross-origin page fetch() /live.js
+    // and read the session token out of the response body, then drive the
+    // token-gated write endpoints. So we deliberately do not advertise CORS.
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -9,6 +9,7 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync, execSync, spawn } from 'node:child_process';
+import { request as httpRequest } from 'node:http';
 import {
   getDesignSidecarPath,
   getLiveDir,
@@ -46,6 +47,23 @@ function startServer(port = 8499, { cwd = REPO_ROOT, env = {} } = {}) {
     proc.stderr.on('data', (d) => { output += d.toString(); });
     proc.on('error', reject);
     setTimeout(() => reject(new Error('Server start timeout. Output: ' + output)), 5000);
+  });
+}
+
+// Issue a raw HTTP GET with a caller-controlled Host header. fetch()/undici
+// forbids overriding Host, so the DNS-rebinding guard test needs node:http.
+function rawRequest(port, path, hostHeader) {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port, path, method: 'GET', headers: { Host: hostHeader } },
+      (res) => {
+        let body = '';
+        res.on('data', (c) => { body += c; });
+        res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
   });
 }
 
@@ -156,6 +174,22 @@ describe('live-server integration', () => {
     assert.equal(data.mode, 'variant');
     assert.equal(typeof data.hasProjectContext, 'boolean');
     assert.equal(data.connectedClients, 0);
+  });
+
+  it('rejects requests with a non-loopback Host header (DNS-rebinding guard)', async () => {
+    // A hostile website served from a rebound hostname that resolves to
+    // 127.0.0.1 would carry that hostname in the Host header. The server must
+    // refuse it so the token-bearing /live.js and the file-writing endpoints
+    // are unreachable cross-origin.
+    const { statusCode, body } = await rawRequest(server.port, '/live.js', 'attacker.example');
+    assert.equal(statusCode, 403);
+    assert.doesNotMatch(body, /__IMPECCABLE_TOKEN__/);
+  });
+
+  it('does not advertise a wildcard CORS origin (token cannot be cross-origin fetched)', async () => {
+    const res = await fetch(`http://localhost:${server.port}/live.js`);
+    assert.equal(res.status, 200);
+    assert.notEqual(res.headers.get('access-control-allow-origin'), '*');
   });
 
   it('/live.js injects the canonical command vocabulary', async () => {


### PR DESCRIPTION
## Problem

The live variant server (`skill/scripts/live-server.mjs`) serves `/live.js` with `Access-Control-Allow-Origin: *` and no auth. That response body embeds the per-session token:

```js
window.__IMPECCABLE_TOKEN__ = '<uuid>';
```

Because the server binds `127.0.0.1` and advertises a wildcard CORS origin, **any website open in the same browser** can:

1. `fetch('http://127.0.0.1:<port>/live.js')` — the wildcard ACAO permits reading the cross-origin response body.
2. Parse the session token out of it.
3. POST to the token-gated write/apply endpoints, writing attacker-controlled content into files under the project `cwd`.

The port is discoverable by scanning from 8400. Written source files then execute on the developer's next build / dev-server reload → code execution on the dev host. Requires only that live mode is running and the developer visits a hostile page.

## Why the wildcard CORS isn't needed

The legitimate consumer loads `/live.js` via a `<script>` tag. Script-tag execution exposes the token to the requesting page **without** CORS read permission, so the real flow never depended on `Access-Control-Allow-Origin: *`. Removing it breaks nothing legitimate and closes the cross-origin `fetch()` read.

## Fix

- Remove `Access-Control-Allow-Origin: *` from the request handler.
- Add a loopback `Host`-header allowlist (`127.0.0.1` / `localhost` / `[::1]` : port). This blocks DNS-rebinding, where a rebound hostname resolving to `127.0.0.1` would otherwise make a hostile page same-origin and let it read the token even without CORS.
- Add regression tests covering the Host guard (403 + no token in body) and the absence of wildcard CORS.

## Testing

`node --test tests/live-server.test.mjs` — the two new tests pass. No change to the pass/fail set of the existing suite vs. baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix on authentication boundaries for a local server that embeds session tokens and exposes file-writing APIs; behavior change could break non-standard clients that relied on wildcard CORS or non-loopback Host headers.
> 
> **Overview**
> Closes a **local live-server exposure** where any website could read the session token from `/live.js` and drive token-gated write endpoints.
> 
> **`live-server.mjs`** drops **`Access-Control-Allow-Origin: *`** so cross-origin `fetch()` cannot read `/live.js` (legitimate use still loads it via `<script>`). Every request is gated by **`isAllowedLoopbackHost`**, which returns **403** unless `Host` is `127.0.0.1`, `localhost`, or `[::1]` with the bound port—blocking DNS-rebinding attacks that would otherwise reach token-bearing routes.
> 
> **`live-server.test.mjs`** adds **`rawRequest`** (custom `Host` via `node:http`) plus regression tests for the Host guard and absence of wildcard CORS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15b1eb67b7ddb11f1789206719bd708c65ce83a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->