### PR TITLE
Fix: surface scan failures in extension popup for local files

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -58,7 +58,7 @@ async function buildScanConfig() {
 // engages with the extension (DevTools panel/sidebar opened, popup scan, etc).
 async function ensureContentScriptInjected(tabId) {
   const state = getState(tabId);
-  if (state.csInjected) return true;
+  if (state.csInjected) return { ok: true };
   try {
     await chrome.scripting.executeScript({
       target: { tabId },
@@ -66,16 +66,29 @@ async function ensureContentScriptInjected(tabId) {
       injectImmediately: true,
     });
     state.csInjected = true;
-    return true;
+    return { ok: true };
   } catch (err) {
-    // Common cause: chrome:// pages, the web store, or other restricted URLs
-    return false;
+    // Common cause: chrome:// pages, the web store, the Chrome Web Store, or
+    // file:// pages when "Allow access to file URLs" is off. Keep the real
+    // error so the UI can explain what happened.
+    return { ok: false, error: err?.message || String(err) };
   }
 }
 
 async function sendScanToTab(tabId) {
-  const ok = await ensureContentScriptInjected(tabId);
-  if (!ok) return;
+  const { ok, error } = await ensureContentScriptInjected(tabId);
+  if (!ok) {
+    // Injection was blocked. Tell an open popup why so it can stop showing
+    // "Scanning..." and surface a hint. The popup may be closed, so ignore
+    // delivery failures.
+    let url = '';
+    try { url = (await chrome.tabs.get(tabId))?.url || ''; } catch { /* tab gone */ }
+    const message = url.startsWith('file:')
+      ? 'Can\u2019t scan local files. Enable \u201CAllow access to file URLs\u201D for Impeccable in chrome://extensions.'
+      : (error || 'This page can\u2019t be scanned.');
+    chrome.runtime.sendMessage({ action: 'scan-failed', tabId, message }).catch(() => {});
+    return;
+  }
   const config = await buildScanConfig();
   chrome.tabs.sendMessage(tabId, { action: 'scan', config }).catch(() => {});
 }

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -85,7 +85,7 @@ async function sendScanToTab(tabId) {
     try { url = (await chrome.tabs.get(tabId))?.url || ''; } catch { /* tab gone */ }
     const message = url.startsWith('file:')
       ? 'Can\u2019t scan local files. Enable \u201CAllow access to file URLs\u201D for Impeccable in chrome://extensions.'
-      : (error || 'This page can\u2019t be scanned.');
+      : `Couldn\u2019t scan this page${error ? `: ${error}` : '.'}`;
     chrome.runtime.sendMessage({ action: 'scan-failed', tabId, message }).catch(() => {});
     return;
   }

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -63,6 +63,17 @@ h1 {
   margin-bottom: 16px;
 }
 
+.scan-error {
+  margin: -8px 0 16px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: oklch(70% 0.13 30);
+}
+
+.scan-error[hidden] {
+  display: none;
+}
+
 .btn {
   display: block;
   width: 100%;

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -20,6 +20,8 @@
     <button class="btn btn-secondary" id="btn-toggle">Hide overlays</button>
   </div>
 
+  <p class="scan-error" id="scan-error" hidden></p>
+
   <footer>
     <a href="https://impeccable.style" id="link-site">impeccable.style</a>
   </footer>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -47,7 +47,7 @@ chrome.runtime.onMessage.addListener((msg) => {
   if (msg.action === 'scan-failed') {
     btnScan.textContent = 'Scan page';
     btnScan.disabled = false;
-    scanError.textContent = msg.message || 'This page can\u2019t be scanned.';
+    scanError.textContent = msg.message || 'Couldn\u2019t scan this page.';
     scanError.hidden = false;
   }
   if (msg.action === 'overlays-toggled-broadcast') {

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -8,6 +8,7 @@ const countNumber = document.getElementById('count-number');
 const countLabel = document.getElementById('count-label');
 const btnScan = document.getElementById('btn-scan');
 const btnToggle = document.getElementById('btn-toggle');
+const scanError = document.getElementById('scan-error');
 
 let overlaysVisible = true;
 
@@ -41,6 +42,13 @@ chrome.runtime.onMessage.addListener((msg) => {
     countLabel.textContent = count === 1 ? 'anti-pattern' : 'anti-patterns';
     btnScan.textContent = 'Scan page';
     btnScan.disabled = false;
+    scanError.hidden = true;
+  }
+  if (msg.action === 'scan-failed') {
+    btnScan.textContent = 'Scan page';
+    btnScan.disabled = false;
+    scanError.textContent = msg.message || 'This page can\u2019t be scanned.';
+    scanError.hidden = false;
   }
   if (msg.action === 'overlays-toggled-broadcast') {
     overlaysVisible = msg.visible;
@@ -51,6 +59,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 btnScan.addEventListener('click', async () => {
   const tabId = await getActiveTabId();
   if (!tabId) return;
+  scanError.hidden = true;
   btnScan.textContent = 'Scanning...';
   btnScan.disabled = true;
   chrome.runtime.sendMessage({ action: 'scan', tabId });

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -11,6 +11,10 @@ const btnToggle = document.getElementById('btn-toggle');
 const scanError = document.getElementById('scan-error');
 
 let overlaysVisible = true;
+// The popup only ever reflects the active tab. Broadcasts from the service
+// worker carry a tabId, so we cache the active one and ignore updates meant
+// for other tabs (e.g. a DevTools-driven rescan failing on a background tab).
+let activeTabId = null;
 
 async function getActiveTabId() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -30,11 +34,14 @@ function updateFromState(state) {
 async function loadState() {
   const tabId = await getActiveTabId();
   if (!tabId) return;
+  activeTabId = tabId;
   chrome.runtime.sendMessage({ action: 'get-state', tabId }, updateFromState);
 }
 
 // Listen for real-time updates from service worker
 chrome.runtime.onMessage.addListener((msg) => {
+  // Ignore broadcasts for a tab other than the one this popup is showing.
+  if (msg.tabId != null && activeTabId != null && msg.tabId !== activeTabId) return;
   if (msg.action === 'findings-updated') {
     const count = msg.findings?.reduce((sum, f) => sum + f.findings.length, 0) || 0;
     countNumber.textContent = String(count);
@@ -59,6 +66,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 btnScan.addEventListener('click', async () => {
   const tabId = await getActiveTabId();
   if (!tabId) return;
+  activeTabId = tabId;
   scanError.hidden = true;
   btnScan.textContent = 'Scanning...';
   btnScan.disabled = true;


### PR DESCRIPTION
## Summary

Fixes #258. Scanning a local `file://` page with "Allow access to file URLs" disabled (the default) left the extension popup stuck on `Scanning...` forever, because Chrome silently blocks content-script injection and the service worker returned without ever notifying the popup.

- `ensureContentScriptInjected()` now returns `{ ok, error }` instead of a bare boolean, preserving the real Chrome injection error.
- `sendScanToTab()` sends a typed `scan-failed` message on failure (replacing the previous faked empty `findings-updated`, which falsely showed `0 anti-patterns`). The message includes a permission hint **only** when the tab URL starts with `file:`; all other failures pass through the real Chrome error (`Couldn't scan this page: <error>`) so the user sees why.
- The popup renders the message as one small line under the buttons, resets the button, and clears the line on the next successful scan or new scan click.

Surgical by design: no DevTools panel/sidebar changes, no popup layout rewrite, no generated output (`extension/detector/`, `dist/`) committed.

### Note on the `{ ok, error }` return shape

`ensureContentScriptInjected()` used to return a bare boolean. It now returns `{ ok, error }` because a boolean can't carry the Chrome injection error out of the `catch`, and surfacing that error is the whole point of the popup hint. The helper is private with a **single caller** (`sendScanToTab`), updated in the same commit, so there's no regression. Heads up for future edits: `{ ok: false }` is a truthy object, so don't write `if (await ensureContentScriptInjected(...))` -- always destructure `{ ok }`.

## Screenshot

Local `file://` page with file-URL access off:

![Impeccable popup showing the file-URL permission hint](https://raw.githubusercontent.com/abdulwahabone/impeccable/pr-261-assets/popup-file-url-error.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized popup and service-worker messaging around scan injection failures; no changes to scan logic, auth, or data handling.
> 
> **Overview**
> Fixes the popup staying on **Scanning...** when Chrome blocks on-demand content-script injection (e.g. local `file://` pages without **Allow access to file URLs**).
> 
> The service worker’s `ensureContentScriptInjected` now returns `{ ok, error }` instead of a boolean, and `sendScanToTab` broadcasts a **`scan-failed`** message with a `file:`-specific permission hint or the real Chrome error for other blocked pages.
> 
> The popup adds a small error line, resets the scan button on failure, clears the line on a new scan or successful **`findings-updated`**, and ignores **`scan-failed`** / update broadcasts for tabs other than the active one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d55ef6aba7500d3875ada37cebf661c86dac3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->