### PR TITLE
Fix: make Chrome extension toolbar badge count anti-patterns

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -20,7 +20,9 @@ function getState(tabId) {
 
 function updateBadge(tabId) {
   const state = tabState.get(tabId);
-  const count = state?.findings?.length || 0;
+  // Count total anti-pattern findings (an element may carry several), matching
+  // the popup and DevTools panel rather than the flagged-element count.
+  const count = state?.findings?.reduce((sum, f) => sum + (f.findings?.length || 0), 0) || 0;
   const text = count > 0 ? String(count) : '';
   chrome.action.setBadgeText({ text, tabId }).catch(() => {});
   chrome.action.setBadgeBackgroundColor({ color: '#d6336c', tabId }).catch(() => {});


### PR DESCRIPTION
## Summary

The Chrome extension showed two different numbers for the same scan. The popup and DevTools panel count total anti-pattern findings, while the toolbar badge counted flagged elements (`state.findings.length`). On `https://impeccable.style/design-system/` that surfaced as 34 (popup/panel) vs 21 (toolbar badge).

Since all three surfaces are labeled "anti-patterns", and one element can carry several findings, the badge is the outlier. This makes the badge sum findings too, so all three agree (34 on that page).

## Change

- `extension/background/service-worker.js` `updateBadge`: `state.findings.length` -> sum of `f.findings.length`.

No detector/engine changes, no rule changes, no generated artifacts touched.

## Verification

- Live scan of the design-system page returns 21 flagged elements / 34 findings; popup and panel already showed 34, and the badge now matches.
- Lint clean.

After the fix, the toolbar badge and the popup both read 34:

![Popup and toolbar badge both showing 34 anti-patterns](https://github.com/abdulwahabone/impeccable/releases/download/issue-assets/impeccable-262-badge-34.png)

## Version bump

The `extension/manifest.json` version bump and changelog entry are intentionally **not** in this PR. Several extension PRs are in flight (this one, #261, #263), and bumping the manifest in each would collide on the same version line. The bump to `v1.2.1` and a single consolidated changelog entry live in the dedicated release PR #265, which merges after these feature PRs land.

Closes #262