### PR TITLE
Fix misleading npx hints in live-mode poll/wrap scripts

### DIFF
--- a/skill/scripts/live-poll.mjs
+++ b/skill/scripts/live-poll.mjs
@@ -18,7 +18,7 @@ import { readLiveServerInfo } from './lib/impeccable-paths.mjs';
 // Absolute path to a sibling script in this skill's scripts dir, so runtime
 // error hints print a directly-runnable command instead of a placeholder.
 const SELF_DIR = path.dirname(fileURLToPath(import.meta.url));
-const scriptCmd = (name) => `node ${path.join(SELF_DIR, name)}`;
+const scriptCmd = (name) => `node "${path.join(SELF_DIR, name)}"`;
 
 // Node's built-in fetch (undici under the hood) enforces a 300s headers
 // timeout that can't be lowered per-request. We cap each request below

--- a/skill/scripts/live-poll.mjs
+++ b/skill/scripts/live-poll.mjs
@@ -2,11 +2,11 @@
  * CLI client for the live variant mode poll/reply protocol.
  *
  * Usage:
- *   npx impeccable poll                         # Block until browser event, print JSON
- *   npx impeccable poll --stream                # Experimental: keep polling; one JSON line per event
- *   npx impeccable poll --timeout=600000        # Custom timeout (ms); default is long-poll friendly
- *   npx impeccable poll --reply <id> done       # Reply "done" to event <id>
- *   npx impeccable poll --reply <id> error "msg" # Reply with error
+ *   node <scripts_path>/live-poll.mjs                         # Block until browser event, print JSON
+ *   node <scripts_path>/live-poll.mjs --stream                # Experimental: keep polling; one JSON line per event
+ *   node <scripts_path>/live-poll.mjs --timeout=600000        # Custom timeout (ms); default is long-poll friendly
+ *   node <scripts_path>/live-poll.mjs --reply <id> done       # Reply "done" to event <id>
+ *   node <scripts_path>/live-poll.mjs --reply <id> error "msg" # Reply with error
  */
 
 import { execFileSync } from 'node:child_process';
@@ -14,6 +14,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { completionAckForAcceptResult, completionTypeForAcceptResult } from './live/completion.mjs';
 import { readLiveServerInfo } from './lib/impeccable-paths.mjs';
+
+// Absolute path to a sibling script in this skill's scripts dir, so runtime
+// error hints print a directly-runnable command instead of a placeholder.
+const SELF_DIR = path.dirname(fileURLToPath(import.meta.url));
+const scriptCmd = (name) => `node ${path.join(SELF_DIR, name)}`;
 
 // Node's built-in fetch (undici under the hood) enforces a 300s headers
 // timeout that can't be lowered per-request. We cap each request below
@@ -27,7 +32,7 @@ const EVENT_TYPES_NEEDING_AGENT_REPLY = new Set(['generate', 'steer', 'manual_ed
 function readServerInfo() {
   const record = readLiveServerInfo(process.cwd());
   if (!record) {
-    console.error('No running live server found. Start one with: npx impeccable live');
+    console.error(`No running live server found. Start one with: ${scriptCmd('live.mjs')}`);
     process.exit(1);
   }
   return record.info;
@@ -82,7 +87,7 @@ export function parseReplyArgs(args) {
 }
 
 function validateReplyArgs({ id, status }) {
-  const usage = "Usage: npx impeccable poll --reply <id> <status> [--file path] [--data '<json>'] [message]";
+  const usage = `Usage: ${scriptCmd('live-poll.mjs')} --reply <id> <status> [--file path] [--data '<json>'] [message]`;
   if (!id || id.startsWith('--')) {
     const err = new Error(`${usage}\nMissing event id after --reply.`);
     err.code = 'INVALID_REPLY_ARGS';
@@ -283,11 +288,11 @@ export async function runPollStream(base, token, {
 function handlePollError(err) {
   if (err.code === 'AUTH_FAILED') {
     console.error(err.message);
-    console.error('Try restarting: npx impeccable live stop && npx impeccable live');
+    console.error(`Try restarting: ${scriptCmd('live-server.mjs')} stop && ${scriptCmd('live.mjs')}`);
     process.exit(1);
   }
   if (err.cause?.code === 'ECONNREFUSED') {
-    console.error('Live server not running. Start one with: npx impeccable live');
+    console.error(`Live server not running. Start one with: ${scriptCmd('live.mjs')}`);
     process.exit(1);
   }
   if (err.code === 'ACK_TIMEOUT') {
@@ -331,7 +336,7 @@ Harness note:
   const info = readServerInfo();
   const base = `http://localhost:${info.port}`;
 
-  // Reply mode: npx impeccable poll --reply <id> <status> [--file path] [--data '<json>'] [message]
+  // Reply mode: node <scripts_path>/live-poll.mjs --reply <id> <status> [--file path] [--data '<json>'] [message]
   if (args.includes('--reply')) {
     let reply;
     try {
@@ -345,7 +350,7 @@ Harness note:
       await postReply(base, info.token, reply);
     } catch (err) {
       if (err.cause?.code === 'ECONNREFUSED') {
-        console.error('Live server not running. Start one with: npx impeccable live');
+        console.error(`Live server not running. Start one with: ${scriptCmd('live.mjs')}`);
       } else {
         console.error('Reply failed:', err.message);
       }

--- a/skill/scripts/live-wrap.mjs
+++ b/skill/scripts/live-wrap.mjs
@@ -2,7 +2,7 @@
  * CLI helper: find an element in source and wrap it in a variant container.
  *
  * Usage:
- *   npx impeccable wrap --id SESSION_ID --count N --query "hero-combined-left" [--file path]
+ *   node <scripts_path>/live-wrap.mjs --id SESSION_ID --count N --query "hero-combined-left" [--file path]
  *
  * Searches project files for the element matching the query (class name, ID, or
  * text snippet), wraps it with the variant scaffolding, and prints the file path


### PR DESCRIPTION
## What

The live-mode `poll`/`wrap` scripts are invoked by the agent via `node {{scripts_path}}/live-*.mjs` — never through the published `npx impeccable` CLI. Their help text and runtime error hints still said `npx impeccable poll|live|wrap`, which is misleading and, for the error paths, not directly runnable.

## Changes

- **Docstrings / inline comments** (never executed): switch to the `node <scripts_path>/...` convention already used by `live-server.mjs`.
- **Runtime-printed error/usage strings**: resolve the script's own directory via `import.meta.url` and print a real, copy-pasteable absolute path instead of a placeholder — e.g.

  ```
  No running live server found. Start one with: node /…/.claude/skills/impeccable/scripts/live.mjs
  ```

This removes the only spot where the agent would have had to interpret a literal `<scripts_path>` placeholder at runtime.

## Scope

Source-only (`skill/scripts/live-poll.mjs`, `skill/scripts/live-wrap.mjs`). Generated provider/harness copies are intentionally **not** included — the `sync-generated-output.yml` workflow regenerates them on `main` after merge.

## Verification

- `node --check` passes on both files.
- Triggered the error paths from the synced bundle → confirmed they print resolved absolute paths.
- Ran the live-mode E2E (`IMPECCABLE_E2E_ONLY=vite8-react-modal`) through the full cycle (handshake → steer → pick → Go → generate → cycle → accept → carbonize cleanup → reload probe): **1/1 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing strings and doc comments only; no changes to poll/reply protocol or wrap logic.
> 
> **Overview**
> Live-mode agents run **`live-poll.mjs`** and **`live-wrap.mjs`** via `node`, not **`npx impeccable`**. This PR aligns help text and **runtime** error/usage strings with that.
> 
> In **`live-poll.mjs`**, it adds **`scriptCmd`** (sibling scripts resolved from **`import.meta.url`**) so messages like “start the live server” or “try restarting” print **copy-pasteable** `node "/…/scripts/live.mjs"` commands instead of **`npx impeccable`** or a literal `<scripts_path>` placeholder. The same helper updates **`--reply`** usage and connection/auth failure hints (including **`live-server.mjs stop`**).
> 
> **`live-wrap.mjs`** only updates the file header usage line to the **`node <scripts_path>/…`** convention. No poll/wrap behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d165a7aa2f60db9b54782576ae8937d121fc9b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->