### PR TITLE
Add APM distribution (build-integrated, skill-only)

### DIFF
--- a/.github/workflows/sync-generated-output.yml
+++ b/.github/workflows/sync-generated-output.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   GENERATED_PATHS: >-
     .agents
+    .apm
     .claude
     .cursor
     .gemini
@@ -33,6 +34,7 @@ env:
     .rovodev
     .trae
     .trae-cn
+    apm.yml
     plugin
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -105,10 +105,14 @@ site/public/_routes.json
 site/public/js/detect-antipatterns-browser.js
 site/public/js/generated/
 
+# APM consumer cache (never commit; apm install writes this locally).
+apm_modules/
+
 # Note: harness skill directories (.claude/skills/, .cursor/skills/, etc.)
-# are intentionally tracked. npx skills reads them from this repo at install
-# time, and they enable clean submodule use. Run `bun run build` to refresh
-# them after editing skill/.
+# and the APM package source (.apm/, apm.yml) are intentionally tracked.
+# npx skills reads harness dirs from this repo at install time; apm install
+# reads .apm/ + apm.yml. Run `bun run build:release` to refresh after
+# editing skill/.
 #
 # Codex CLI consumes `.agents/skills/`; the asset-producer subagent ships
 # nested inside that skill (agents/*.toml), auto-discovered on install.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ If your project already uses [APM](https://microsoft.github.io/apm/), install Im
 apm install pbakaus/impeccable
 ```
 
-APM deploys the skill to `.github/skills/impeccable/` by default and pins the commit in `apm.lock.yaml`. To fan out to Claude Code, Cursor, or OpenCode as well, run `apm runtime setup claude`, `apm runtime setup cursor`, or `apm runtime setup opencode` once, then rerun `apm install`.
+APM copies the skill (no symlink) into its converged `.agents/skills/impeccable/` directory and pins the commit in `apm.lock.yaml`, so `git clone && apm install` reproduces it byte-for-byte. The bundled helper scripts (setup, hooks, live mode) are baked for that converged path, so they resolve out of the box. The `--legacy-skill-paths` mode deploys to per-client folders (`.claude/skills/`, `.cursor/skills/`, …) without the converged copy, which the bundled-script paths are not aligned to.
 
 To refresh after a version bump, rerun `apm install` or update the pin in `apm.yml` (for example `pbakaus/impeccable#v3.8.0`).
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,11 @@ If your project already uses [APM](https://microsoft.github.io/apm/), install Im
 apm install pbakaus/impeccable
 ```
 
-APM copies the skill (no symlink) into its converged `.agents/skills/impeccable/` directory and pins the commit in `apm.lock.yaml`, so `git clone && apm install` reproduces it byte-for-byte. The bundled helper scripts (setup, hooks, live mode) are baked for that converged path, so they resolve out of the box. The `--legacy-skill-paths` mode deploys to per-client folders (`.claude/skills/`, `.cursor/skills/`, …) without the converged copy, which the bundled-script paths are not aligned to.
+APM puts the skill in `.agents/skills/impeccable/` and records the exact version in `apm.lock.yaml`, so anyone who clones the repo and runs `apm install` gets the same files. It copies the skill instead of symlinking it, so the bundled scripts (setup, hooks, live mode) work right away.
 
-To refresh after a version bump, rerun `apm install` or update the pin in `apm.yml` (for example `pbakaus/impeccable#v3.8.0`).
+`--legacy-skill-paths` is the one exception: it puts the skill in per-tool folders (`.claude/skills/`, `.cursor/skills/`) and skips the `.agents/` copy, so the bundled scripts can't find their helpers there.
+
+To update later, rerun `apm install`, or pin a version in `apm.yml` (for example `pbakaus/impeccable#v3.8.0`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ cp -r dist/qoder/.qoder your-project/
 cp -r dist/qoder/.qoder/skills/* ~/.qoder/skills/
 ```
 
+### Option 5: APM (Agent Package Manager)
+
+If your project already uses [APM](https://microsoft.github.io/apm/), install Impeccable from the repo package:
+
+```bash
+apm install pbakaus/impeccable
+```
+
+APM deploys the skill to `.github/skills/impeccable/` by default and pins the commit in `apm.lock.yaml`. To fan out to Claude Code, Cursor, or OpenCode as well, run `apm runtime setup claude`, `apm runtime setup cursor`, or `apm runtime setup opencode` once, then rerun `apm install`.
+
+To refresh after a version bump, rerun `apm install` or update the pin in `apm.yml` (for example `pbakaus/impeccable#v3.8.0`).
+
 ## Usage
 
 Once installed, every command runs through the single `/impeccable` skill:

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,26 +31,29 @@ import { ANTIPATTERNS } from '../cli/engine/registry/antipatterns.mjs';
  * Generate authoritative counts from source data and write to site/public/js/generated/counts.js.
  * Also validates that key HTML files reference the correct numbers.
  */
-function generateCounts(rootDir, skills, buildDir) {
-  // Count active commands. After the v3.0 consolidation, commands are sub-commands
-  // of /impeccable. Count them from the command router table in SKILL.md.
+// Count active commands. After the v3.0 consolidation, commands are sub-commands
+// of /impeccable, counted from the command router table in SKILL.md. Shared by
+// generateCounts (count validation) and the APM manifest description so the two
+// never disagree.
+function countActiveCommands(skills) {
   const impeccableSkill = skills.find(s => s.name === 'impeccable');
-  let commandCount;
   if (impeccableSkill) {
     // Count lines in the command table that start with | `...` | — tolerant
     // of argument hints inside the backticks (e.g. `craft [feature]`) and of
     // multi-word commands (e.g. `pin <command>`).
     const routerMatches = impeccableSkill.body.match(/^\| `[^`]+` \|/gm);
-    commandCount = routerMatches ? routerMatches.length : 0;
-  } else {
-    // Fallback: count user-invocable skills
-    const activeCommands = skills.filter(s => {
-      if (!s.userInvocable) return false;
-      const content = fs.readFileSync(s.filePath, 'utf-8');
-      return !content.includes('DEPRECATED');
-    });
-    commandCount = activeCommands.length;
+    return routerMatches ? routerMatches.length : 0;
   }
+  // Fallback: count non-deprecated user-invocable skills
+  return skills.filter(s => {
+    if (!s.userInvocable) return false;
+    const content = fs.readFileSync(s.filePath, 'utf-8');
+    return !content.includes('DEPRECATED');
+  }).length;
+}
+
+function generateCounts(rootDir, skills, buildDir) {
+  const commandCount = countActiveCommands(skills);
 
   // Count detection rules from the detector registry.
   const detectionCount = new Set(ANTIPATTERNS.map(rule => rule.id)).size;
@@ -793,8 +796,10 @@ async function build() {
     console.log('📦 Built Claude Code plugin subtree at ./plugin/');
 
     // Build the APM package source at ./.apm/ + root apm.yml so consumers can
-    // run `apm install pbakaus/impeccable`. Use the agents (Codex) variant for
-    // a provider-neutral SKILL.md; skill-only — no nested agents/ or hooks/.
+    // run `apm install pbakaus/impeccable`. Ship the agents (Codex) variant: APM
+    // always writes a converged `.agents/skills/` copy, so the variant's baked
+    // `.agents/skills/impeccable/scripts/...` paths resolve no matter which
+    // harness reads the deployed SKILL.md. Skill-only — no nested hooks/.
     const apmRoot = path.join(ROOT_DIR, '.apm');
     const apmSkillsDir = path.join(apmRoot, 'skills');
     const apmSkillDest = path.join(apmSkillsDir, 'impeccable');
@@ -806,21 +811,28 @@ async function build() {
       copyDirSync(apmSkillSrc, apmSkillDest);
       const nestedAgents = path.join(apmSkillDest, 'agents');
       if (fs.existsSync(nestedAgents)) fs.rmSync(nestedAgents, { recursive: true });
+
+      // Write the manifest only once the skill tree exists, so a missing source
+      // never leaves a valid-looking apm.yml with no `.apm/skills/impeccable/`.
+      // Interpolate the command count from the router table (same source as
+      // generateCounts) so the description can't drift when commands change.
+      const commandCount = countActiveCommands(skills);
+      const apmManifest = [
+        'name: impeccable',
+        `version: ${skillsVersion}`,
+        `description: Design fluency for frontend development. 1 skill, ${commandCount} commands, curated anti-pattern detection.`,
+        'author: pbakaus',
+        'dependencies:',
+        '  apm: []',
+        '  mcp: []',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(ROOT_DIR, 'apm.yml'), apmManifest);
+
+      console.log('📦 Built APM package source at ./.apm/ and apm.yml');
+    } else {
+      console.warn('⚠️  Skipped APM package build: agents variant skill not found at', apmSkillSrc);
     }
-
-    const apmManifest = [
-      'name: impeccable',
-      `version: ${skillsVersion}`,
-      'description: Design fluency for frontend development. 1 skill, 23 commands, curated anti-pattern detection.',
-      'author: pbakaus',
-      'dependencies:',
-      '  apm: []',
-      '  mcp: []',
-      '',
-    ].join('\n');
-    fs.writeFileSync(path.join(ROOT_DIR, 'apm.yml'), apmManifest);
-
-    console.log('📦 Built APM package source at ./.apm/ and apm.yml');
   } else {
     console.log('📋 Skipped root harness and plugin sync (--skip-root-sync)');
   }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -791,6 +791,36 @@ async function build() {
     );
 
     console.log('📦 Built Claude Code plugin subtree at ./plugin/');
+
+    // Build the APM package source at ./.apm/ + root apm.yml so consumers can
+    // run `apm install pbakaus/impeccable`. Use the agents (Codex) variant for
+    // a provider-neutral SKILL.md; skill-only — no nested agents/ or hooks/.
+    const apmRoot = path.join(ROOT_DIR, '.apm');
+    const apmSkillsDir = path.join(apmRoot, 'skills');
+    const apmSkillDest = path.join(apmSkillsDir, 'impeccable');
+    const apmSkillSrc = path.join(DIST_DIR, 'agents', '.agents', 'skills', 'impeccable');
+
+    if (fs.existsSync(apmSkillsDir)) fs.rmSync(apmSkillsDir, { recursive: true });
+    if (fs.existsSync(apmSkillSrc)) {
+      fs.mkdirSync(apmSkillsDir, { recursive: true });
+      copyDirSync(apmSkillSrc, apmSkillDest);
+      const nestedAgents = path.join(apmSkillDest, 'agents');
+      if (fs.existsSync(nestedAgents)) fs.rmSync(nestedAgents, { recursive: true });
+    }
+
+    const apmManifest = [
+      'name: impeccable',
+      `version: ${skillsVersion}`,
+      'description: Design fluency for frontend development. 1 skill, 23 commands, curated anti-pattern detection.',
+      'author: pbakaus',
+      'dependencies:',
+      '  apm: []',
+      '  mcp: []',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(ROOT_DIR, 'apm.yml'), apmManifest);
+
+    console.log('📦 Built APM package source at ./.apm/ and apm.yml');
   } else {
     console.log('📋 Skipped root harness and plugin sync (--skip-root-sync)');
   }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -831,6 +831,11 @@ async function build() {
 
       console.log('📦 Built APM package source at ./.apm/ and apm.yml');
     } else {
+      // Source missing: tear down any stale `.apm/` + `apm.yml` so we never
+      // leave a manifest pointing at a skill tree that no longer exists.
+      if (fs.existsSync(apmRoot)) fs.rmSync(apmRoot, { recursive: true });
+      const staleManifest = path.join(ROOT_DIR, 'apm.yml');
+      if (fs.existsSync(staleManifest)) fs.rmSync(staleManifest);
       console.warn('⚠️  Skipped APM package build: agents variant skill not found at', apmSkillSrc);
     }
   } else {


### PR DESCRIPTION
## Motivation
`npx impeccable install` already gives each harness its own correct variant (it copies each harness's compiled build from the universal bundle). APM does **not** beat that — it ships a single skill folder and copies that same folder into every harness, so there's no per-harness bundle. On that axis APM is slightly behind.

The one thing APM adds: for teams already running all their agent context through APM, it lets them install impeccable the same way they install everything else (`apm install pbakaus/impeccable`), with pinned versions in `apm.lock.yaml` and one manifest covering many skills, prompts, and MCP servers. It rides the existing build, so it costs almost nothing to maintain.

| | `npx impeccable install` | APM |
|---|---|---|
| Per-harness variant | yes | no (one shared) |
| Lands the skill as | real copy | real copy |
| Lockfile / pinning | no (always latest) | yes (`apm.lock.yaml`) |
| Reproducible across time | no (tracks latest) | yes (pinned commit) |
| Scope | one skill | many skills, prompts, MCP |

## Summary
- Generate `apm.yml` and `.apm/skills/impeccable/` during `build:release` from the same `skill/` source, so consumers can run `apm install pbakaus/impeccable`.
- Add `.apm` and `apm.yml` to the sync-generated-output workflow so CI commits them to `main` after merge.
- Document APM as Installation Option 5 in the README.

Closes #289

## Test plan
- [x] `bun run build:release` produces `apm.yml` + `.apm/skills/impeccable/`; `bun run build` skips it
- [x] `bun run test` passes
- [x] `apm install` deploys real copies (no symlink); paths resolve; lockfile replay is reproducible
- [ ] After merge: sync workflow commits `.apm/` + `apm.yml` to `main`, then `apm install pbakaus/impeccable` works from GitHub

### What the APM install test showed
Ran `apm install` locally (APM 0.21) into a repo with `.claude/`, `.cursor/`, `.github/` present.

| Check | Result |
|---|---|
| Variants in the package | 1 (a single shared skill folder) |
| Content per harness | identical across `.agents` and `.claude` (not per-harness) |
| Skill on disk | real directory copy (not a symlink) |
| Bundled script paths | resolve via the converged `.agents/skills/` copy |
| Lockfile replay | byte-identical |

## Notes
Source-only PR. Generated APM artifacts are omitted per repo policy; the sync workflow produces them on `main`.
