### PR TITLE
Fix live toast stale callback race

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -7916,7 +7916,7 @@ void main() {
     const barTopFromBottom = barRect && barRect.height > 0
       ? Math.max(16, window.innerHeight - barRect.top + 12)
       : 16;
-    toastEl = el('div', {
+    const currentToast = el('div', {
       position: 'fixed', bottom: barTopFromBottom + 'px', left: '50%',
       transform: 'translateX(-50%) translateY(8px)',
       background: C.ink, color: C.white,
@@ -7926,19 +7926,24 @@ void main() {
       transition: 'opacity 0.25s ' + EASE + ', transform 0.25s ' + EASE,
       pointerEvents: 'none', maxWidth: '420px', textAlign: 'center',
     });
-    toastEl.id = PREFIX + '-toast';
-    toastEl.textContent = message;
-    uiAppend(toastEl);
+    toastEl = currentToast;
+    currentToast.id = PREFIX + '-toast';
+    currentToast.textContent = message;
+    uiAppend(currentToast);
     requestAnimationFrame(() => {
-      toastEl.style.opacity = '1';
-      toastEl.style.transform = 'translateX(-50%) translateY(0)';
+      if (toastEl !== currentToast) return;
+      currentToast.style.opacity = '1';
+      currentToast.style.transform = 'translateX(-50%) translateY(0)';
     });
     setTimeout(() => {
-      if (toastEl) {
-        toastEl.style.opacity = '0';
-        toastEl.style.transform = 'translateX(-50%) translateY(8px)';
-        setTimeout(() => { if (toastEl) { toastEl.remove(); toastEl = null; } }, 250);
-      }
+      if (toastEl !== currentToast) return;
+      currentToast.style.opacity = '0';
+      currentToast.style.transform = 'translateX(-50%) translateY(8px)';
+      setTimeout(() => {
+        if (toastEl !== currentToast) return;
+        currentToast.remove();
+        toastEl = null;
+      }, 250);
     }, duration);
   }
 

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -490,6 +490,34 @@ describe('live-browser.js regression guards', () => {
     );
   });
 
+  it('toast enter and dismiss timers only touch the current toast element', () => {
+    assert.match(
+      SOURCE,
+      /function showToast\(message, duration\)[\s\S]{0,1200}?const currentToast = el\('div'/,
+      'showToast must capture the created toast in a local so delayed callbacks cannot dereference or remove a stale global toastEl',
+    );
+    assert.match(
+      SOURCE,
+      /requestAnimationFrame\(\(\) => \{[\s\S]{0,80}?if \(toastEl !== currentToast\) return;[\s\S]{0,120}?currentToast\.style\.opacity = '1';/,
+      'toast enter rAF must no-op when dismissToast or a newer toast replaced toastEl before the frame fires',
+    );
+    assert.match(
+      SOURCE,
+      /setTimeout\(\(\) => \{[\s\S]{0,80}?if \(toastEl !== currentToast\) return;[\s\S]{0,120}?currentToast\.style\.opacity = '0';/,
+      'toast auto-dismiss timer must not animate a newer toast created after this timer was scheduled',
+    );
+    assert.match(
+      SOURCE,
+      /setTimeout\(\(\) => \{[\s\S]{0,80}?if \(toastEl !== currentToast\) return;[\s\S]{0,80}?currentToast\.remove\(\);[\s\S]{0,80}?toastEl = null;/,
+      'toast removal timer must only remove and clear the same toast it scheduled',
+    );
+    assert.doesNotMatch(
+      SOURCE,
+      /requestAnimationFrame\(\(\) => \{\s*toastEl\.style/,
+      'toast enter rAF must not read toastEl.style directly after dismissToast can null it',
+    );
+  });
+
   it('insert mode UI and generate payload guards', () => {
     assert.match(SOURCE, /function toggleInsert\(\)/, 'global bar must expose insert toggle');
     assert.match(SOURCE, /PREFIX \+ '-insert-toggle'/, 'insert toggle needs stable id');


### PR DESCRIPTION
## Summary
- bind live-mode toast rAF/timeout callbacks to the toast element that scheduled them
- prevent `dismissToast()` or a newer toast from leaving stale callbacks that touch `toastEl`
- add a regression guard for the #268 timing race and stale timer ownership

## Why
Fixes #268.

`showToast()` schedules an enter `requestAnimationFrame`, but `dismissToast()` can remove the current toast and set `toastEl = null` before that frame runs. The old callback then read `toastEl.style` and could throw. A plain null guard would close that crash, but it still leaves older timeout callbacks able to animate or remove a newer toast.

This patch captures the created element as `currentToast` and makes each delayed callback no-op unless `toastEl === currentToast`.

## Verification
- `node --test tests/live-browser-regression.test.mjs`
- `node --test tests/live-browser-regression.test.mjs tests/live-browser-source.test.mjs tests/live-browser-dom.test.mjs tests/live-browser-script-parts.test.mjs tests/live-browser-session.test.mjs`
- `git diff --check`
- `npx --yes bun run test:live` still fails on `tests/live-copy-edit-agent.test.mjs` (`flags invalid JSX syntax in post-apply checks`); confirmed the same failure on clean `origin/main`.
- `npx --yes bun run test:live-e2e` is blocked in this checkout because `@anthropic-ai/sdk` is not installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI toast lifecycle fix with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a timing race in live-mode **`showToast()`** where enter **`requestAnimationFrame`** and auto-dismiss **`setTimeout`** callbacks could run after **`dismissToast()`** or a newer toast replaced the global **`toastEl`**, causing crashes or animating/removing the wrong toast.
> 
> Each toast now binds delayed work to a local **`currentToast`**; enter, fade-out, and removal callbacks no-op unless **`toastEl === currentToast`**. Regression tests in **`live-browser-regression.test.mjs`** lock in that ownership behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a5a56007671033c342233c866f96cffa227352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->