### PR TITLE
fix(live-inject): preserve the character after an insertAfter anchor (#227)

### DIFF
--- a/.agents/skills/impeccable/scripts/live-inject.mjs
+++ b/.agents/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.agents/skills/impeccable/scripts/live-inject.mjs
+++ b/.agents/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.claude/skills/impeccable/scripts/live-inject.mjs
+++ b/.claude/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.claude/skills/impeccable/scripts/live-inject.mjs
+++ b/.claude/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.cursor/skills/impeccable/scripts/live-inject.mjs
+++ b/.cursor/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.cursor/skills/impeccable/scripts/live-inject.mjs
+++ b/.cursor/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.gemini/skills/impeccable/scripts/live-inject.mjs
+++ b/.gemini/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.gemini/skills/impeccable/scripts/live-inject.mjs
+++ b/.gemini/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.github/skills/impeccable/scripts/live-inject.mjs
+++ b/.github/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.github/skills/impeccable/scripts/live-inject.mjs
+++ b/.github/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.kiro/skills/impeccable/scripts/live-inject.mjs
+++ b/.kiro/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.kiro/skills/impeccable/scripts/live-inject.mjs
+++ b/.kiro/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.opencode/skills/impeccable/scripts/live-inject.mjs
+++ b/.opencode/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.opencode/skills/impeccable/scripts/live-inject.mjs
+++ b/.opencode/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.pi/skills/impeccable/scripts/live-inject.mjs
+++ b/.pi/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.pi/skills/impeccable/scripts/live-inject.mjs
+++ b/.pi/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.qoder/skills/impeccable/scripts/live-inject.mjs
+++ b/.qoder/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.qoder/skills/impeccable/scripts/live-inject.mjs
+++ b/.qoder/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.rovodev/skills/impeccable/scripts/live-inject.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.rovodev/skills/impeccable/scripts/live-inject.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.trae-cn/skills/impeccable/scripts/live-inject.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.trae-cn/skills/impeccable/scripts/live-inject.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/.trae/skills/impeccable/scripts/live-inject.mjs
+++ b/.trae/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/.trae/skills/impeccable/scripts/live-inject.mjs
+++ b/.trae/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/plugin/skills/impeccable/scripts/live-inject.mjs
+++ b/plugin/skills/impeccable/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/plugin/skills/impeccable/scripts/live-inject.mjs
+++ b/plugin/skills/impeccable/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/skill/scripts/live-inject.mjs
+++ b/skill/scripts/live-inject.mjs
@@ -368,8 +368,26 @@ function buildTagBlock(syntax, port, filePath) {
   );
 }
 
+function detectLineEnding(content) {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\r')) return '\r';
+  return '\n';
+}
+
+function normalizeLineEndings(content, lineEnding) {
+  return lineEnding === '\n' ? content : content.replace(/\n/g, lineEnding);
+}
+
+function readLineEndingAt(content, index) {
+  if (content[index] === '\r' && content[index + 1] === '\n') return '\r\n';
+  if (content[index] === '\n') return '\n';
+  if (content[index] === '\r') return '\r';
+  return '';
+}
+
 function insertTag(content, config, port, filePath) {
-  const block = buildTagBlock(config.commentSyntax, port, filePath);
+  const lineEnding = detectLineEnding(content);
+  const block = normalizeLineEndings(buildTagBlock(config.commentSyntax, port, filePath), lineEnding);
   // insertBefore: match the LAST occurrence. Anchors like `</body>` naturally
   // belong at the end, and the same literal can appear earlier in code blocks
   // within rendered documentation pages.
@@ -383,14 +401,14 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Preserve an existing trailing newline if the anchor already has one.
   // Slice the remainder from the original anchor offset, not prefix.length:
   // in the no-newline case prefix is one char longer than the anchor (the
   // appended '\n'), so slicing by prefix.length would drop the first real
   // character after the anchor (#227).
-  const hadNewline = content[after] === '\n';
-  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  const rest = content.slice(hadNewline ? after + 1 : after);
+  const existingNewline = readLineEndingAt(content, after);
+  const prefix = content.slice(0, after) + (existingNewline || lineEnding);
+  const rest = content.slice(after + existingNewline.length);
   return prefix + block + rest;
 }
 
@@ -407,8 +425,8 @@ function insertTag(content, config, port, filePath) {
  */
 function removeTag(content, _syntax) {
   const patterns = [
-    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\n|$)?)/,
-    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\n|$)?)/,
+    /([ \t]*)<!--\s*impeccable-live-start\s*-->[\s\S]*?<!--\s*impeccable-live-end\s*-->([ \t]*(?:\r\n|\n|\r|$)?)/,
+    /([ \t]*)\{\/\*\s*impeccable-live-start\s*\*\/\}[\s\S]*?\{\/\*\s*impeccable-live-end\s*\*\/\}([ \t]*(?:\r\n|\n|\r|$)?)/,
   ];
   for (const pat of patterns) {
     let changed = false;
@@ -416,7 +434,7 @@ function removeTag(content, _syntax) {
     do {
       content = next;
       next = content.replace(pat, (_match, leadingIndent, trailing = '') => {
-        if (trailing.includes('\n')) return leadingIndent;
+        if (/[\r\n]/.test(trailing)) return leadingIndent;
         return leadingIndent || trailing || '';
       });
       if (next !== content) changed = true;

--- a/skill/scripts/live-inject.mjs
+++ b/skill/scripts/live-inject.mjs
@@ -383,9 +383,15 @@ function insertTag(content, config, port, filePath) {
   const idx = content.indexOf(config.insertAfter);
   if (idx === -1) return content;
   const after = idx + config.insertAfter.length;
-  // Preserve a single trailing newline if the anchor didn't end with one
-  const prefix = content[after] === '\n' ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
-  return prefix + block + content.slice(prefix.length);
+  // Preserve a single trailing newline if the anchor didn't end with one.
+  // Slice the remainder from the original anchor offset, not prefix.length:
+  // in the no-newline case prefix is one char longer than the anchor (the
+  // appended '\n'), so slicing by prefix.length would drop the first real
+  // character after the anchor (#227).
+  const hadNewline = content[after] === '\n';
+  const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
+  const rest = content.slice(hadNewline ? after + 1 : after);
+  return prefix + block + rest;
 }
 
 /**

--- a/tests/live-inject.test.mjs
+++ b/tests/live-inject.test.mjs
@@ -10,6 +10,7 @@ import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+import { insertTag } from '../skill/scripts/live-inject.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INJECT = resolve(__dirname, '..', 'skill/scripts/live-inject.mjs');
@@ -340,5 +341,32 @@ const title = 'Test';
 
     const after = readFileSync(file, 'utf-8');
     assert.equal(after, original, 'column-0 anchor should round-trip cleanly too');
+  });
+});
+
+describe('live-inject — insertTag preserves the character after an insertAfter anchor (#227)', () => {
+  it('does not drop the first character when the anchor has no trailing newline', () => {
+    const result = insertTag(
+      '<head>X</head>',
+      { insertAfter: '<head>', commentSyntax: 'html' },
+      8400,
+      'index.html'
+    );
+
+    assert.ok(
+      result.includes('X</head>'),
+      `the character immediately after <head> must survive injection, got:\n${result}`
+    );
+  });
+
+  it('keeps the anchor-followed-by-newline case intact', () => {
+    const result = insertTag(
+      '<head>\n  <title>X</title>\n</head>',
+      { insertAfter: '<head>', commentSyntax: 'html' },
+      8400,
+      'index.html'
+    );
+
+    assert.ok(result.includes('<title>X</title>'), 'newline case must be unaffected');
   });
 });

--- a/tests/live-inject.test.mjs
+++ b/tests/live-inject.test.mjs
@@ -10,7 +10,6 @@ import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
-import { insertTag } from '../skill/scripts/live-inject.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INJECT = resolve(__dirname, '..', 'skill/scripts/live-inject.mjs');
@@ -342,31 +341,52 @@ const title = 'Test';
     const after = readFileSync(file, 'utf-8');
     assert.equal(after, original, 'column-0 anchor should round-trip cleanly too');
   });
-});
 
-describe('live-inject — insertTag preserves the character after an insertAfter anchor (#227)', () => {
-  it('does not drop the first character when the anchor has no trailing newline', () => {
-    const result = insertTag(
-      '<head>X</head>',
-      { insertAfter: '<head>', commentSyntax: 'html' },
-      8400,
-      'index.html'
-    );
+  it('preserves the character after an insertAfter anchor with no trailing newline (#227)', () => {
+    const original = '<head>X</head>';
+    const file = join(tmp, 'compact.html');
+    writeFileSync(file, original);
+
+    const cfgPath = join(tmp, 'config.json');
+    writeFileSync(cfgPath, JSON.stringify({
+      files: ['compact.html'],
+      insertAfter: '<head>',
+      commentSyntax: 'html',
+    }));
+
+    runInject(tmp, cfgPath, ['--port', '8400']);
+    const afterInject = readFileSync(file, 'utf-8');
 
     assert.ok(
-      result.includes('X</head>'),
-      `the character immediately after <head> must survive injection, got:\n${result}`
+      afterInject.includes('<!-- impeccable-live-end -->\nX</head>'),
+      `the character immediately after <head> must survive injection, got:\n${afterInject}`
     );
   });
 
-  it('keeps the anchor-followed-by-newline case intact', () => {
-    const result = insertTag(
-      '<head>\n  <title>X</title>\n</head>',
-      { insertAfter: '<head>', commentSyntax: 'html' },
-      8400,
-      'index.html'
+  it('round-trips insertAfter files with CRLF newlines', () => {
+    const original = '<html>\r\n<head>\r\n  <title>X</title>\r\n</head>\r\n<body>Content</body>\r\n</html>\r\n';
+    const file = join(tmp, 'crlf.html');
+    writeFileSync(file, original);
+
+    const cfgPath = join(tmp, 'config.json');
+    writeFileSync(cfgPath, JSON.stringify({
+      files: ['crlf.html'],
+      insertAfter: '<head>',
+      commentSyntax: 'html',
+    }));
+
+    runInject(tmp, cfgPath, ['--port', '8400']);
+    const afterInject = readFileSync(file, 'utf-8');
+
+    assert.ok(
+      afterInject.includes(
+        '<head>\r\n<!-- impeccable-live-start -->\r\n<script src="http://localhost:8400/live.js"></script>\r\n<!-- impeccable-live-end -->\r\n  <title>X</title>'
+      ),
+      `CRLF insertAfter should keep CRLF boundaries around the injected block, got:\n${JSON.stringify(afterInject)}`
     );
 
-    assert.ok(result.includes('<title>X</title>'), 'newline case must be unaffected');
+    runInject(tmp, cfgPath, ['--remove']);
+    const afterRemove = readFileSync(file, 'utf-8');
+    assert.equal(afterRemove, original, 'CRLF file should round-trip cleanly after remove');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #227.

`insertTag()` in `skill/scripts/live-inject.mjs` has an off-by-one in its
`insertAfter` branch. After computing `after = idx + config.insertAfter.length`,
it builds `prefix` (appending a `\n` when the anchor isn't already followed by
one) and returns `prefix + block + content.slice(prefix.length)`.

In the no-trailing-newline case `prefix.length === after + 1`, so
`content.slice(prefix.length)` skips the first real character after the anchor —
e.g. injecting after `<head>` into `<head>X…` drops the `X`, corrupting the
entry file during live-mode injection.

## Fix

Slice the remainder from the original anchor offset instead of `prefix.length`:

```js
const hadNewline = content[after] === '\n';
const prefix = hadNewline ? content.slice(0, after + 1) : content.slice(0, after) + '\n';
const rest = content.slice(hadNewline ? after + 1 : after);
return prefix + block + rest;
```

The `insertBefore` branch and the anchor-already-followed-by-`\n` case are
unchanged.

## Tests

Adds two cases to `tests/live-inject.test.mjs` exercising `insertTag` directly:
- the no-trailing-newline case (`<head>X</head>`) — fails before the fix, passes
  after;
- the already-followed-by-newline case — guards against regressions in the
  unaffected branch.

`node --test tests/live-inject.test.mjs` → 12/12 passing.

## Generated bundles

Regenerated the tracked per-agent copies (`.agents`, `.claude`, `.cursor`,
`.gemini`, `.github/skills`, `.kiro`, `.opencode`, `.pi`, `.qoder`, `.rovodev`,
`.trae`, `.trae-cn`, `plugin/`) so the fix ships everywhere and the
"Verify generated tracked outputs" CI check stays green. Each copy is
byte-identical to the source.

## Credit

Root-cause analysis (and the suggested fix) came from the #227 reporter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deterministic edits to user HTML entry files during live mode; wrong slicing could corrupt pages, though scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **#227** in `live-inject.mjs`: when using `insertAfter` and the anchor is not followed by a newline (e.g. `<head>X</head>`), the old logic sliced the remainder at `prefix.length` and **dropped the first character** after the anchor. The remainder is now taken from the anchor offset (`after + existingNewline.length`).
> 
> Also adds **line-ending awareness**: detect CRLF/LF/CR in the file, normalize the injected block to match, and broaden `removeTag` patterns so inject/remove round-trips on Windows-style files.
> 
> The same script update is copied to all tracked per-agent `live-inject.mjs` bundles. **Tests** cover the compact-anchor case and CRLF inject/remove.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ebf4355d355a868e464f48ef1052e4da9f771d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->