### PR TITLE
[codex] Fix live page editable focus handling

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6489,10 +6489,13 @@
     ) {
       return;
     }
+    if (isPageEditableElement(deepActive) && !isInlineEditActive(deepActive)) {
+      return;
+    }
     // While a contenteditable text-leaf is focused, let the browser handle
     // all keys except Escape. Escape cancels the current edit (restores
     // original text) and blurs without saving, staying in CONFIGURING.
-    if (e.target.isContentEditable && inlineEditRows.some((r) => r.el === e.target)) {
+    if (e.target.isContentEditable && isInlineEditActive(e.target)) {
       if (e.key !== 'Escape') return;
       e.preventDefault();
       e.stopPropagation();
@@ -8312,6 +8315,21 @@ void main() {
       && !steerLocked;
   }
 
+  function isPageEditableElement(el) {
+    if (!el || own(el)) return false;
+    if (/^(INPUT|TEXTAREA|SELECT)$/.test(el.tagName || '')) return true;
+    return !!el.isContentEditable;
+  }
+
+  function isInlineEditActive(el) {
+    return !!el && inlineEditRows.some((r) => r.el === el);
+  }
+
+  function isPageEditableActive() {
+    const active = activeElementDeep();
+    return isPageEditableElement(active) && !isInlineEditActive(active);
+  }
+
   function pageHasHostTextSelection() {
     const sel = window.getSelection?.();
     if (!sel || sel.isCollapsed) return false;
@@ -8325,6 +8343,7 @@ void main() {
   function shouldSteerAutoFocus() {
     return shouldFocusSteerChat()
       && !steerFocusSuspended
+      && !isPageEditableActive()
       && performance.now() >= steerFocusPauseUntil;
   }
 

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -154,6 +154,24 @@ describe('live-browser.js regression guards', () => {
     );
   });
 
+  it('does not autofocus the steering chat while a page editable is focused', () => {
+    assert.match(
+      SOURCE,
+      /function isPageEditableElement\(el\) \{[\s\S]{0,160}?own\(el\)[\s\S]{0,160}?\^\(INPUT\|TEXTAREA\|SELECT\)\$[\s\S]{0,80}?el\.isContentEditable/,
+      'page-owned inputs, textareas, selects, and contenteditables must be recognized before steer focus recovery runs',
+    );
+    assert.match(
+      SOURCE,
+      /function isPageEditableActive\(\) \{[\s\S]{0,120}?activeElementDeep\(\)[\s\S]{0,120}?isPageEditableElement\(active\) && !isInlineEditActive\(active\)/,
+      'auto-focus recovery must check the deep active element instead of only host text selection',
+    );
+    assert.match(
+      SOURCE,
+      /function shouldSteerAutoFocus\(\) \{[\s\S]{0,160}?&& !isPageEditableActive\(\)/,
+      'steer chat auto-focus must back off while the page owns an editable caret',
+    );
+  });
+
   it('pins edit badge button metrics instead of inheriting host button chrome', () => {
     const start = SOURCE.indexOf('const calloutStyle = (color, borderColor) => ({');
     const end = SOURCE.indexOf('    });', start);
@@ -342,6 +360,22 @@ describe('live-browser.js regression guards', () => {
       SOURCE,
       /&& !shouldPassthroughElementNav\(deepActive, e\)/,
       'global input guard must honor empty-input arrow passthrough',
+    );
+  });
+
+  it('lets page editables keep Enter and arrow keydown events', () => {
+    const start = SOURCE.indexOf('function handleKeyDown(e)');
+    const pendingApplyStart = SOURCE.indexOf('if (pendingApplyInFlight)', start);
+    const guardSource = SOURCE.slice(start, pendingApplyStart);
+    assert.match(
+      guardSource,
+      /isPageEditableElement\(deepActive\) && !isInlineEditActive\(deepActive\)[\s\S]{0,40}?return;/,
+      'page-owned editables must short-circuit global key handling before variant navigation or accept handling',
+    );
+    assert.match(
+      guardSource,
+      /e\.target\.isContentEditable && isInlineEditActive\(e\.target\)/,
+      'impeccable inline edit rows must keep their existing Escape-cancel path',
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes #241.

Live mode now respects page-owned editable controls while the steer bar is active. Page inputs, textareas, selects, and contenteditable editors keep focus instead of being refocused back to the steer input, and Enter/arrow keys inside those controls no longer trigger variant accept or cycling.

## Root Cause

The steer focus recovery path only checked live-mode state, selection, and steer suspension. A collapsed caret inside a page editable did not count as host text selection, so mouseup recovery could pull focus back to the steer chat. The global keydown handler also only skipped Impeccable-owned inputs, allowing page-owned editables to fall through into live-mode shortcuts.

## Validation

- `node --test tests/live-browser-regression.test.mjs`
- `node --test tests/live-browser-source.test.mjs`
- `bun run build`
- `bun run test` outside sandbox
- `bun run test:live-e2e` outside sandbox

Note: sandboxed browser/Playwright launches hit this repo's documented macOS sandbox limitation, so the authoritative browser suites were rerun outside the sandbox.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live-mode focus recovery and global key routing in a large browser script; wrong classification could still steal focus or block Impeccable shortcuts, but scope is narrow and covered by regression tests.
> 
> **Overview**
> Live mode now treats **page-owned** inputs, textareas, selects, and contenteditables as off-limits for steer-bar focus recovery and global shortcut handling, while **Impeccable inline edit rows** keep their existing Escape-cancel behavior via a shared `isInlineEditActive` check.
> 
> **Focus:** `shouldSteerAutoFocus` skips recovery when the deep active element is a page editable (but not an inline Impeccable edit), so the steer chat no longer steals the caret from collapsed selections in host controls.
> 
> **Keyboard:** `handleKeyDown` returns early for those same page editables so Enter and arrows stay with the page instead of variant accept/cycle shortcuts.
> 
> Regression tests in `live-browser-regression.test.mjs` lock in the new helpers and guard ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9773d7bcdc50340233e7d4d046b629c2478128d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->