### PR TITLE
Fix React hydration mismatch from live pick-cursor class on SSR roots

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -1916,8 +1916,6 @@
     syncPageInteractionCursor();
   }
 
-  let pageInteractionCursorActive = false;
-
   /**
    * Drive the page-level pick / insert cursor through the textContent of one
    * injected <style>, never by mutating <html> (className or inline style).
@@ -1933,7 +1931,6 @@
     let style = document.getElementById(PICK_CURSOR_STYLE_ID);
     if (!cursor) {
       if (style) style.textContent = '';
-      pageInteractionCursorActive = false;
       return;
     }
     if (!style) {
@@ -1947,7 +1944,6 @@
       '* { cursor: ' + cursor + ' !important; }\n'
       + '[id^="' + PREFIX + '"],\n'
       + '[id^="' + PREFIX + '"] * { cursor: revert !important; }';
-    pageInteractionCursorActive = true;
   }
 
   /** Page-level cursor while pick or insert mode is targeting page elements. */

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -57,7 +57,7 @@
   const Z = { highlight: 100001, bar: 100005, picker: 100007, toast: 100010 };
   const EASE = 'cubic-bezier(0.22, 1, 0.36, 1)'; // ease-out-quint
   const PREFIX = 'impeccable-live';
-  const PICK_CURSOR_CLASS = PREFIX + '-pick-cursor';
+  const PICK_CURSOR_STYLE_ID = PREFIX + '-pick-cursor-style';
   const MANUAL_APPLY_STATE_TTL_MS = 15 * 60 * 1000;
   const sessionState = window.__IMPECCABLE_LIVE_SESSION__?.createLiveBrowserSessionState({
     prefix: PREFIX,
@@ -1918,43 +1918,47 @@
 
   let pageInteractionCursorActive = false;
 
-  function ensurePickCursorStyle() {
-    if (document.getElementById(PREFIX + '-pick-cursor-style')) return;
-    const style = document.createElement('style');
-    style.id = PREFIX + '-pick-cursor-style';
+  /**
+   * Drive the page-level pick / insert cursor through the textContent of one
+   * injected <style>, never by mutating <html> (className or inline style).
+   * Frameworks that server-render the <html>/<body> roots (Next.js App Router)
+   * report a React 19 hydration mismatch when the client adds an attribute the
+   * server HTML never emitted, so a `class`/inline `style` toggled on
+   * `document.documentElement` trips "a tree hydrated but some attributes ...
+   * didn't match" on the next Fast-Refresh re-render. Keying the cursor off a
+   * stable-id <style> keeps the effect off the hydrated host elements (same
+   * shape as the scroll-anchor lock). A falsy cursor clears the rule.
+   */
+  function setPageInteractionCursor(cursor) {
+    let style = document.getElementById(PICK_CURSOR_STYLE_ID);
+    if (!cursor) {
+      if (style) style.textContent = '';
+      pageInteractionCursorActive = false;
+      return;
+    }
+    if (!style) {
+      style = document.createElement('style');
+      style.id = PICK_CURSOR_STYLE_ID;
+      // Styles the host page, not the chrome - inside the adapter's shadow UI
+      // root (uiAppendStyle's target) these selectors would match nothing.
+      (document.head || document.documentElement).appendChild(style);
+    }
     style.textContent =
-      'html.' + PICK_CURSOR_CLASS + ' * { cursor: crosshair !important; }\n'
-      + 'html.' + PICK_CURSOR_CLASS + ' [id^="' + PREFIX + '"],\n'
-      + 'html.' + PICK_CURSOR_CLASS + ' [id^="' + PREFIX + '"] * { cursor: revert !important; }';
-    // Styles the host page, not the chrome - inside the adapter's shadow UI
-    // root (uiAppendStyle's target) these selectors would match nothing.
-    document.head.appendChild(style);
+      '* { cursor: ' + cursor + ' !important; }\n'
+      + '[id^="' + PREFIX + '"],\n'
+      + '[id^="' + PREFIX + '"] * { cursor: revert !important; }';
+    pageInteractionCursorActive = true;
   }
 
   /** Page-level cursor while pick or insert mode is targeting page elements. */
   function syncPageInteractionCursor() {
-    const pickCursor = state === 'PICKING' && pickActive && !insertActive;
-    let axisCursor = '';
-    if (state === 'PICKING' && insertActive) {
-      axisCursor = insertHoverAnchor ? cursorForInsertAxis(insertHoverAxis || 'column') : '';
+    let cursor = '';
+    if (state === 'PICKING' && pickActive && !insertActive) {
+      cursor = 'crosshair';
+    } else if (state === 'PICKING' && insertActive && insertHoverAnchor) {
+      cursor = cursorForInsertAxis(insertHoverAxis || 'column');
     }
-
-    if (pickCursor) {
-      ensurePickCursorStyle();
-      document.documentElement.classList.add(PICK_CURSOR_CLASS);
-      document.documentElement.style.cursor = '';
-      pageInteractionCursorActive = true;
-      return;
-    }
-
-    document.documentElement.classList.remove(PICK_CURSOR_CLASS);
-    if (axisCursor) {
-      document.documentElement.style.cursor = axisCursor;
-      pageInteractionCursorActive = true;
-    } else if (pageInteractionCursorActive) {
-      document.documentElement.style.cursor = '';
-      pageInteractionCursorActive = false;
-    }
+    setPageInteractionCursor(cursor);
   }
 
   /**
@@ -9983,7 +9987,7 @@ void main() {
     // Remove detection overlays
     window.postMessage({ source: 'impeccable-command', action: 'remove' }, '*');
     setLiveState('IDLE');
-    document.getElementById(PREFIX + '-pick-cursor-style')?.remove();
+    document.getElementById(PICK_CURSOR_STYLE_ID)?.remove();
     window.__IMPECCABLE_LIVE_INIT__ = false;
     console.log('[impeccable] Live mode exited.');
   }

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -559,15 +559,37 @@ describe('live-browser.js regression guards', () => {
       /function syncPageInteractionCursor\(\)[\s\S]{0,420}?cursorForInsertAxis/,
       'insert picking cursor follows row/column axis',
     );
-    assert.match(
+    // The pick / insert cursor must be driven by an injected <style>, never by a
+    // class or inline style on <html>. <html>/<body> are server-rendered by
+    // frameworks like Next.js App Router, so a client-only attribute the server
+    // HTML never emitted trips React 19's "a tree hydrated but some attributes
+    // ... didn't match" on the next Fast-Refresh re-render — surfacing as a
+    // console.error that fails the nextjs-app-router live-e2e expectConsoleClean
+    // probe. Same fix shape as the scroll-anchor lock above.
+    assert.doesNotMatch(
       SOURCE,
-      /function ensurePickCursorStyle\(\)[\s\S]{0,420}?cursor: crosshair !important/,
-      'pick mode injects a crosshair cursor that wins over page pointer styles',
+      /document\.documentElement\.classList\.(?:add|remove|toggle)\(/,
+      'event=live_browser.pick_cursor_hydration actor=browser operation=sync_page_interaction_cursor risk=react19_hydration_mismatch_on_next_app_router expected=stylesheet_rule actual=class_on_html',
     );
     assert.match(
       SOURCE,
-      /document\.documentElement\.classList\.add\(PICK_CURSOR_CLASS\)/,
-      'pick mode toggles a document-level class for the crosshair cursor',
+      /const PICK_CURSOR_STYLE_ID = PREFIX \+ '-pick-cursor-style';/,
+      'the pick-cursor style needs a stable id constant so it can be created and removed by id',
+    );
+    assert.match(
+      SOURCE,
+      /function setPageInteractionCursor\(cursor\)[\s\S]{0,700}?cursor: ' \+ cursor \+ ' !important/,
+      'pick / insert cursor is applied through the injected <style> textContent, keyed by PICK_CURSOR_STYLE_ID',
+    );
+    assert.match(
+      SOURCE,
+      /cursor = 'crosshair'/,
+      'pick mode uses a crosshair cursor that wins over page pointer styles',
+    );
+    assert.match(
+      SOURCE,
+      /document\.getElementById\(PICK_CURSOR_STYLE_ID\)\?\.remove\(\)/,
+      'exiting live mode removes the injected pick-cursor <style> so it never outlives the session',
     );
     assert.match(SOURCE, /function hitSiblingInsertGap\(/, 'insert mode detects gaps between siblings');
     assert.match(SOURCE, /function resolveInsertHover\(/, 'insert hover resolves axis-aware boundaries');


### PR DESCRIPTION
## What

Entering pick mode toggled an `impeccable-live-pick-cursor` class on `document.documentElement` (and the insert-axis cursor wrote an inline `style.cursor` on it). `<html>`/`<body>` are server-rendered by frameworks like Next.js App Router, so a client-only attribute the server HTML never emitted makes React 19 log *"a tree hydrated but some attributes of the server rendered HTML didn't match"* on the next Fast-Refresh re-render. It surfaced as a `console.error` that flaked the `nextjs-app-router` live-e2e fixture's `expectConsoleClean` probe.

## Why it wasn't covered by #276

#276 fixed the **scroll-anchor lock**, which mutated `<html>`/`<body>` inline `overflowAnchor`. That is the same root-cause *category* (client mutation of a hydrated SSR root), but a different offender. The pick-cursor class on `<html>` is a second instance the earlier fix did not touch — which is why the flake came back.

## The fix

Apply #276's shape to the cursor: drive the pick / insert cursor entirely through the `textContent` of one injected `<style>` keyed by `PICK_CURSOR_STYLE_ID`, never by a class or inline style on `<html>`.

- Same computed effect: a global `* { cursor: <x> !important }` rule, reverted inside the overlay chrome (`[id^="impeccable-live"]`).
- Created on activation, content cleared when inactive, element removed on teardown.
- Removes both the `classList.add/remove` on `<html>` **and** the insert-axis `documentElement.style.cursor` inline write.

## Tests

`tests/live-browser-regression.test.mjs` updated to pin the new shape (mirroring the scroll-anchor guard):
- `doesNotMatch` any `document.documentElement.classList.(add|remove|toggle)(` in the overlay;
- the cursor is applied through the injected `<style>` keyed by `PICK_CURSOR_STYLE_ID`;
- the style is removed by id on exit.

**Verified end-to-end locally:** `IMPECCABLE_E2E_ONLY=nextjs-app-router bun run test:live-e2e` now passes the full click → Go → cycle → accept cycle with a clean console (the probe that was failing). Build (prose + counts) and the live-browser unit suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized live-overlay cursor behavior with equivalent visual effect; regression tests lock the no-`html`-mutation contract.
> 
> **Overview**
> **Pick and insert cursors no longer touch server-rendered `<html>`**, avoiding React 19 hydration mismatches on Next.js App Router (and flaky `expectConsoleClean` in live e2e).
> 
> Live mode used to add a pick-cursor **class** and set **inline `cursor`** on `document.documentElement`. That matches the scroll-anchor issue fixed in #276: client-only attributes on hydrated roots. The change follows the same pattern—one `<style>` keyed by `PICK_CURSOR_STYLE_ID` whose `textContent` toggles a global `* { cursor: … !important }` rule (with revert inside `[id^="impeccable-live"]` chrome). `setPageInteractionCursor` replaces `ensurePickCursorStyle` plus `classList` / inline style; teardown removes the style by id.
> 
> **Regression tests** in `live-browser-regression.test.mjs` now forbid `document.documentElement.classList` mutations for this path and assert the stylesheet-based implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28741b51573af45a527f47ee81110babd4331eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->