### PR TITLE
fix(cli): replace extract-zip with node-stream-zip to fix silent install failure on Node v24.16.0+

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,9 +8,9 @@
         "css-select": "^7.0.0",
         "css-tree": "^3.2.1",
         "domutils": "^4.0.2",
-        "extract-zip": "^2.0.1",
         "htmlparser2": "^12.0.0",
         "marked": "^18.0.5",
+        "node-stream-zip": "^1.15.0",
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.71",
@@ -357,8 +357,6 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
-
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
@@ -547,8 +545,6 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
     "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
@@ -591,8 +587,6 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
-    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
@@ -606,8 +600,6 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
-
-    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -644,8 +636,6 @@
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
 
@@ -897,6 +887,8 @@
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
+    "node-stream-zip": ["node-stream-zip@1.15.0", "", {}, "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
@@ -945,8 +937,6 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
-
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -972,8 +962,6 @@
     "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "puppeteer": ["puppeteer@25.1.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.4", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1624250", "lilconfig": "^3.1.3", "puppeteer-core": "25.1.0", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/puppeteer/node/cli.js" } }, "sha512-7L6/0JM7XStK99lIL4xQySyNEXNfII6pk0BxkI5kKBTOhR7AsoQiv067YTsE/rIXxQiq9ajlO4WcqBjS/FWK1A=="],
 
@@ -1207,8 +1195,6 @@
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
-    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
-
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
@@ -1260,8 +1246,6 @@
     "wrangler/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { get } from 'node:https';
 import { createHash } from 'node:crypto';
 import { tmpdir, homedir } from 'node:os';
-import extract from 'extract-zip';
+import StreamZip from 'node-stream-zip';
 import { getHookConsent, setHookConsent } from '../../lib/impeccable-config.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -437,6 +437,25 @@ function hashSkillsDir(skillsDir) {
 }
 
 /**
+ * Extract every entry of a zip archive into `targetDir`. This replaces
+ * `extract-zip`, whose `yauzl`/`fd-slicer` read stack stalls on Node v24.16.0 /
+ * v26.1.0+ (nodejs/node#63487): extraction stops after a handful of entries,
+ * its promise never settles, and -- because nothing else keeps the event loop
+ * alive -- the CLI exits 0 with no error, so `npx impeccable install` silently
+ * installs nothing. `node-stream-zip` reads entries directly with `fs` and is
+ * unaffected on every Node version.
+ */
+async function extractZip(zipPath, targetDir) {
+  const zip = new StreamZip.async({ file: zipPath });
+  try {
+    // `null` extracts the whole archive; resolves with the entry count.
+    await zip.extract(null, targetDir);
+  } finally {
+    await zip.close();
+  }
+}
+
+/**
  * Download the universal bundle to a temp dir and return its path.
  * Caller is responsible for cleanup.
  */
@@ -448,7 +467,7 @@ async function downloadAndExtractBundle() {
   const tmpDir = join(tmpdir(), `impeccable-update-${Date.now()}`);
   await downloadFile(`${API_BASE}/api/download/bundle/universal`, tmpZip);
   mkdirSync(tmpDir, { recursive: true });
-  await extract(tmpZip, { dir: tmpDir });
+  await extractZip(tmpZip, tmpDir);
   rmSync(tmpZip, { force: true });
   return tmpDir;
 }
@@ -467,7 +486,7 @@ async function copyOrExtractLocalBundle(sourceValue) {
     return tmpDir;
   }
 
-  await extract(source, { dir: tmpDir });
+  await extractZip(source, tmpDir);
   return tmpDir;
 }
 
@@ -1701,6 +1720,7 @@ export {
   copyProviderSkills,
   decideHookInstall,
   expectedHookDests,
+  extractZip,
   formatInstallDetectionLines,
   linkProviderSkills,
   mergeHookManifests,

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "css-select": "^7.0.0",
     "css-tree": "^3.2.1",
     "domutils": "^4.0.2",
-    "extract-zip": "^2.0.1",
     "htmlparser2": "^12.0.0",
-    "marked": "^18.0.5"
+    "marked": "^18.0.5",
+    "node-stream-zip": "^1.15.0"
   },
   "optionalDependencies": {
     "puppeteer": "^25.1.0"

--- a/tests/zip.test.mjs
+++ b/tests/zip.test.mjs
@@ -7,17 +7,21 @@
  * 0-byte universal.zip and every `npx impeccable install` failed with
  * "End-of-central-directory signature not found". Nothing covered the zip
  * writer, so the suite stayed green. These tests exercise the real writer and
- * round-trip through extract-zip (the same unpacker the CLI uses).
+ * round-trip through the same unpacker the CLI uses (extractZip, backed by
+ * node-stream-zip). The many-file extraction test additionally guards the
+ * Node v24.16.0 / v26.1.0+ silent partial-extraction regression
+ * (nodejs/node#63487) that made `npx impeccable install` exit 0 after writing
+ * only a fraction of the bundle.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, statSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, statSync, rmSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import extract from 'extract-zip';
 
 import { createProviderZip, createAllZips } from '../scripts/lib/zip.js';
+import { extractZip } from '../cli/bin/commands/skills.mjs';
 
 function makeUniversalTree(distDir) {
   const skillDir = join(distDir, 'universal', 'skills', 'impeccable');
@@ -25,6 +29,54 @@ function makeUniversalTree(distDir) {
   writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: impeccable\n---\nhello\n');
   mkdirSync(join(distDir, 'universal', '.claude'), { recursive: true });
   writeFileSync(join(distDir, 'universal', '.claude', 'settings.json'), '{}\n');
+}
+
+/**
+ * Build a representative multi-provider universal tree carrying far more
+ * entries than the Node v24.16.0 extract-zip stall point (~31-72 files,
+ * depending on layout). The partial-extraction regression test relies on this
+ * so a regression in the unpacker fails the count assertion instead of
+ * shipping silently. Returns the number of files written.
+ */
+function makeLargeUniversalTree(distDir, { providers = ['.claude', '.cursor', '.agents', '.gemini', '.github', '.kiro'], scriptCount = 8, extraSkills = ['audit', 'polish'] } = {}) {
+  let files = 0;
+  for (const provider of providers) {
+    // The impeccable skill ships a scripts/ dir with many files, like the real
+    // bundle. This is where most entries live.
+    const scriptsDir = join(distDir, 'universal', provider, 'skills', 'impeccable', 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(join(distDir, 'universal', provider, 'skills', 'impeccable', 'SKILL.md'), `---\nname: impeccable\n---\nprovider ${provider}\n`);
+    files += 1;
+    for (let i = 0; i < scriptCount; i++) {
+      writeFileSync(join(scriptsDir, `script-${i}.mjs`), `// ${provider} script ${i}\nexport default ${i};\n`);
+      files += 1;
+    }
+    // Sibling skills with a SKILL.md + a reference file each.
+    for (const name of extraSkills) {
+      const refDir = join(distDir, 'universal', provider, 'skills', name, 'reference');
+      mkdirSync(refDir, { recursive: true });
+      writeFileSync(join(distDir, 'universal', provider, 'skills', name, 'SKILL.md'), `---\nname: ${name}\n---\n`);
+      writeFileSync(join(refDir, `${name}.md`), `# ${name} reference\n`);
+      files += 2;
+    }
+    // Provider root config (mirrors .claude/settings.json, .cursor/hooks.json).
+    writeFileSync(join(distDir, 'universal', provider, 'config.json'), '{}\n');
+    files += 1;
+  }
+  return files;
+}
+
+/** Count regular files under a directory tree (used to assert full extraction). */
+function countFiles(dir) {
+  let count = 0;
+  const walk = (d) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      if (entry.isDirectory()) walk(join(d, entry.name));
+      else count += 1;
+    }
+  };
+  walk(dir);
+  return count;
 }
 
 describe('release bundle zip writer', () => {
@@ -38,12 +90,43 @@ describe('release bundle zip writer', () => {
     assert.ok(existsSync(zipPath), 'universal.zip was not created');
     assert.ok(statSync(zipPath).size > 0, 'universal.zip is empty (0 bytes)');
 
-    // Round-trip: the CLI downloads this exact artifact and extract()s it.
+    // Round-trip through the same unpacker the CLI uses (extractZip). The CLI
+    // downloads this exact artifact and extractZip()s it.
     const out = mkdtempSync(join(tmpdir(), 'imp-unzip-'));
-    await extract(zipPath, { dir: out });
+    await extractZip(zipPath, out);
     const skillMd = join(out, 'skills', 'impeccable', 'SKILL.md');
     assert.ok(existsSync(skillMd), 'unpacked bundle is missing skills/impeccable/SKILL.md');
     assert.match(readFileSync(skillMd, 'utf8'), /name: impeccable/);
+
+    rmSync(dist, { recursive: true, force: true });
+    rmSync(out, { recursive: true, force: true });
+  });
+
+  it('REGRESSION: extracts every entry of a many-file bundle (no silent partial extraction on Node v24.16.0+)', async () => {
+    // Guards nodejs/node#63487: extract-zip's yauzl/fd-slicer read stack stalls
+    // on Node v24.16.0 / v26.1.0+ (pause/resume on a destroyed stream became a
+    // no-op), so extraction stops early, its promise never settles, and --
+    // because nothing else keeps the event loop alive -- `npx impeccable install`
+    // exits 0 with no error, silently installing a fraction of the bundle. This
+    // fixture carries 84 files (well past the ~31-72 entry stall point), so a
+    // return to extract-zip (or any unpacker that stops early) fails the count
+    // assertion here instead of shipping silently. For continuous coverage of
+    // the Node-side regression, run this suite on a v24.16.0 CI job.
+    const dist = mkdtempSync(join(tmpdir(), 'imp-zip-large-'));
+    const written = makeLargeUniversalTree(dist);
+
+    await createAllZips(dist);
+
+    const zipPath = join(dist, 'universal.zip');
+    assert.ok(existsSync(zipPath), 'universal.zip was not created');
+    assert.ok(statSync(zipPath).size > 0, 'universal.zip is empty (0 bytes)');
+
+    // Round-trip through the exact code path downloadAndExtractBundle runs.
+    const out = mkdtempSync(join(tmpdir(), 'imp-unzip-large-'));
+    await extractZip(zipPath, out);
+
+    const extracted = countFiles(out);
+    assert.equal(extracted, written, `partial extraction: only ${extracted} of ${written} files unpacked`);
 
     rmSync(dist, { recursive: true, force: true });
     rmSync(out, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes #250. On Node v24.16.0 / v26.1.0+, `npx impeccable install` printed `Downloading impeccable skills...`, exited `0`, and installed nothing — the bundle downloaded fine but extraction stalled partway and its promise never settled, so the process exited clean with zero error.

Root cause is upstream ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)): a streams change made `pause()`/`resume()` no-ops on destroyed streams, which breaks `extract-zip`'s `yauzl`/`fd-slicer` read stack. Cypress, Playwright, and Electron hit the identical silent-exit-0 symptom.

This swaps `extract-zip` for `node-stream-zip` (pure JS, zero deps, reads with `fs` directly) across both extraction call sites (`downloadAndExtractBundle`, `copyOrExtractLocalBundle`). Also adds a regression test that extracts an 84-file bundle through the real unpacker and asserts every entry lands on disk, so a partial-extraction regression fails loudly instead of shipping silently.

Verified end-to-end on Node v24.16.0: the production bundle (1,194 files) now extracts completely.

## Type of change

- [ ] New command
- [ ] New / updated skill reference
- [ ] New anti-pattern guidance
- [x] Bug fix
- [ ] Documentation update
- [ ] Build system / tooling
- [ ] Other:

## Checklist

- [ ] Source files updated in `source/`
- [ ] `bun run build` ran successfully
- [x] `bun test` passes
- [x] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Kiro / OpenCode / Qoder)
- [ ] README / DEVELOP.md updated if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core install/unpack path for all users; behavior is intentionally different from extract-zip but is covered by round-trip and large-archive tests.
> 
> **Overview**
> Fixes silent **`npx impeccable install`** on Node v24.16.0+ where bundle download succeeded but **`extract-zip`** (yauzl/fd-slicer) stalled partway, the promise never settled, and the CLI exited **0** with nothing installed ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)).
> 
> **`extract-zip`** is removed in favor of **`node-stream-zip`** via a new **`extractZip`** helper used in **`downloadAndExtractBundle`** and **`copyOrExtractLocalBundle`**. **`extractZip`** is exported for tests. **`tests/zip.test.mjs`** now round-trips through **`extractZip`** and adds an **84-file** regression test that asserts every entry is extracted so partial unpack fails in CI instead of shipping silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf0f7baebc3a22b24786641e5e96e9c02e033da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->