### PR TITLE
Give GitHub Copilot equal prominence in harness listings

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,7 +6,7 @@ brand
 
 ## Users
 
-Designers, product managers, and engineers who use AI coding tools (Cursor, Claude Code, Gemini CLI, Codex CLI, and others) and want better design output from their AI. They land on the site from GitHub, social media, or word of mouth, already aware that AI-generated UIs have quality problems. They're looking for a practical solution, not education about the problem.
+Designers, product managers, and engineers who use AI coding tools (Cursor, Claude Code, GitHub Copilot, Gemini CLI, Codex CLI, and others) and want better design output from their AI. They land on the site from GitHub, social media, or word of mouth, already aware that AI-generated UIs have quality problems. They're looking for a practical solution, not education about the problem.
 
 ## Product Purpose
 

--- a/README.md
+++ b/README.md
@@ -260,11 +260,12 @@ If you reach for one command often, pin it with `/impeccable pin audit` to get `
 
 ## Design hook
 
-On Claude Code, Codex, and Cursor, `npx impeccable install` and `npx impeccable update` install a provider-native hook manifest along with the skill payload. The hook runs the Impeccable design detector on direct UI file edits and surfaces findings back into the agent flow. Claude Code and Codex surface findings after the edit. Cursor blocks bad proposed writes before they land.
+On Claude Code, GitHub Copilot, Codex, and Cursor, `npx impeccable install` and `npx impeccable update` install a provider-native hook manifest along with the skill payload. The hook runs the Impeccable design detector on direct UI file edits and surfaces findings back into the agent flow. Claude Code, GitHub Copilot, and Codex surface findings after the edit. Cursor blocks bad proposed writes before they land.
 
 Installed hook surfaces:
 
 - Claude Code: `.claude/settings.local.json` (gitignored, machine-local) runs `${CLAUDE_PROJECT_DIR}/.claude/skills/impeccable/scripts/hook.mjs`. A hook moved into the shared `settings.json` is honored in place.
+- GitHub Copilot: `.github/hooks/impeccable.json` (committed, shared by the Copilot CLI and the cloud agent) runs `.github/skills/impeccable/scripts/hook.mjs`. The Copilot CLI activates it once the file is on the repository's default branch and the folder is trusted.
 - Cursor: `.cursor/hooks.json` runs `.cursor/skills/impeccable/scripts/hook-before-edit.mjs`.
 - Codex: `.codex/hooks.json` runs `.agents/skills/impeccable/scripts/hook.mjs`.
 
@@ -310,11 +311,11 @@ Full detector docs: [impeccable.style/docs/detector](https://impeccable.style/do
 
 - [Cursor](https://cursor.com)
 - [Claude Code](https://claude.ai/code)
-- [OpenCode](https://opencode.ai)
-- [Pi](https://pi.dev)
+- [GitHub Copilot](https://github.com/features/copilot)
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [Codex CLI](https://github.com/openai/codex)
-- [VS Code Copilot](https://code.visualstudio.com)
+- [OpenCode](https://opencode.ai)
+- [Pi](https://pi.dev)
 - [Kiro](https://kiro.dev)
 - [Trae](https://trae.ai)
 - [Rovo Dev](https://www.atlassian.com/software/rovo)

--- a/README.npm.md
+++ b/README.npm.md
@@ -81,7 +81,7 @@ impeccable detect [options] [file-or-dir-or-url...]
 
 ## Part of Impeccable
 
-This CLI is part of [Impeccable](https://impeccable.style), a cross-provider design skill pack for AI-powered development tools. The full suite includes 23 commands for Claude, Cursor, Gemini, Codex, and more.
+This CLI is part of [Impeccable](https://impeccable.style), a cross-provider design skill pack for AI-powered development tools. The full suite includes 23 commands for Claude, Cursor, GitHub Copilot, Gemini, Codex, and more.
 
 ## License
 

--- a/site/content/reference/hooks.md
+++ b/site/content/reference/hooks.md
@@ -1,6 +1,6 @@
 ---
 title: Design hooks
-tagline: "Automatic detector feedback inside Claude Code, Codex, and Cursor."
+tagline: "Automatic detector feedback inside Claude Code, GitHub Copilot, Codex, and Cursor."
 description: "Install, enable, disable, debug, and tune Impeccable's provider-native design hook for automatic detector feedback on UI file edits."
 section: automation
 order: 2
@@ -34,7 +34,7 @@ npx impeccable update --no-hooks
 
 The hook scans direct edits to UI code and styles. When it finds a new issue, it sends the agent a short reminder with the finding and a fix direction.
 
-Claude Code and Codex run after the edit. Cursor checks proposed writes before they land and blocks only when the detector finds an issue in the proposed UI code.
+Claude Code, GitHub Copilot, and Codex run after the edit. Cursor checks proposed writes before they land and blocks only when the detector finds an issue in the proposed UI code.
 
 Plain `.ts` and `.js` files are scanned, but the hook stays quiet unless it finds something design-relevant.
 
@@ -57,12 +57,14 @@ The terminal equivalent is `npx impeccable ignores ...`, which writes the same d
 <details class="docs-prose-details">
   <summary>Supported harnesses and approval steps</summary>
   <div>
-    <p><code>npx impeccable install</code> and <code>npx impeccable update</code> install provider-native hook manifests for Claude Code, Codex, and Cursor.</p>
+    <p><code>npx impeccable install</code> and <code>npx impeccable update</code> install provider-native hook manifests for Claude Code, GitHub Copilot, Codex, and Cursor.</p>
     <ul>
       <li>Claude Code: <code>.claude/settings.local.json</code> by default.</li>
+      <li>GitHub Copilot: <code>.github/hooks/impeccable.json</code>, a committed file shared by the Copilot CLI and the cloud agent.</li>
       <li>Codex: <code>.codex/hooks.json</code>.</li>
       <li>Cursor: <code>.cursor/hooks.json</code>.</li>
     </ul>
+    <p>GitHub Copilot reads the committed <code>.github/hooks/impeccable.json</code>. In the Copilot CLI the hook activates once that file is on the repository's default branch and you trust the folder; the cloud agent reads it straight from the repo.</p>
     <p>Codex requires one extra approval step. After install or update, open <code>/hooks</code> in Codex and approve the project hook. Codex tracks trust by hook definition, so updates can require approval again.</p>
     <p>Cursor users should also confirm hooks are enabled in Cursor Settings -> Hooks.</p>
   </div>

--- a/site/content/tutorials/getting-started.md
+++ b/site/content/tutorials/getting-started.md
@@ -48,7 +48,7 @@ Prefer a different setup? Claude Code users can install the plugin with `/plugin
 
 When a new version ships later, run `npx impeccable update` from the same project root. `npx impeccable check` tells you first whether you are behind, and plugin users update from the `/plugin` menu instead.
 
-On Claude Code, Codex, and Cursor, the installer can also add Impeccable's automatic design hook. See [Design hooks](/docs/hooks) for harness-specific behavior and approval steps.
+On Claude Code, GitHub Copilot, Codex, and Cursor, the installer can also add Impeccable's automatic design hook. See [Design hooks](/docs/hooks) for harness-specific behavior and approval steps.
 
 ## Step 2. Set up Impeccable for your project
 

--- a/site/pages/designing/index.astro
+++ b/site/pages/designing/index.astro
@@ -353,7 +353,7 @@ import '../../styles/designing-kinpaku.css';
   <section class="ks-section designing-phase designing-phase--appendix" aria-label="Where Impeccable runs">
     <header class="ks-section-head designing-phase-head">
       <h2 class="designing-phase-title">Mostly, you're in the skill.</h2>
-      <p class="ks-section-sub designing-phase-sub">The 23 commands run inside your AI coding tool: Cursor, Claude Code, Codex, Gemini CLI, Copilot. That's where everything on this page happens. The same anti-pattern detector also runs in two places outside the chat.</p>
+      <p class="ks-section-sub designing-phase-sub">The 23 commands run inside your AI coding tool: Cursor, Claude Code, GitHub Copilot, Codex, Gemini CLI. That's where everything on this page happens. The same anti-pattern detector also runs in two places outside the chat.</p>
     </header>
 
     <div class="designing-phase-body">

--- a/site/pages/faq.astro
+++ b/site/pages/faq.astro
@@ -63,6 +63,7 @@ import '../styles/changelog-faq-kinpaku.css';
           <p><strong>Tool-specific setup:</strong></p>
           <ul>
             <li><strong>Cursor:</strong> Requires Nightly channel + Agent Skills enabled in Settings → Rules</li>
+            <li><strong>GitHub Copilot:</strong> Skills install to <code>.github/skills/</code>. The design hook lives in <code>.github/hooks/impeccable.json</code> and runs in both the Copilot CLI and the cloud agent once it is committed to the repository's default branch.</li>
             <li><strong>Gemini CLI:</strong> Requires <code>@google/gemini-cli@preview</code> + Skills enabled via <code>/settings</code></li>
             <li><strong>Codex:</strong> Skills do not appear in the normal <code>/</code> command picker. Open <code>/skills</code> or type <code>$</code>. Repo installs live in <code>.agents/skills/</code>, user installs live in <code>~/.agents/skills/</code>. Restart Codex if a new skill does not show up.</li>
           </ul>
@@ -75,6 +76,7 @@ import '../styles/changelog-faq-kinpaku.css';
           <p>Skills and commands are intermediate features. If you're just getting started, learn the basics first:</p>
           <ul>
             <li><strong>Claude Code:</strong> <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener">Official Documentation</a></li>
+            <li><strong>GitHub Copilot:</strong> <a href="https://docs.github.com/en/copilot" target="_blank" rel="noopener">GitHub Copilot Docs</a></li>
             <li><strong>Cursor:</strong> <a href="https://docs.cursor.com" target="_blank" rel="noopener">Cursor Docs</a></li>
             <li><strong>Gemini CLI:</strong> <a href="https://geminicli.com/docs/" target="_blank" rel="noopener">Gemini CLI Docs</a></li>
             <li><strong>Codex CLI:</strong> <a href="https://github.com/openai/codex" target="_blank" rel="noopener">Codex GitHub</a></li>

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -78,9 +78,9 @@ import '../styles/testimonials.css';
         <div class="hero-rebuild-logos" aria-label="AI coding harnesses Impeccable works with">
           <span class="hero-rebuild-logo has-tooltip" data-tooltip="Codex CLI"><img src="assets/openai-logo.png" alt="Codex CLI" width="20" height="20" loading="lazy"></span>
           <span class="hero-rebuild-logo has-tooltip" data-tooltip="Claude Code"><img src="assets/claude-logo.png" alt="Claude Code" width="22" height="22" loading="lazy"></span>
+          <span class="hero-rebuild-logo has-tooltip" data-tooltip="GitHub Copilot"><img src="assets/github-copilot-logo.svg" alt="GitHub Copilot" width="20" height="20" loading="lazy"></span>
           <span class="hero-rebuild-logo has-tooltip" data-tooltip="Cursor"><img src="assets/cursor-logo.png" alt="Cursor" width="22" height="22" loading="lazy"></span>
           <span class="hero-rebuild-logo has-tooltip" data-tooltip="Gemini CLI"><img src="assets/gemini-logo.png" alt="Gemini CLI" width="20" height="20" loading="lazy"></span>
-          <span class="hero-rebuild-logo has-tooltip" data-tooltip="GitHub Copilot"><img src="assets/github-copilot-logo.svg" alt="GitHub Copilot" width="20" height="20" loading="lazy"></span>
           <span class="hero-rebuild-logo has-tooltip" data-tooltip="Antigravity"><img src="assets/antigravity-logo.png" alt="Antigravity" width="20" height="20" loading="lazy"></span>
           <span class="hero-rebuild-logo has-tooltip" data-tooltip="OpenCode"><img src="assets/opencode-logo.png" alt="OpenCode" width="20" height="20" loading="lazy"></span>
           <span class="hero-rebuild-logo has-tooltip" data-tooltip="Pi"><img src="assets/pi-logo.svg" alt="Pi" width="20" height="20" loading="lazy"></span>


### PR DESCRIPTION
## Why

Per the GitHub partnership commitment to give **GitHub Copilot equal prominence** wherever we list multiple harnesses, I audited every user-facing surface that enumerates supported tools. GitHub Copilot was missing or buried in several.

## Hooks docs gap (the one that prompted this)

The Copilot-hook PR (#279) updated `skill/reference/hooks.md` (the LLM-facing skill reference) but **not** `site/content/reference/hooks.md` — the file that renders the public **`/docs/hooks`** page. That page still read "inside Claude Code, Codex, and Cursor" with no Copilot. Fixed here (tagline, post-edit list, manifest table, and a default-branch/trust note).

## Surfaces fixed

**Was missing → now lists GitHub Copilot:**
- `site/content/reference/hooks.md` — public `/docs/hooks` (tagline + manifest list + Copilot surface/trust note)
- `README.md` — Design hook section + manifest surface list
- `site/content/tutorials/getting-started.md` — hook installer note
- `site/pages/faq.astro` — tool-specific setup list **and** the "official docs" links list
- `PRODUCT.md` — audience line
- `README.npm.md` — suite description

**Prominence / naming:**
- Homepage hero logo row + README "Supported Tools": moved GitHub Copilot **up to third** (after Claude Code) instead of trailing behind lesser-known harnesses.
- `site/pages/designing` — list GitHub Copilot earlier, by full name.
- README "Supported Tools" link now points at **GitHub Copilot** (`github.com/features/copilot`) instead of the unrelated **VS Code** entry.

**Intentionally left alone:** the historical `v1.1.0` changelog entry still says "VS Code Copilot" — it's an accurate record of what shipped in that release.

## Notes

- All copy-only changes to source files; the prose validator passes (`✓ no AI tells in user-facing copy`).
- Source-first: no generated provider permutations staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only; no application logic, install behavior, or security-sensitive paths change.
> 
> **Overview**
> **Copy-only** updates across docs and marketing so **GitHub Copilot** is listed wherever harnesses are enumerated and sits with the top-tier tools instead of trailing or missing.
> 
> **Hooks and install docs** now include Copilot alongside Claude Code, Codex, and Cursor: post-edit hook behavior, `.github/hooks/impeccable.json`, skills under `.github/skills/`, and when the Copilot CLI/cloud agent pick up the committed hook (default branch + trust). Surfaces touched include public `/docs/hooks`, README design-hook section, and the getting-started tutorial.
> 
> **Discovery and prominence:** `PRODUCT.md` and npm README audience lines name Copilot; FAQ adds Copilot setup paths and official docs; homepage hero logo order moves Copilot **third** (after Claude Code); README **Supported Tools** promotes Copilot, links `github.com/features/copilot`, and drops the unrelated VS Code Copilot entry in favor of a clearer harness list.
> 
> **No runtime or installer code** changes—only user-facing prose and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d6c6c9567991bb880aac0c0341aec2550c4e664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->