### PR TITLE
Fix Firefox DevTools extension paths

### DIFF
--- a/extension/devtools/devtools.js
+++ b/extension/devtools/devtools.js
@@ -8,13 +8,13 @@
 
 chrome.devtools.panels.create(
   'Impeccable',
-  'icons/icon-32.png',
-  'devtools/panel.html'
+  '/icons/icon-32.png',
+  '/devtools/panel.html'
 );
 
 // Sidebar pane in the Elements panel: shows findings for the currently selected element
 chrome.devtools.panels.elements.createSidebarPane('Impeccable', (sidebar) => {
-  sidebar.setPage('devtools/sidebar.html');
+  sidebar.setPage('/devtools/sidebar.html');
   sidebar.setHeight('200px');
 });
 

--- a/scripts/test-suites.mjs
+++ b/scripts/test-suites.mjs
@@ -68,7 +68,7 @@ export const SUITES = {
       /^extension\/(background|content|detector|devtools|popup|manifest\.json)/,
       /^scripts\/(benchmark-detector|build-browser-detector|build-extension)\.js$/,
       /^site\/(pages\/detector|public\/antipattern|data\/anti-patterns-catalog\.js)/,
-      /^tests\/(detect-antipatterns|fixtures\/antipatterns)/,
+      /^tests\/(detect-antipatterns|extension-build|fixtures\/antipatterns)/,
     ],
     commands: [
       {
@@ -81,6 +81,7 @@ export const SUITES = {
       {
         runner: 'node',
         files: [
+          'tests/extension-build.test.mjs',
           'tests/detect-antipatterns-fixtures.test.mjs',
           'tests/detect-antipatterns-browser.test.mjs',
         ],

--- a/tests/extension-build.test.mjs
+++ b/tests/extension-build.test.mjs
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('extension DevTools packaging', () => {
+  it('uses extension-root paths for DevTools panel pages', () => {
+    const source = readFileSync(path.join(ROOT, 'extension/devtools/devtools.js'), 'utf-8');
+
+    assert.match(
+      source,
+      /chrome\.devtools\.panels\.create\(\s*['"]Impeccable['"],\s*['"]\/icons\/icon-32\.png['"],\s*['"]\/devtools\/panel\.html['"]\s*\)/s,
+      'Firefox resolves DevTools URLs relative to devtools.html unless they start at the extension root',
+    );
+    assert.match(source, /sidebar\.setPage\(['"]\/devtools\/sidebar\.html['"]\)/);
+    assert.doesNotMatch(source, /['"]devtools\/(?:panel|sidebar)\.html['"]/);
+    assert.doesNotMatch(source, /['"]icons\/icon-32\.png['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Firefox temporary-extension DevTools failure where the Impeccable tab tried to load:

`moz-extension://.../devtools/devtools/panel.html`

Firefox resolves DevTools panel URLs relative to the current extension page unless they start at the extension root. The Chrome package tolerated the previous relative paths, but Firefox needs root-relative paths.

Changes:

- use root-relative paths for the DevTools panel icon and panel page
- use a root-relative path for the Elements sidebar page
- add a regression test so extension DevTools paths stay Firefox-compatible

## Validation

- `node --test tests/extension-build.test.mjs`
- `node --test tests/test-suites.test.mjs`
- `bun run build:extension`
- `npx --yes web-ext@8 lint --source-dir dist/extension-firefox` (0 errors, existing innerHTML warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small packaging-path change in DevTools registration plus a static source regression test; no auth, data, or runtime logic changes.
> 
> **Overview**
> Fixes Firefox DevTools loading the Impeccable panel and Elements sidebar under doubled paths (e.g. `devtools/devtools/panel.html`) by switching DevTools registration URLs in `extension/devtools/devtools.js` to **extension-root** paths (`/icons/icon-32.png`, `/devtools/panel.html`, `/devtools/sidebar.html`). Chrome still accepts the old relative form; Firefox requires the leading slash.
> 
> Adds **`tests/extension-build.test.mjs`** to assert those root-relative paths and forbid the old relative `devtools/...` and `icons/...` strings, and hooks that test into the **detector** suite in `scripts/test-suites.mjs` so CI runs it with other extension/detector changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 800c3060374674a16bc06a2c904a7bb887952caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->