### PR TITLE
Release: bump Chrome extension to v1.2.1

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Impeccable",
   "description": "Detect common UI anti-patterns in any web page",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "permissions": ["activeTab", "scripting", "storage", "webNavigation"],
   "host_permissions": ["<all_urls>"],
   "background": {

--- a/site/pages/changelog.astro
+++ b/site/pages/changelog.astro
@@ -173,6 +173,15 @@ import '../styles/changelog-faq-kinpaku.css';
       </ul>
     </article>
 
+    <article id="ext-v1.2.1" class="cf-entry">
+      <header class="cf-entry-head"><span class="cf-version">Extension v1.2.1</span><span class="cf-date">June 18, 2026</span></header>
+      <ul class="cf-items">
+        <li><strong>The toolbar badge count matches the popup and panel.</strong> The browser-action badge counted flagged elements while the popup and DevTools panel counted anti-pattern findings, so the same scan showed two numbers (for example 21 vs 34). One element can carry several findings; the badge now counts findings too, so every surface agrees. Reported in <a href="https://github.com/pbakaus/impeccable/issues/262" target="_blank" rel="noopener">#262</a>.</li>
+        <li><strong>Local file scans report why they fail.</strong> Scanning a <code>file://</code> page with file-URL access off used to leave the popup stuck on "Scanning…" forever. The popup now shows the real reason, with a permission hint for local files, and clears it on the next scan. Reported in <a href="https://github.com/pbakaus/impeccable/issues/258" target="_blank" rel="noopener">#258</a>.</li>
+        <li><strong>Popup matches the Kinpaku design system.</strong> The toolbar popup picks up the canonical carved-tile mark and light/dark theming that follows your system preference. Reported in <a href="https://github.com/pbakaus/impeccable/issues/260" target="_blank" rel="noopener">#260</a>.</li>
+      </ul>
+    </article>
+
     <article id="ext-v1.2.0" class="cf-entry">
       <header class="cf-entry-head"><span class="cf-version">Extension v1.2.0</span><span class="cf-date">June 14, 2026</span></header>
       <ul class="cf-items">


### PR DESCRIPTION
## Summary

Release bump for the Chrome extension. The recent extension fixes ship together as `v1.2.1`. Per `CLAUDE.md`, the manifest version bump and changelog entry are a release step, so they live here in one place instead of being duplicated across each feature PR (which would collide on the same version line).

- `extension/manifest.json`: `1.2.0` -> `1.2.1`.
- `site/pages/changelog.astro`: one consolidated `Extension v1.2.1` entry.

## Covers

- #264 - toolbar badge counts anti-pattern findings (fixes #262)
- #261 - surface local `file://` scan failures in the popup (fixes #258)
- #263 - popup Kinpaku theme + light/dark (fixes #260)

## Merge order

Draft until the three feature PRs above land on `main`. Merge this last, then tag with `bun run release:ext` (attaches `dist/extension.zip` for the Chrome Web Store upload).

No detector/engine changes; no generated artifacts committed.

Made with [Cursor](https://cursor.com)