### PR TITLE
Fix live variant cycling hydration mismatch on SSR frameworks (#287)

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -5792,33 +5792,70 @@
     return variantDiv;
   }
 
-  // Hold window.scrollY at a fixed value across DOM mutations inside the
-  // session's wrapper (HMR patches, variant inserts, cycle swaps).
+  // Variant visibility and range/toggle params are expressed through ONE
+  // injected stylesheet, never inline attributes on the variant divs. Those
+  // divs are scaffolded into page source, so SSR frameworks (Next.js App
+  // Router) server-render them; toggling their `hidden` / inline `style` /
+  // `--p-*` client-side trips a React 19 hydration mismatch on the next
+  // Fast-Refresh re-render — the same failure mode the scroll-anchor (#276)
+  // and pick-cursor (#286) fixes address. A stylesheet rule has the same
+  // computed effect without mutating any hydrated element's attributes.
+  // (steps params keep driving `data-p-*` attributes, matching scoped CSS.)
+  const VARIANT_HIDE_DECL = 'display: none !important;';
+  const VARIANT_SHOW_DECL = 'display: block !important;';
+
+  // Build a direct-child variant selector for a session. With `num`, targets a
+  // single variant (`… > [data-impeccable-variant="N"]`); without it, targets
+  // every variant via the bare `[data-impeccable-variant]` attribute.
+  function variantStateSelector(sessionId, num) {
+    const wrapper = '[data-impeccable-variants="' + sessionId + '"]';
+    const variant = num == null
+      ? '[data-impeccable-variant]'
+      : '[data-impeccable-variant="' + num + '"]';
+    return wrapper + ' > ' + variant;
+  }
+
+  // Serialize the visible variant's knob values into `--p-<id>` custom-property
+  // declarations. Only range (number) and toggle (boolean) values become a
+  // custom property; steps params drive `data-p-*` attributes instead.
+  function variantParamDecls(values) {
+    return Object.entries(values || {})
+      .map(([id, val]) => {
+        if (typeof val === 'number') return ' --p-' + id + ': ' + val + ';';
+        if (typeof val === 'boolean') return ' --p-' + id + ': ' + (val ? '1' : '0') + ';';
+        return '';
+      })
+      .join('');
+  }
+
   function updateVariantStateStylesheet(sessionId, num) {
     if (!sessionId || !num) return;
+
     let styleEl = document.getElementById(VARIANT_STATE_STYLE_ID);
     if (!styleEl) {
       styleEl = document.createElement('style');
       styleEl.id = VARIANT_STATE_STYLE_ID;
       (document.head || document.documentElement).appendChild(styleEl);
     }
-    const base = '[data-impeccable-variants="' + sessionId + '"] > [data-impeccable-variant';
-    let css = base + ']:not([data-impeccable-variant="' + num + '"]) { display: none !important; }\n';
-    // Force-show the visible variant (overrides source inline display:none on
-    // v2/v3) plus its range/toggle custom properties from paramsCurrentValues.
-    let decls = 'display: block !important;';
-    for (const [id, val] of Object.entries(paramsCurrentValues || {})) {
-      if (typeof val === 'number') decls += ' --p-' + id + ': ' + val + ';';
-      else if (typeof val === 'boolean') decls += ' --p-' + id + ': ' + (val ? '1' : '0') + ';';
-    }
-    css += base + '="' + num + '"] { ' + decls + ' }\n';
-    styleEl.textContent = css;
+
+    // Hide every variant except the visible one (incl. the SSR'd "original").
+    const hideOthers = variantStateSelector(sessionId)
+      + ':not([data-impeccable-variant="' + num + '"]) { ' + VARIANT_HIDE_DECL + ' }';
+
+    // Force-show the visible variant (beats the source inline display:none on
+    // v2/v3) and apply its knob values as custom properties.
+    const showVisible = variantStateSelector(sessionId, num)
+      + ' { ' + VARIANT_SHOW_DECL + variantParamDecls(paramsCurrentValues) + ' }';
+
+    styleEl.textContent = hideOthers + '\n' + showVisible + '\n';
   }
 
   function removeVariantStateStylesheet() {
     document.getElementById(VARIANT_STATE_STYLE_ID)?.remove();
   }
 
+  // Hold window.scrollY at a fixed value across DOM mutations inside the
+  // session's wrapper (HMR patches, variant inserts, cycle swaps).
   function startScrollLock(sessionId, initialTargetY) {
     stopScrollLock();
     scrollLockTargetY = typeof initialTargetY === 'number' && isFinite(initialTargetY)

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -153,6 +153,7 @@
   let scrollLockRaf = null;
   let scrollLockAbort = null;
   const SCROLL_ANCHOR_LOCK_ID = 'impeccable-scroll-anchor-lock';
+  const VARIANT_STATE_STYLE_ID = 'impeccable-variant-state';
 
   // Dedicated key for scroll position - SEPARATE from LS_KEY so that
   // saveSession's state updates don't clobber a carefully-captured scrollY.
@@ -3035,16 +3036,16 @@
   function applyParamValue(variantEl, param, value) {
     if (!variantEl) return;
     const attr = 'data-p-' + param.id;
-    if (param.kind === 'range') {
-      variantEl.style.setProperty('--p-' + param.id, String(value));
-    } else if (param.kind === 'toggle') {
+    if (param.kind === 'toggle') {
       const on = !!value;
-      variantEl.style.setProperty('--p-' + param.id, on ? '1' : '0');
       if (on) variantEl.setAttribute(attr, 'on');
       else variantEl.removeAttribute(attr);
     } else if (param.kind === 'steps') {
       variantEl.setAttribute(attr, String(value));
     }
+    // range/toggle --p-* custom properties are driven through the injected
+    // variant-state stylesheet so we never mutate inline style on SSR'd divs.
+    updateVariantStateStylesheet(currentSessionId, visibleVariant);
   }
 
   function applyParamDefaults(variantEl, params) {
@@ -4706,6 +4707,7 @@
       paramsCurrentValues = {};
       tuneOpen = false;
       hideParamsPanel();
+      removeVariantStateStylesheet();
       return;
     }
     const variantEl = getVisibleVariantEl();
@@ -4771,20 +4773,7 @@
 
   function isVariantShown(el) {
     if (!el) return false;
-    if (el.hidden) return false;
-    if (el.style?.display === 'none') return false;
-    return true;
-  }
-
-  function setVariantShown(el, shown) {
-    if (!el) return;
-    if (shown) {
-      el.removeAttribute('hidden');
-      el.style.display = '';
-    } else {
-      el.setAttribute('hidden', '');
-      el.style.display = 'none';
-    }
+    return getComputedStyle(el).display !== 'none';
   }
 
   function scheduleCyclingBarSync(sessionId, variantNum) {
@@ -4823,11 +4812,7 @@
     }
     const wrapper = document.querySelector('[data-impeccable-variants="' + sessionId + '"]');
     if (!wrapper) return false;
-    for (const child of wrapper.children) {
-      const v = child.dataset ? child.dataset.impeccableVariant : null;
-      if (!v) continue;
-      setVariantShown(child, v === String(num));
-    }
+    updateVariantStateStylesheet(sessionId, num);
     // Unconditional refresh - covers first-reveal (no-op if state isn't
     // CYCLING yet, the subsequent CYCLING transition triggers its own
     // refresh) and every cycle step.
@@ -5492,6 +5477,7 @@
     if (pendingSvelteComponentRetryObserver) { pendingSvelteComponentRetryObserver.disconnect(); pendingSvelteComponentRetryObserver = null; }
     if (pendingVariantAnchorRetryObserver) { pendingVariantAnchorRetryObserver.disconnect(); pendingVariantAnchorRetryObserver = null; }
     stopScrollLock();
+    removeVariantStateStylesheet();
     clearSession();
     clearHandled();
     resetSessionFileMeta();
@@ -5808,6 +5794,31 @@
 
   // Hold window.scrollY at a fixed value across DOM mutations inside the
   // session's wrapper (HMR patches, variant inserts, cycle swaps).
+  function updateVariantStateStylesheet(sessionId, num) {
+    if (!sessionId || !num) return;
+    let styleEl = document.getElementById(VARIANT_STATE_STYLE_ID);
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = VARIANT_STATE_STYLE_ID;
+      (document.head || document.documentElement).appendChild(styleEl);
+    }
+    const base = '[data-impeccable-variants="' + sessionId + '"] > [data-impeccable-variant';
+    let css = base + ']:not([data-impeccable-variant="' + num + '"]) { display: none !important; }\n';
+    // Force-show the visible variant (overrides source inline display:none on
+    // v2/v3) plus its range/toggle custom properties from paramsCurrentValues.
+    let decls = 'display: block !important;';
+    for (const [id, val] of Object.entries(paramsCurrentValues || {})) {
+      if (typeof val === 'number') decls += ' --p-' + id + ': ' + val + ';';
+      else if (typeof val === 'boolean') decls += ' --p-' + id + ': ' + (val ? '1' : '0') + ';';
+    }
+    css += base + '="' + num + '"] { ' + decls + ' }\n';
+    styleEl.textContent = css;
+  }
+
+  function removeVariantStateStylesheet() {
+    document.getElementById(VARIANT_STATE_STYLE_ID)?.remove();
+  }
+
   function startScrollLock(sessionId, initialTargetY) {
     stopScrollLock();
     scrollLockTargetY = typeof initialTargetY === 'number' && isFinite(initialTargetY)
@@ -7636,6 +7647,7 @@ void main() {
     stopScrollTracking();
     if (variantObserver) { variantObserver.disconnect(); variantObserver = null; }
     stopScrollLock();
+    removeVariantStateStylesheet();
     clearScrollY();
     clearSession();
     resetSessionFileMeta();
@@ -7897,6 +7909,7 @@ void main() {
     if (variantObserver) { variantObserver.disconnect(); variantObserver = null; }
     if (pendingVariantAnchorRetryObserver) { pendingVariantAnchorRetryObserver.disconnect(); pendingVariantAnchorRetryObserver = null; }
     stopScrollLock();
+    removeVariantStateStylesheet();
     clearScrollY();
     finalizeInsertSession();
     clearSession();
@@ -9984,6 +9997,7 @@ void main() {
     window.postMessage({ source: 'impeccable-command', action: 'remove' }, '*');
     setLiveState('IDLE');
     document.getElementById(PICK_CURSOR_STYLE_ID)?.remove();
+    removeVariantStateStylesheet();
     window.__IMPECCABLE_LIVE_INIT__ = false;
     console.log('[impeccable] Live mode exited.');
   }

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -4707,7 +4707,6 @@
       paramsCurrentValues = {};
       tuneOpen = false;
       hideParamsPanel();
-      removeVariantStateStylesheet();
       return;
     }
     const variantEl = getVisibleVariantEl();
@@ -4716,6 +4715,7 @@
       paramsCurrentValues = {};
       tuneOpen = false;
       hideParamsPanel();
+      if (currentSessionId && visibleVariant) updateVariantStateStylesheet(currentSessionId, visibleVariant);
       return;
     }
     applyParamDefaults(variantEl, params);
@@ -5829,7 +5829,7 @@
   }
 
   function updateVariantStateStylesheet(sessionId, num) {
-    if (!sessionId || !num) return;
+    if (!sessionId || num == null || num < 1) return;
 
     let styleEl = document.getElementById(VARIANT_STATE_STYLE_ID);
     if (!styleEl) {

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -3043,6 +3043,16 @@
     } else if (param.kind === 'steps') {
       variantEl.setAttribute(attr, String(value));
     }
+    // Svelte component variants are client-mounted into
+    // [data-impeccable-component-mount] with no [data-impeccable-variant="N"]
+    // wrapper for the state stylesheet to target, and the element is not SSR'd,
+    // so there is no React hydration to mismatch. Drive range/toggle --p-* inline
+    // on the mounted element so scoped preview CSS resolves them.
+    if (svelteComponentSession?.sessionId === currentSessionId) {
+      if (param.kind === 'range') variantEl.style.setProperty('--p-' + param.id, String(value));
+      else if (param.kind === 'toggle') variantEl.style.setProperty('--p-' + param.id, value ? '1' : '0');
+      return;
+    }
     // range/toggle --p-* custom properties are driven through the injected
     // variant-state stylesheet so we never mutate inline style on SSR'd divs.
     updateVariantStateStylesheet(currentSessionId, visibleVariant);

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -355,6 +355,16 @@ describe('live-browser.js regression guards', () => {
       /function removeVariantStateStylesheet\(\)[\s\S]{0,120}?document\.getElementById\(VARIANT_STATE_STYLE_ID\)\?\.remove\(\)/,
       'leaving CYCLING or tearing down live mode must remove the injected variant-state <style>',
     );
+    assert.doesNotMatch(
+      SOURCE,
+      /function refreshParamsPanel\(\)[\s\S]{0,220}?if \(state !== 'CYCLING'\)[\s\S]{0,220}?removeVariantStateStylesheet\(\)/,
+      'refreshParamsPanel must not strip the variant-state sheet during GENERATING first-reveal',
+    );
+    assert.match(
+      SOURCE,
+      /function refreshParamsPanel\(\)[\s\S]{0,600}?if \(!variantEl \|\| params\.length === 0\)[\s\S]{0,220}?updateVariantStateStylesheet\(currentSessionId, visibleVariant\)/,
+      'paramless variant switches must re-sync the variant-state sheet to clear stale --p-* params',
+    );
     assert.match(
       SOURCE,
       /function isVariantShown\(el\)[\s\S]{0,120}?getComputedStyle\(el\)\.display/,

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -330,10 +330,15 @@ describe('live-browser.js regression guards', () => {
       /function setVariantShown\(/,
       'event=live_browser.variant_visibility_hydration actor=browser operation=show_variant_in_dom risk=react19_hydration_mismatch_on_next_app_router expected=stylesheet_rule actual=hidden_and_inline_display_on_variant_div',
     );
-    assert.doesNotMatch(
+    assert.match(
       SOURCE,
-      /variantEl\.style\.setProperty\('--p-'/,
-      'range/toggle --p-* params must not mutate inline style on server-rendered variant divs',
+      /if \(svelteComponentSession\?\.sessionId === currentSessionId\)[\s\S]{0,280}?variantEl\.style\.setProperty\('--p-'/,
+      'client-mounted Svelte component variants drive --p-* inline (no SSR div, no hydration), unlike server-rendered variant divs',
+    );
+    assert.match(
+      SOURCE,
+      /function applyParamValue\([\s\S]{0,1200}?svelteComponentSession\?\.sessionId === currentSessionId[\s\S]{0,400}?return;[\s\S]{0,400}?updateVariantStateStylesheet\(currentSessionId, visibleVariant\)/,
+      'applyParamValue must short-circuit the Svelte inline path before the SSR stylesheet path',
     );
     assert.match(
       SOURCE,

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -342,7 +342,12 @@ describe('live-browser.js regression guards', () => {
     );
     assert.match(
       SOURCE,
-      /function updateVariantStateStylesheet\(sessionId, num\)[\s\S]{0,700}?createElement\('style'\)[\s\S]{0,400}?display: none !important/,
+      /const VARIANT_HIDE_DECL = 'display: none !important;';/,
+      'the hidden-variant rule should be a named constant for readability',
+    );
+    assert.match(
+      SOURCE,
+      /function updateVariantStateStylesheet\(sessionId, num\)[\s\S]{0,500}?createElement\('style'\)[\s\S]{0,500}?VARIANT_HIDE_DECL/,
       'variant cycling must hide non-visible variants with an injected <style> rule keyed by VARIANT_STATE_STYLE_ID',
     );
     assert.match(
@@ -671,7 +676,7 @@ describe('live-browser.js regression guards', () => {
     );
     assert.match(
       SOURCE,
-      /function updateVariantStateStylesheet\(sessionId, num\)[\s\S]{0,900}?display: none !important/,
+      /function updateVariantStateStylesheet\(sessionId, num\)[\s\S]{0,900}?VARIANT_HIDE_DECL/,
       'variant cycling must hide non-visible variants via injected stylesheet, not hidden/style.display on SSR divs',
     );
     assert.match(

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -318,6 +318,45 @@ describe('live-browser.js regression guards', () => {
     );
   });
 
+  it('drives variant visibility and --p-* params through a stylesheet, not inline SSR element mutation', () => {
+    // Variant divs live in page source, so Next.js App Router server-renders
+    // them. Toggling hidden/style.display/--p-* on those nodes client-side
+    // makes React 19 report a hydration mismatch on the next Fast-Refresh
+    // re-render — the same failure mode as scroll-anchor (#276) and pick-cursor
+    // (#286). Visibility and range/toggle custom properties must go through an
+    // injected <style> rule instead.
+    assert.doesNotMatch(
+      SOURCE,
+      /function setVariantShown\(/,
+      'event=live_browser.variant_visibility_hydration actor=browser operation=show_variant_in_dom risk=react19_hydration_mismatch_on_next_app_router expected=stylesheet_rule actual=hidden_and_inline_display_on_variant_div',
+    );
+    assert.doesNotMatch(
+      SOURCE,
+      /variantEl\.style\.setProperty\('--p-'/,
+      'range/toggle --p-* params must not mutate inline style on server-rendered variant divs',
+    );
+    assert.match(
+      SOURCE,
+      /const VARIANT_STATE_STYLE_ID = 'impeccable-variant-state';/,
+      'the variant-state style needs a stable id constant so it can be created and removed by id',
+    );
+    assert.match(
+      SOURCE,
+      /function updateVariantStateStylesheet\(sessionId, num\)[\s\S]{0,700}?createElement\('style'\)[\s\S]{0,400}?display: none !important/,
+      'variant cycling must hide non-visible variants with an injected <style> rule keyed by VARIANT_STATE_STYLE_ID',
+    );
+    assert.match(
+      SOURCE,
+      /function removeVariantStateStylesheet\(\)[\s\S]{0,120}?document\.getElementById\(VARIANT_STATE_STYLE_ID\)\?\.remove\(\)/,
+      'leaving CYCLING or tearing down live mode must remove the injected variant-state <style>',
+    );
+    assert.match(
+      SOURCE,
+      /function isVariantShown\(el\)[\s\S]{0,120}?getComputedStyle\(el\)\.display/,
+      'visible-variant detection must read computed display, not el.hidden or el.style.display',
+    );
+  });
+
   it('global bar includes expandable page chat affordance', () => {
     assert.match(
       SOURCE,
@@ -632,8 +671,8 @@ describe('live-browser.js regression guards', () => {
     );
     assert.match(
       SOURCE,
-      /function setVariantShown\(el, shown\)[\s\S]{0,200}?removeAttribute\('hidden'\)/,
-      'variant cycling must clear the hidden attribute, not only style.display',
+      /function updateVariantStateStylesheet\(sessionId, num\)[\s\S]{0,900}?display: none !important/,
+      'variant cycling must hide non-visible variants via injected stylesheet, not hidden/style.display on SSR divs',
     );
     assert.match(
       SOURCE,

--- a/tests/live-e2e/ui.mjs
+++ b/tests/live-e2e/ui.mjs
@@ -699,7 +699,7 @@ export async function getVisibleVariant(page) {
         const wrapper = window.__impeccableLiveQuery('[data-impeccable-variants]');
         if (wrapper) {
           const variants = [...wrapper.querySelectorAll('[data-impeccable-variant]:not([data-impeccable-variant="original"])')];
-          const visible = variants.find((variant) => variant.style.display !== 'none');
+          const visible = variants.find((variant) => getComputedStyle(variant).display !== 'none');
           const idx = visible ? parseInt(visible.dataset.impeccableVariant || '0', 10) : 0;
           if (idx > 0) return idx;
         }


### PR DESCRIPTION
## tldr

### The problem

When you use Impeccable live mode on a Next.js app (and other SSR setups), we inject design variants as extra divs in the page. Next.js renders those on the server, then React hydrates them in the browser and expects the DOM to match exactly.

While you’re cycling variants, the overlay was directly editing those divs — flipping hidden, setting style="display: …", and writing CSS variables like --p-radius on the elements. React sees that mismatch and throws a hydration error. That’s what issue #287 is about.


### What we changed

Instead of touching the variant divs, we inject a single <style> tag that says something like “hide variants 1 and 3, show variant 2,” and put any slider/toggle values in there too. Visually it’s the same; we’re just not mutating the HTML React is trying to hydrate.

Same approach we already used for scroll locking and the pick cursor — CSS rules instead of inline DOM edits on server-rendered elements.



## Technical Details

- Stops live mode from mutating server-rendered variant divs (`hidden`, inline `style.display`, `--p-*` via `style.setProperty`) during cycling and param tuning.
- Drives visibility and range/toggle custom properties through one injected, session-scoped `<style>` element (`VARIANT_STATE_STYLE_ID`), matching the fix pattern used for scroll-anchor lock (#276) and pick-cursor (#286).
- Updates `isVariantShown` and the live-e2e `getVisibleVariant` helper to use `getComputedStyle` so detection matches the new stylesheet-driven layout.

Fixes #287.

## Root cause

Variant `<div data-impeccable-variant="…">` nodes are scaffolded into page source (e.g. `app/page.jsx`), so Next.js App Router server-renders them. The overlay previously toggled `hidden` / `style.display` and wrote `--p-*` inline while cycling, which React 19 flags as a hydration mismatch on the next Fast-Refresh re-render — surfacing as a flaky `expectConsoleClean` failure in the `nextjs-app-router` live-e2e fixture.

## Test plan

- [x] `node --test tests/live-browser-regression.test.mjs` (new guard + updated insert-mode assertion)
- [x] `bun run test` (198/198)
- [x] `IMPECCABLE_E2E_ONLY=nextjs-app-router bun run test:live-e2e` × 3 consecutive runs (no console flake)
- [x] Full `bun run test:live-e2e` (23/23)

## Notes

- `data-p-*` attributes for `steps` / `toggle` are intentionally unchanged; scoped CSS in source still keys off those attributes. Full elimination is a separate follow-up.
- Source-first PR: no generated harness output synced (`skill/` + `tests/` only).


Made with [Cursor](https://cursor.com)