### PR TITLE
Fix privacy wording for skill version check

### DIFF
--- a/site/pages/privacy.astro
+++ b/site/pages/privacy.astro
@@ -19,10 +19,13 @@ import '../styles/sub-pages.css';
 
 <div class="privacy-content">
   <h1>Privacy Policy</h1>
-  <p class="updated">Last updated: April 6, 2026</p>
+  <p class="updated">Last updated: June 8, 2026</p>
 
   <h2>What Impeccable is</h2>
-  <p>Impeccable is an open-source collection of agent skills (text files) that run locally in your AI coding tool. The skills themselves collect no data, make no network requests, and have no analytics.</p>
+  <p>Impeccable is an open-source collection of agent skills (text files) that run locally in your AI coding tool. The skills themselves collect no data, send no project content to Impeccable, and have no analytics. The only network request made by the skill is an optional, GET-only version check described below.</p>
+
+  <h2>Skill version check</h2>
+  <p>When an agent loads the Impeccable skill, <code>scripts/context.mjs</code> may make a best-effort <code>GET</code> request to <code>https://impeccable.style/api/version</code> at most once per day to check whether a newer skill version is available. The request sends no project files, prompts, page content, detection results, or personal information. It is silent on failure and can be disabled by setting <code>IMPECCABLE_NO_UPDATE_CHECK=1</code>.</p>
 
   <h2>Website analytics</h2>
   <p>The Impeccable website (<a href="https://impeccable.style">impeccable.style</a>) uses Google Analytics to understand traffic patterns (page views, referrers, country). No personal information is collected beyond what Google Analytics provides by default. No cookies are used for advertising.</p>


### PR DESCRIPTION
### Motivation
- Clarify the privacy page so it accurately represents the skill's network behavior and reassures users that no project data is transmitted.

### Description
- Update `site/pages/privacy.astro` to change the "Last updated" date to `June 8, 2026` and replace the inaccurate "make no network requests" wording with precise language that the skill "sends no project content to Impeccable".
- Add a new "Skill version check" section that documents the optional, GET-only request to `https://impeccable.style/api/version`, its once-per-day cadence, the data it does **not** send, and the opt-out environment variable `IMPECCABLE_NO_UPDATE_CHECK=1`.

### Testing
- Ran `bun test tests/build.test.js` and it passed.
- Launched the dev server and verified the updated page content with `curl`, confirming the new "Skill version check" text appears (success).
- Attempted `bun run build`, which failed due to a missing optional `puppeteer` dependency causing Vite to error resolving `cli/engine/engines/browser/detect-url.mjs` (build not completed).
- Attempted to capture a screenshot via Playwright, but `npx playwright install chromium` failed because the Playwright CDN returned `403 Forbidden`, so headless browser verification could not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26fd06a8c88329a6842b3394a5a0cc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static privacy page text only; no runtime, auth, or data-handling code changes.
> 
> **Overview**
> Updates the **Privacy Policy** page so it matches how the local skill actually behaves around network access.
> 
> The **“What Impeccable is”** section no longer claims the skills make **no** network requests; it now states they **send no project content to Impeccable**, with the sole skill-side request being an optional version check. A new **“Skill version check”** section documents the optional daily `GET` to `https://impeccable.style/api/version` from `scripts/context.mjs`, what data is **not** sent, silent failure, and opt-out via `IMPECCABLE_NO_UPDATE_CHECK=1`. The **last updated** date is bumped to **June 8, 2026**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78daa04910fb13ac006045d0a4f29768dec2311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->