### PR TITLE
Add COPY.md support via document-copy command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "impeccable",
   "metadata": {
-    "description": "Design fluency for AI harnesses. 1 skill, 23 commands, and curated anti-patterns for impeccable frontend design."
+    "description": "Design fluency for AI harnesses. 1 skill, 24 commands, and curated anti-patterns for impeccable frontend design."
   },
   "owner": {
     "name": "Paul Bakaus",
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "impeccable",
-      "description": "Design fluency for frontend development. 1 skill with 23 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
+      "description": "Design fluency for frontend development. 1 skill with 24 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
       "version": "3.8.0",
       "author": {
         "name": "Paul Bakaus",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "impeccable",
-  "description": "Design fluency for frontend development. 1 skill with 23 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
+  "description": "Design fluency for frontend development. 1 skill with 24 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
   "version": "3.8.0",
   "author": {
     "name": "Paul Bakaus",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Architecture (v3.0+)
 
-There is **one** user-invocable skill, `impeccable`, with **23 commands** underneath it. Users type `/impeccable polish`, `/impeccable audit`, etc. The skill is defined in `skill/`:
+There is **one** user-invocable skill, `impeccable`, with **24 commands** underneath it. Users type `/impeccable polish`, `/impeccable audit`, etc. The skill is defined in `skill/`:
 
 - `SKILL.src.md` — frontmatter (with the auto-trigger-optimized description and the `allowed-tools` list), shared design laws, and the **Commands** router table. Provider `SKILL.md` files are generated from this source.
 - `reference/` — one `<command>.md` per command (`audit.md`, `polish.md`, `critique.md`, etc.) plus the domain reference files (`typography.md`, `color-and-contrast.md`, etc.). When a sub-command is matched, the router loads its reference file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Impeccable
 
-Design guidance for AI coding agents. 1 skill, 23 commands, live browser iteration, and 44 deterministic detector rules for AI-generated frontend design.
+Design guidance for AI coding agents. 1 skill, 24 commands, live browser iteration, and 44 deterministic detector rules for AI-generated frontend design.
 
 > **Quick start:** From your project root, run `npx impeccable install`, then run `/impeccable init` inside your AI coding tool. Full docs: [impeccable.style](https://impeccable.style).
 
@@ -12,7 +12,7 @@ Every model trained on the same SaaS templates. Skip the guidance and you get th
 
 Impeccable adds:
 - **One setup flow.** `/impeccable init` writes `PRODUCT.md` and offers `DESIGN.md`, so later commands know the audience, brand/product lane, voice, anti-references, colors, type, and components.
-- **23 commands.** A shared design vocabulary with your AI: `polish`, `audit`, `critique`, `distill`, `animate`, `bolder`, `quieter`, and more.
+- **24 commands.** A shared design vocabulary with your AI: `polish`, `audit`, `critique`, `distill`, `animate`, `bolder`, `quieter`, and more.
 - **44 deterministic detector rules** plus LLM-only critique checks. The CLI and browser extension run the deterministic rules with no LLM and no API key.
 
 ## What's Included

--- a/scripts/lib/sub-pages-data.js
+++ b/scripts/lib/sub-pages-data.js
@@ -73,6 +73,7 @@ export const SKILL_CATEGORIES = {
   // SYSTEM - setup and tooling
   init: 'system',
   document: 'system',
+  'document-copy': 'system',
   extract: 'system',
   live: 'system',
 };
@@ -131,8 +132,9 @@ export const COMMAND_RELATIONSHIPS = {
   harden: { combinesWith: ['optimize'] },
   onboard: { combinesWith: ['clarify', 'delight'] },
   // System
-  init: { combinesWith: ['document'] },
-  document: { combinesWith: ['init', 'extract'] },
+  init: { combinesWith: ['document', 'document-copy'] },
+  document: { combinesWith: ['init', 'extract', 'document-copy'] },
+  'document-copy': { combinesWith: ['init', 'document'] },
   extract: { combinesWith: ['document'] },
   live: {},
 };

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -707,7 +707,7 @@ const EXCLUDED_FROM_SUGGESTIONS = new Set([
 // These are the commands that audit/critique/etc. reference when suggesting next steps.
 const IMPECCABLE_SUB_COMMANDS = [
   'adapt', 'animate', 'audit', 'bolder', 'clarify', 'colorize',
-  'critique', 'delight', 'distill', 'document', 'harden', 'layout',
+  'critique', 'delight', 'distill', 'document', 'document-copy', 'harden', 'layout',
   'onboard', 'optimize', 'overdrive', 'polish', 'quieter', 'shape', 'typeset',
 ];
 

--- a/scripts/test-suites.mjs
+++ b/scripts/test-suites.mjs
@@ -61,6 +61,7 @@ export const SUITES = {
           'tests/hook-build.test.mjs',
           'tests/hook.test.mjs',
           'tests/impeccable-paths.test.mjs',
+          'tests/scan-copy.test.mjs',
           'tests/target-args.test.mjs',
           'tests/shiki-theme.test.mjs',
           'tests/test-suites.test.mjs',

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -20,14 +20,14 @@ import '../styles/testimonials.css';
 
 <Base
   title="Impeccable: The missing upgrade to Anthropic's impeccable skill"
-  description="1 skill, 23 commands, and curated anti-patterns for impeccable frontend design. Works with Cursor, Claude Code, GitHub Copilot, Gemini CLI, and Codex CLI."
+  description="1 skill, 24 commands, and curated anti-patterns for impeccable frontend design. Works with Cursor, Claude Code, GitHub Copilot, Gemini CLI, and Codex CLI."
   activeNav="home"
   canonicalPath="/"
   bodyClass="home-kinpaku kinpaku-chrome"
   mainId="main-content"
   mainClass="site-content"
   ogTitle="Impeccable: Design skills for AI harnesses"
-  ogDescription="1 skill, 23 commands, and curated anti-patterns for impeccable frontend design. Works with Cursor, Claude Code, GitHub Copilot, Gemini CLI, and Codex CLI."
+  ogDescription="1 skill, 24 commands, and curated anti-patterns for impeccable frontend design. Works with Cursor, Claude Code, GitHub Copilot, Gemini CLI, and Codex CLI."
   ogImage="https://impeccable.style/og-image-v2.jpg"
   twitterSite="@pbakaus"
   twitterCreator="@pbakaus"
@@ -316,7 +316,7 @@ import '../styles/testimonials.css';
       </div>
       <div class="language-content">
         <div class="language-intro-row" data-reveal>
-          <p class="section-lead">23 commands give you a shared design vocabulary with your AI. Each maps to one discipline (<code>/typeset</code> for type, <code>/colorize</code> for color, <code>/animate</code> for motion), so you can ask for the exact thing without explaining it. Pick any to see it in action, or <a href="/docs" class="cheatsheet-link">browse the full reference &rarr;</a></p>
+          <p class="section-lead">24 commands give you a shared design vocabulary with your AI. Each maps to one discipline (<code>/typeset</code> for type, <code>/colorize</code> for color, <code>/animate</code> for motion), so you can ask for the exact thing without explaining it. Pick any to see it in action, or <a href="/docs" class="cheatsheet-link">browse the full reference &rarr;</a></p>
           <div class="language-view-toggle" role="tablist" aria-label="Commands view">
             <button type="button" role="tab" class="language-view-tab is-active" data-view="palette" aria-selected="true">Palette</button>
             <button type="button" role="tab" class="language-view-tab" data-view="periodic" aria-selected="false">Periodic</button>

--- a/site/scripts/components/framework-viz.js
+++ b/site/scripts/components/framework-viz.js
@@ -47,6 +47,7 @@ const commandSymbols = {
 	'onboard': 'On',
 	'init': 'In',
 	'document': 'Dc',
+	'document-copy': 'Cp',
 	'extract': 'Ex',
 	'live': 'Li'
 };
@@ -58,7 +59,7 @@ const commandNumbers = {
 	'delight': 10, 'bolder': 11, 'quieter': 12, 'overdrive': 13,
 	'distill': 14, 'clarify': 15, 'adapt': 16,
 	'polish': 17, 'optimize': 18, 'harden': 19, 'onboard': 20,
-	'init': 21, 'document': 22, 'extract': 23, 'live': 24
+	'init': 21, 'document': 22, 'document-copy': 23, 'extract': 24, 'live': 25
 };
 
 // After the v3.0 consolidation, all commands except the root "impeccable" are

--- a/site/scripts/data.js
+++ b/site/scripts/data.js
@@ -89,6 +89,7 @@ export const commandProcessSteps = {
   'onboard': ['Identify', 'Design', 'Guide', 'Measure'],
   'init': ['Explore', 'Interview', 'Configure', 'Recommend'],
   'document': ['Scan', 'Extract', 'Describe', 'Write'],
+  'document-copy': ['Scan', 'Interview', 'Map', 'Write'],
   'extract': ['Identify', 'Abstract', 'Migrate', 'Document'],
   'live': ['Start', 'Select', 'Generate', 'Accept']
 };
@@ -122,6 +123,7 @@ export const commandCategories = {
   // SYSTEM - setup and tooling
   'init': 'system',
   'document': 'system',
+  'document-copy': 'system',
   'extract': 'system',
   'live': 'system'
 };

--- a/skill/SKILL.src.md
+++ b/skill/SKILL.src.md
@@ -15,7 +15,7 @@ Designs and iterates production-grade frontend interfaces. Real working code, co
 
 You MUST do these steps before proceeding:
 
-1. Run `node {{scripts_path}}/context.mjs` once per session. If the request names or implies a file, route, or app inside a monorepo, infer the concrete path and run `node {{scripts_path}}/context.mjs --target <path>` instead. If you've already seen its output in this conversation, do not re-run it. The script either prints the project's PRODUCT.md (and DESIGN.md when present) as a markdown block, or tells you it's missing. Follow whatever it prints. **If it reports `NO_PRODUCT_MD`, stop and follow `reference/init.md` before doing anything else.** If the output ends with an `UPDATE_AVAILABLE` directive, follow it (ask the user once about updating, then continue). It never blocks the current task.
+1. Run `node {{scripts_path}}/context.mjs` once per session. If the request names or implies a file, route, or app inside a monorepo, infer the concrete path and run `node {{scripts_path}}/context.mjs --target <path>` instead. If you've already seen its output in this conversation, do not re-run it. The script either prints the project's PRODUCT.md (and DESIGN.md / COPY.md when present) as a markdown block, or tells you it's missing. Follow whatever it prints. **If it reports `NO_PRODUCT_MD`, stop and follow `reference/init.md` before doing anything else.** If the output ends with an `UPDATE_AVAILABLE` directive, follow it (ask the user once about updating, then continue). It never blocks the current task.
 2. If the user invoked a sub-command (`craft`, `shape`, `audit`, `polish`, ...), you MUST read `reference/<command>.md` next. Non-optional. The reference defines the command's flow; without it you will skip steps the user expects.
 3. Familiarize yourself with any existing design system, conventions, and components in the code. Read at least one project file (CSS / tokens / theme / a representative component or page). **Required even when you've loaded a sub-command reference in step 2.** Don't reinvent the wheel; use what's there when it works, branch out when the UX wins.
 4. Read the matching register reference. **This is non-optional; skipping it produces generic output.** If the project is marketing, a landing page, a campaign, long-form content, or a portfolio (design IS the product), read `reference/brand.md`. If it is app UI, admin, a dashboard, or a tool (design SERVES the product), read `reference/product.md`. Pick by first match: (1) task cue ("landing page" vs "dashboard"); (2) surface in focus (the page, file, or route being worked on); (3) `register` field in PRODUCT.md.
@@ -125,6 +125,7 @@ If someone could look at this interface and say "AI made that" without doubt, it
 | `shape [feature]` | Build | Plan UX/UI before writing code | [reference/shape.md](reference/shape.md) |
 | `init` | Build | Set up project context: PRODUCT.md, DESIGN.md, live config, next steps | [reference/init.md](reference/init.md) |
 | `document` | Build | Generate DESIGN.md from existing project code | [reference/document.md](reference/document.md) |
+| `document-copy` | Build | Generate COPY.md experience language system from repo + interview | [reference/document-copy.md](reference/document-copy.md) |
 | `extract [target]` | Build | Pull reusable tokens and components into design system | [reference/extract.md](reference/extract.md) |
 | `critique [target]` | Evaluate | UX design review with heuristic scoring | [reference/critique.md](reference/critique.md) |
 | `audit [target]` | Evaluate | Technical quality checks (a11y, perf, responsive) | [reference/audit.md](reference/audit.md) |
@@ -153,6 +154,7 @@ Plus three management commands: `pin <command>`, `unpin <command>`, and `hooks <
 
    Reason over the signals; there is no score to obey:
    - `setup.hasDesign` false while `setup.hasCode` true → `document` (capture the visual system).
+   - `setup.hasCopy` false while `setup.hasCode` true → `document-copy` (capture the experience language).
    - `critique.latest` is `null` → the project has never been critiqued; for a set-up project with a real surface, offering `/impeccable critique <surface>` is a strong default.
    - `critique.latest` with a low `score` or non-zero `p0` / `p1` → `polish` (it reads that snapshot as its backlog), or re-run `critique` if the snapshot looks stale.
    - `git.changedFiles` pointing at one surface → scope `audit` or `polish` to those files specifically, naming them.

--- a/skill/reference/brand-copy.md
+++ b/skill/reference/brand-copy.md
@@ -1,0 +1,28 @@
+# Brand copy register
+
+When copy **is the product**: marketing sites, landing pages, campaigns, long-form content, portfolios.
+
+## The brand copy test
+
+Would someone remember the voice after one read? Brand copy can be more expressive than product UI — but it still must not sacrifice clarity for cleverness.
+
+## Relationship to COPY.md
+
+Brand projects may still use COPY.md for voice, terminology, and CTA patterns. Register in frontmatter: `register: brand`.
+
+Product UI copy rules (dense operator matrices, analytics definitions) usually do not apply. Journey playbooks focus on conversion, narrative arc, and editorial rhythm.
+
+## Brand permissions
+
+- Display typography and editorial voice can be more distinctive
+- Longer sentences and narrative paragraphs where appropriate
+- Emotional range wider than product UI
+- Campaign-specific terminology with explicit campaign scope
+
+## Brand bans
+
+- Eyebrow-on-every-section scaffolding (see impeccable absolute bans)
+- Voice that could belong to any SaaS category without anti-references
+- Product-admin jargon on marketing surfaces
+
+For visual register rules, use [brand.md](brand.md).

--- a/skill/reference/clarify.md
+++ b/skill/reference/clarify.md
@@ -1,5 +1,7 @@
 > **Additional context needed**: audience technical level and users' mental state in context.
 
+If `COPY.md` exists (bundled in `context.mjs` output), read it first. Align rewrites with the experience promise, persona voice, journey playbooks, and decision trees documented there. When COPY.md and PRODUCT.md disagree on voice, COPY.md wins for microcopy; PRODUCT.md wins for strategic positioning.
+
 Find the unclear, confusing, or poorly written interface text and rewrite it. Vague copy creates support tickets and abandonment; specific copy gets users through the task.
 
 

--- a/skill/reference/copy-ai-trust.md
+++ b/skill/reference/copy-ai-trust.md
@@ -1,0 +1,48 @@
+# AI trust language
+
+Use when the product ships AI-assisted features (smart suggestions, summaries, drafting, classification, etc.).
+
+## Principles
+
+1. **Transparency** — users know when content is AI-generated
+2. **Bounded confidence** — never imply certainty the system cannot support
+3. **Governability** — operators understand what thresholds and settings affect output
+4. **Fallback clarity** — no-answer, low-confidence, and human-escalation paths are explicit
+5. **Non-anthropomorphic default** — no fake personality unless customer-configured
+
+## Operator configuration copy
+
+Must explain:
+- What the feature does for end users
+- What changes when enabled (visibility, load, moderation)
+- What thresholds trade off (coverage vs precision)
+- Prerequisites (API keys, data sources, models)
+- Where to audit (logs, review queues)
+
+**Weak:** "Turn on AI magic"  
+**Better:** "Enable smart suggestions. Users see AI-generated drafts when confidence meets your threshold."
+
+## End-user disclosure
+
+- Use customer-configured display name when set; default to neutral ("AI suggestion", "Generated summary")
+- Prefer "AI-generated" or "suggested" when review/uncertainty matters
+- Citation/source language when sources exist
+- Feedback affordances (helpful / not helpful) without guilt-tripping
+
+## Failure and no-answer
+
+| Weak | Better |
+|------|--------|
+| Error | Could not generate a reliable suggestion |
+| AI unavailable | No suggestion met your workspace confidence threshold |
+| Something went wrong | Unable to load AI activity. Try again. |
+
+## Protected AI copy
+
+These must stay platform-consistent (not customer-rewritten without review):
+- Disclosure that content is AI-generated
+- Data/privacy boundaries where legally required
+- Confidence/threshold semantics
+- Moderation and audit terminology
+
+Customizable: display name, citation heading, tone previews (demo content only).

--- a/skill/reference/copy-decision-trees.md
+++ b/skill/reference/copy-decision-trees.md
@@ -1,0 +1,56 @@
+# Copy decision trees
+
+Use for **Errors**, **Empty states**, and **Success** sections in COPY.md. Formulas alone are insufficient.
+
+## Error messages
+
+```
+What failed?
+├── Validation (user can fix input)
+│   └── Imperative: what to enter + example if helpful
+├── Permission (user cannot fix)
+│   └── What they can't do + who can help (admin, owner)
+├── Network / timeout
+│   └── Name the action + retry + wait if known
+├── Conflict / state (stale data)
+│   └── What changed + refresh or review
+└── Unknown server error
+    └── Name the action if possible + retry; avoid bare codes
+```
+
+Never blame the user. Never expose raw codes to end users without explanation.
+
+## Empty states
+
+Classify before writing:
+
+| Type | User need | Copy job |
+|------|-----------|----------|
+| **First-use / setup incomplete** | Get started | Educate + primary CTA |
+| **Filtered / no matches** | Adjust search | Name filter + suggest change |
+| **New workspace / no content yet** | Activation | Invite first action (role-aware) |
+| **Permission-limited** | Understand gap | Explain restriction + path |
+| **Not yet generated** | Wait or configure | Explain when data appears |
+| **Failed load** | Recover | Error pattern, not empty pattern |
+
+**Weak:** "No items"  
+**Better:** "No projects yet. Create your first project to start tracking work."  
+**Role-aware:** Workspace admin vs member may need different CTAs for the same empty surface.
+
+## Success messages (especially operator)
+
+Answer when relevant:
+- **What changed?**
+- **Who/what is affected?**
+- **When does it take effect?**
+- **Next step?**
+- **Undo/review path?**
+
+**Weak:** Success  
+**Better:** "Teammate invite sent. They'll get access when they accept the email."
+
+Simple actions may use brief success; high-risk configuration must not.
+
+## Before / after tables
+
+Every decision tree section in COPY.md should include at least one **Weak | Better | Why** table with real or realistic product examples.

--- a/skill/reference/copy-journeys.md
+++ b/skill/reference/copy-journeys.md
@@ -1,0 +1,57 @@
+# Journey playbooks
+
+Use when writing or auditing **Journey Playbooks** in COPY.md. Every product COPY.md must include at least **5–8** journeys ranked by business importance — not inferred only from string frequency.
+
+## Per-journey template
+
+For each journey, document:
+
+| Field | Question |
+|-------|----------|
+| **Journey** | Name (e.g. "Upgrade to paid plan") |
+| **Primary persona** | Who (use operator audience matrix if applicable) |
+| **Job to be done** | What success looks like |
+| **User anxiety** | What they're afraid of getting wrong |
+| **Desired feeling** | e.g. in control, invited, safe |
+| **Copy role** | What language must do in this flow |
+| **Key moments** | Ordered screens/steps (from code or product knowledge) |
+| **Example copy** | 2–4 real or target strings per moment |
+| **Anti-patterns** | What this journey must never sound like |
+
+## Default journey candidates (product / B2B)
+
+Pick what applies; do not list all generically without evidence:
+
+**Operator / admin**
+- First-time workspace setup
+- Invite teammates or assign roles
+- Feature enablement (especially AI or integrations)
+- Billing or plan change
+- Analytics review / drill-down
+- Developer integration setup (API keys, webhooks)
+- Destructive configuration change
+
+**End user / member**
+- Anonymous visit → registration
+- Sign-in failure / account recovery
+- First core action (first task, first post, first file)
+- Search with no results
+- Permission denied
+- Receiving AI-generated help
+- Destructive content action
+
+**Marketing / brand** (register: brand)
+- Landing → pricing → signup
+- Feature story → proof → CTA
+- Documentation → quickstart → install
+
+## Sequencing rule
+
+Journey copy is about **order**: what the user sees first, what anxiety you remove next, what decision you enable. A journey playbook without ordered moments is not a playbook.
+
+## Evidence sources
+
+1. Route map / feature registry in code
+2. `PRODUCT.md` user and purpose sections
+3. User or stakeholder input (interview Step 4)
+4. Representative locale files along the flow — not isolated keys

--- a/skill/reference/document-copy.md
+++ b/skill/reference/document-copy.md
@@ -1,0 +1,205 @@
+Generate a `COPY.md` file at the project root that captures the project's **experience language system** — not a string inventory.
+
+COPY.md answers: *What should this product feel like to use, and how does language help users succeed across high-value journeys?*
+
+It complements `PRODUCT.md` (strategy) and `DESIGN.md` (visual). **Evidence from the repo is required; frequency counts are not sufficient alone.**
+
+## Anti-goals (reject these outputs)
+
+- A doc that is mostly "top 25 frequent strings"
+- Generic voice ("professional, dependable") with no experience promise
+- One "admin" persona when the product has multiple operator roles
+- Microcopy patterns with no journey playbooks
+- AI features documented in three bullets
+- Empty-state formula without type decision tree
+
+## When to run
+
+- No `COPY.md` exists
+- COPY.md reads like generated i18n metadata
+- Major new journeys (AI, onboarding, billing)
+- Before `/impeccable clarify` at scale
+
+If `COPY.md` exists: ask **refresh**, **merge**, or **skip**.
+
+## Two paths
+
+- **Scan mode** (default): i18n files or inline UI strings exist → extract evidence, interview for ambition, write full COPY.md
+- **Seed mode**: no strings yet → interview + `<!-- SEED -->`; re-run scan when code lands
+
+Run `scan-copy.mjs` first. Empty scan → offer seed mode.
+
+`/impeccable document-copy --seed` forces seed mode regardless of code presence.
+
+## Scan mode
+
+### Step 1: Run scanner (evidence, not voice)
+
+```bash
+node {{scripts_path}}/scan-copy.mjs --target <path>
+```
+
+Use output for: i18n mechanics, key conventions, samples, debt signals. **Do not treat frequent strings as voice rules.**
+
+### Step 2: Read strategic context
+
+1. `PRODUCT.md` — users, purpose, brand personality, anti-references
+2. `DESIGN.md` — only overlapping terminology (button labels vs visual treatment)
+3. Existing `COPY.md` if refreshing
+4. Register reference: [product-copy.md](product-copy.md) or [brand-copy.md](brand-copy.md) per `register` in PRODUCT.md
+
+### Step 3: Map journeys (required)
+
+Identify **5–8** highest-value journeys from code + PRODUCT.md. Follow [copy-journeys.md](copy-journeys.md). Walk each journey's text files in sequence — not random samples.
+
+Minimum reads per journey: first screen, primary action, error, empty/success if present.
+
+**Generic examples** (pick what applies; do not list without evidence):
+- Task app: create project → invite teammate → first task completed
+- Billing SaaS: trial signup → upgrade plan → payment failure recovery
+- Analytics: connect data source → build first dashboard → share report
+- Marketing site: hero → pricing → signup
+
+### Step 4: Experience interview (required unless fully documented)
+
+Ask 2–3 questions per round. Do not skip when voice would stay generic.
+
+**Round A — ambition**
+- One-sentence **experience promise** for copy (what language must help users do/feel)
+- Emotional outcomes per primary persona (operator vs end user vs buyer)
+- Anti-voice: what this product must never sound like
+
+**Round B — governance & white-label** (B2B / multi-tenant products)
+- What copy can customers customize vs what stays platform-protected?
+- AI disclosure and threshold language — any legal/compliance constraints?
+
+**Round C — journeys** (if unclear from code)
+- Rank top 5 journeys by business importance
+- Known support-ticket or drop-off copy failures
+
+Synthesize answers into COPY.md even when inferred — mark `<!-- CONFIRM -->` items for user validation.
+
+### Step 5: Write COPY.md
+
+#### Frontmatter
+
+```yaml
+---
+name: <project>
+register: product | brand
+experiencePromise: "<one sentence — copy's job>"
+copyPrinciples:
+  - "<tradeoff principle, e.g. Name the consequence, not just the action>"
+sourceLocale: en-US
+i18n:
+  detectedApi: formatMessage | useIntl | i18next | t() | unknown
+  filePatterns: ["<patterns found>"]
+personas:
+  <id>:
+    audience: operator | member | buyer | ...
+    tone: <adjectives>
+    formality: low | neutral | high
+protectedCopy: ["security errors", "AI disclosure", ...]
+customizableCopy: ["workspace display name", "welcome messages", ...]
+patterns:
+  error-validation: "Enter a valid email address"
+  empty-first-use: "<example from repo or target>"
+terminology:
+  productNames: []
+---
+```
+
+`patterns` = exemplar strings from repo **or** agreed targets — label which.
+
+#### Markdown body — nine sections (exact order)
+
+1. `## Overview`
+2. `## Copy Principles`
+3. `## Voice & Tone`
+4. `## Terminology`
+5. `## Journey Playbooks`
+6. `## Patterns`
+7. `## Decision Trees`
+8. `## Internationalization & Accessibility`
+9. `## Governance & Do's and Don'ts`
+
+Optional subtitles OK; literal section words must appear.
+
+##### Section guides
+
+**Overview** — Experience promise (1–2 sentences). Who COPY.md serves. How it relates to customer branding. Explicitly state this is an experience-language system, not a string dump.
+
+**Copy Principles** — 4–6 principles that resolve tradeoffs (activation vs brevity, trust vs enthusiasm). Pull from interview + [product-copy.md](product-copy.md).
+
+**Voice & Tone** — Persona subsections. For admin/operator products: **audience matrix** (workspace admin, analyst, developer, etc.). Anti-voice list.
+
+**Terminology** — Canonical terms, variants, product names. Context-variant key conventions if applicable.
+
+**Journey Playbooks** — 5–8 journeys using [copy-journeys.md](copy-journeys.md) template. Ordered moments. Real key citations where possible.
+
+**Patterns** — Microcopy: buttons, forms, confirmations, loading, analytics labels, navigation. Each subsection: rule + **Weak | Better | Why** table (≥3 rows per major pattern).
+
+**Decision Trees** — Errors, empty states, success (admin). Use [copy-decision-trees.md](copy-decision-trees.md). Empty-state **types** table required.
+
+**AI & Trust** — Include as `### AI & Trust` under Decision Trees when the product has AI features; use [copy-ai-trust.md](copy-ai-trust.md). Omit only when product has zero AI surfaces.
+
+**Internationalization & Accessibility** — i18n file layout, APIs, ICU, locale workflow. Cognitive accessibility: link text, permissions, disabled states, chart summaries.
+
+**Governance & Do's and Don'ts** — Who owns COPY.md updates; PR checklist for new strings; deprecated terms; known debt with targets; forceful Never/Always rules.
+
+### Step 6: Quality gate (before finishing)
+
+- [ ] Experience promise is specific to this product, not generic SaaS
+- [ ] Operator audience matrix present (if admin UI exists)
+- [ ] ≥5 journey playbooks with ordered moments
+- [ ] Empty-state types documented
+- [ ] AI trust section present (if AI in product)
+- [ ] Customizable vs protected copy defined (if white-label)
+- [ ] ≥3 Weak/Better/Why tables
+- [ ] i18n rules cite detected patterns, not assumed paths
+- [ ] Known debt section names actionable fixes
+
+Fail the gate → expand weak sections; do not ship a string inventory.
+
+### Step 7: Wrap up
+
+Summarize: promise, principles, journeys covered, gaps needing screenshots/support data, suggested `/impeccable clarify <journey>` targets.
+
+## Seed mode
+
+Interview only. Write COPY.md with `<!-- SEED -->`. Sections 5–7 may be `TBD`. Re-run scan mode after strings exist.
+
+### Step 1: Confirm seed mode
+
+"There's no existing copy to scan. I'll ask a few questions to seed a starter COPY.md. Re-run `/impeccable document-copy` once there's code. OK?"
+
+### Step 2: Five questions
+
+Group into one interaction:
+
+1. **Experience promise** — one sentence: what should language help users accomplish?
+2. **Primary personas** — who reads the copy (operator, member, buyer)?
+3. **Anti-voice** — what must this product never sound like? (name a category cliché)
+4. **Three named references** — products whose copy feels right; what specifically?
+5. **Register** — product UI vs marketing/brand surface?
+
+### Step 3: Write seed COPY.md
+
+Populate Overview, Copy Principles, Voice & Tone from answers. Mark unverified sections `TBD` or `<!-- SEED -->`.
+
+## Style guidelines
+
+- **Experience before inventory.** Journey playbooks and the experience promise are the core; string frequency is evidence only.
+- **Cite PRODUCT.md anti-references by name** in Governance Do's and Don'ts.
+- **Match section names exactly.** Tooling and agents parse COPY.md by header.
+- **Weak | Better | Why** tables beat abstract rules. Use realistic SaaS examples (task apps, billing, analytics), not customer-specific journeys.
+- **Be forceful.** "Never", "always", "required" — match PRODUCT.md's strategic tone.
+- **Don't duplicate PRODUCT.md or DESIGN.md.** COPY.md is strictly how the product reads.
+
+## Pitfalls
+
+- Don't paste raw i18n key dumps into the body.
+- Don't treat `frequentStrings` from scan-copy.mjs as voice guidance.
+- Don't overwrite existing COPY.md without asking.
+- Don't collapse multiple operator roles into one generic "admin" voice.
+- Don't invent journeys with no code or product evidence.

--- a/skill/reference/init.md
+++ b/skill/reference/init.md
@@ -4,13 +4,14 @@ The setup command for a project. One codebase crawl feeds everything it writes:
 
 - **PRODUCT.md** (strategic): root project file for register, target users, product purpose, brand personality, anti-references, strategic design principles. Answers "who/what/why".
 - **DESIGN.md** (visual): root project file for visual theme, color palette, typography, components, layout. Follows the [DESIGN.md format spec](https://raw.githubusercontent.com/google-labs-code/design.md/main/docs/spec.md). Answers "how it looks".
+- **COPY.md** (experience language): root project file for voice, journey playbooks, microcopy patterns, terminology, and i18n rules. Answers "how it reads across journeys".
 - **`.impeccable/live/config.json`** (live mode): pre-configured so `{{command_prefix}}impeccable live` boots straight into variant mode with no first-time detour.
 
-It closes by pointing the user at the best command to run next. Every other impeccable command reads PRODUCT.md and DESIGN.md before doing any work.
+It closes by pointing the user at the best command to run next. Every other impeccable command reads PRODUCT.md, DESIGN.md, and COPY.md (when present) before doing any work.
 
 ## Step 1: Load current state
 
-Check what already exists. PRODUCT.md and DESIGN.md live at the project root, or under `.agents/context/` or `docs/` (case-insensitive). Read whichever are present with your native file tool. Also note whether `.impeccable/live/config.json` already exists (Step 6 leaves it untouched if so).
+Check what already exists. PRODUCT.md, DESIGN.md, and COPY.md live at the project root, or under `.agents/context/` or `docs/` (case-insensitive). Read whichever are present with your native file tool. Also note whether `.impeccable/live/config.json` already exists (Step 6 leaves it untouched if so).
 
 Decision tree:
 - **Neither file exists (empty project or no context yet)**: do Steps 2-4 (write PRODUCT.md), then decide on DESIGN.md based on whether there's code to analyze.
@@ -135,6 +136,15 @@ If the user agrees, delegate to `/impeccable document` (it auto-detects scan vs 
 
 If the user prefers to skip, mention they can run `/impeccable document` any time later.
 
+Offer `/impeccable document-copy` when the project has UI strings or i18n files (or after PRODUCT.md is written for pre-implementation seed mode):
+
+- **Strings exist**: "I can generate a COPY.md that captures your experience language — voice, journeys, and microcopy patterns — so agents stay on-voice. Want to do that now?"
+- **Pre-implementation**: "I can seed a starter COPY.md from a short interview about experience promise and personas. Re-run once there's code. Want to do that now?"
+
+If the user agrees, delegate to `/impeccable document-copy`. Load its reference and follow that flow.
+
+If the user prefers to skip, mention they can run `/impeccable document-copy` any time later.
+
 ## Step 6: Configure live mode (when code exists)
 
 If the project has code with HTML entries and a dev server (the same "code exists" condition that puts `/impeccable document` in scan mode), pre-configure live mode now. You already identified the framework and the served HTML entry in Step 2, so this is nearly free, and it spares the user the first-time setup detour when they later run `/impeccable live`.
@@ -155,9 +165,9 @@ Writing the config file is harmless and needs no consent; only the CSP **source-
 
 Summarize tersely:
 - Register captured (brand / product)
-- What was written (PRODUCT.md, DESIGN.md, live config, or a subset)
+- What was written (PRODUCT.md, DESIGN.md, COPY.md, live config, or a subset)
 - The 3-5 strategic principles from PRODUCT.md that will guide future work
-- If DESIGN.md or live config is pending, one line on how to set it up later
+- If DESIGN.md, COPY.md, or live config is pending, one line on how to set it up later
 
 Then recommend the **best commands to run next**, drawn from what your Step 2 crawl already surfaced. Do not run a fresh analysis here; surface observations you already have. Tailor to register and to what you saw, offer the 2-4 most relevant (not a menu dump), and give the exact command to type. Group by intent:
 

--- a/skill/reference/product-copy.md
+++ b/skill/reference/product-copy.md
@@ -1,0 +1,66 @@
+# Product copy register
+
+When copy **serves the product**: app UI, admin consoles, dashboards, settings, onboarding, AI surfaces inside the product.
+
+## The product copy test
+
+Not "is every string grammatically correct." The test is: does the language help the user **complete a high-value journey** with **confidence** — and would a fluent user of the category's best tools (Linear, Notion, Stripe Dashboard, Figma) trust this product to configure, participate, or decide?
+
+Failure mode: every micro-label is fine, but the full flow feels fragmented, anxious, or generic.
+
+## What product COPY.md must optimize for
+
+1. **Activation** — first value, not just first click
+2. **Confidence** — consequences before and after action
+3. **Trust** — AI, permissions, billing, security
+4. **Momentum** — meaningful next steps, not dead ends
+5. **Governed flexibility** — customer brand where allowed; platform clarity where required
+6. **Decision support** — operators interpret, not just configure
+
+Consistency is the floor. These six are the ceiling.
+
+## Operators are not one voice
+
+For B2B / multi-tenant products, split operator-side audiences:
+
+| Audience | Copy optimizes for | Jargon tolerance |
+|----------|-------------------|------------------|
+| Workspace / program admin | Actionable interpretation, growth | Low–medium |
+| Content moderator | Speed, consequence, next action | Medium |
+| Analyst | Definitions, periods, caveats | Medium (precision) |
+| Developer / integrator | Exact system behavior | High |
+| Account owner / governance | Control, scope, risk | Low |
+| Executive stakeholder | Outcomes, not implementation | Low |
+
+Document the matrix for the product. Do not collapse an admin app into one tone row.
+
+## Journey-first, pattern-second
+
+Microcopy rules (buttons, errors) are necessary but insufficient. COPY.md must include **journey playbooks** for the product's highest-value flows. See [copy-journeys.md](copy-journeys.md).
+
+## AI inside the product
+
+If the product ships AI features, AI trust language is not a subsection — it is a first-class concern. See [copy-ai-trust.md](copy-ai-trust.md).
+
+## White-label tension
+
+Define **customizable copy** (customer-owned) vs **protected platform copy** (supportability, compliance, security). Multi-tenant products need this explicitly.
+
+## Cognitive accessibility
+
+Beyond localized `aria-label`:
+
+- Meaningful link text out of context
+- No direction-only instructions ("click below")
+- Plain-language permission denials
+- Disabled-state explanations
+- Chart/table summaries for screen readers
+
+## Product copy bans (on top of shared rules)
+
+- Generic enterprise voice with no experience promise ("professional, dependable" alone)
+- Empty states that only announce absence
+- Success toasts that confirm without scope or effect
+- AI copy that implies certainty without system support
+- One operator voice for admins and developers
+- String-frequency tables presented as "voice"

--- a/skill/scripts/command-metadata.json
+++ b/skill/scripts/command-metadata.json
@@ -11,6 +11,10 @@
     "description": "Generate a DESIGN.md file that captures the current visual design system. Auto-extracts colors, typography, spacing, radii, and component patterns from the codebase, then asks the user to confirm descriptive language for atmosphere and color character. Follows the Google Stitch DESIGN.md format so the file is tool-compatible. Use when you need a visual design spec an AI agent can follow to stay on-brand.",
     "argumentHint": ""
   },
+  "document-copy": {
+    "description": "Generate a COPY.md experience language system: voice, journey playbooks, microcopy patterns, and i18n rules. Scans locale files for evidence, interviews for experience promise and personas, then writes a structured COPY.md that complements PRODUCT.md and DESIGN.md. Use when you need UX writing guidance agents can follow across journeys — not a string inventory.",
+    "argumentHint": ""
+  },
   "extract": {
     "description": "Pull reusable patterns, components, and design tokens into the design system. Identifies repeated patterns and consolidates them. Use when you have drift across the codebase and want to bring things back to a consistent system.",
     "argumentHint": "[target]"

--- a/skill/scripts/context-signals.mjs
+++ b/skill/scripts/context-signals.mjs
@@ -11,7 +11,7 @@
  * output is always valid JSON.
  *
  * Signals:
- *   - setup:     PRODUCT.md / DESIGN.md presence, register, whether code exists
+ *   - setup:     PRODUCT.md / DESIGN.md / COPY.md presence, register, whether code exists
  *   - critique:  the latest cached critique score (.impeccable/critique)
  *   - git:       branch + files changed vs the default branch (a scope hint)
  *   - devServer: whether a local dev server answers on a common port (gates live)
@@ -195,6 +195,8 @@ export async function gatherSignals(cwd = process.cwd()) {
       productPath: ctx.productPath,
       hasDesign: ctx.hasDesign,
       designPath: ctx.designPath,
+      hasCopy: ctx.hasCopy,
+      copyPath: ctx.copyPath,
       hasCode: hasCode(cwd),
       register: extractRegister(ctx.product),
     },

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -1,11 +1,11 @@
 /**
- * Context loader: prints PRODUCT.md (and DESIGN.md if present) as one
+ * Context loader: prints PRODUCT.md (and DESIGN.md / COPY.md when present) as one
  * markdown block on stdout, or exits with empty stdout when no PRODUCT.md
  * is found anywhere. The skill keys off "empty stdout" to branch into the
  * init flow.
  *
  * Path resolution (first match wins):
- *   1. Active project root, if PRODUCT.md or DESIGN.md is there
+ *   1. Active project root, if PRODUCT.md, DESIGN.md, or COPY.md is there
  *   2. Active project .agents/context/ then docs/
  *   3. Monorepo root context, using the same order, as a per-file fallback
  *   4. $IMPECCABLE_CONTEXT_DIR (absolute or cwd-relative) — power-user
@@ -24,6 +24,8 @@ import { parseTargetOptions } from './lib/target-args.mjs';
 
 const PRODUCT_NAMES = ['PRODUCT.md', 'Product.md', 'product.md'];
 const DESIGN_NAMES = ['DESIGN.md', 'Design.md', 'design.md'];
+const COPY_NAMES = ['COPY.md', 'Copy.md', 'copy.md'];
+const CONTEXT_FILE_NAMES = [...PRODUCT_NAMES, ...DESIGN_NAMES, ...COPY_NAMES];
 const FALLBACK_DIRS = ['.agents/context', 'docs'];
 const MONOREPO_MARKER_FILES = ['pnpm-workspace.yaml', 'turbo.json', 'nx.json', 'lerna.json'];
 const MONOREPO_FALLBACK_PROJECT_DIRS = ['apps', 'packages'];
@@ -63,8 +65,10 @@ export function loadContext(cwd = process.cwd(), options = {}) {
   const absCwd = path.resolve(cwd);
   const productPath = resolved.productPath;
   const designPath = resolved.designPath;
+  const copyPath = resolved.copyPath;
   const product = productPath ? safeRead(productPath) : null;
   const design = designPath ? safeRead(designPath) : null;
+  const copy = copyPath ? safeRead(copyPath) : null;
   return {
     hasProduct: !!product,
     product,
@@ -72,9 +76,13 @@ export function loadContext(cwd = process.cwd(), options = {}) {
     hasDesign: !!design,
     design,
     designPath: designPath ? path.relative(absCwd, designPath) : null,
+    hasCopy: !!copy,
+    copy,
+    copyPath: copyPath ? path.relative(absCwd, copyPath) : null,
     contextDir: resolved.contextDir,
     productContextDir: productPath ? path.dirname(productPath) : null,
     designContextDir: designPath ? path.dirname(designPath) : null,
+    copyContextDir: copyPath ? path.dirname(copyPath) : null,
     projectRoot: resolved.projectRoot,
     repoRoot: resolved.repoRoot,
     isMonorepo: resolved.isMonorepo,
@@ -95,13 +103,17 @@ function resolveContext(cwd = process.cwd(), options = {}) {
   let designPath =
     (projectContextDir ? firstExisting(projectContextDir, DESIGN_NAMES) : null)
     || (rootContextDir ? firstExisting(rootContextDir, DESIGN_NAMES) : null);
+  let copyPath =
+    (projectContextDir ? firstExisting(projectContextDir, COPY_NAMES) : null)
+    || (rootContextDir ? firstExisting(rootContextDir, COPY_NAMES) : null);
 
   let envContextDir = null;
-  if (!productPath && !designPath) {
+  if (!productPath && !designPath && !copyPath) {
     envContextDir = resolveEnvContextDir(absCwd);
     if (envContextDir) {
       productPath = firstExisting(envContextDir, PRODUCT_NAMES);
       designPath = firstExisting(envContextDir, DESIGN_NAMES);
+      copyPath = firstExisting(envContextDir, COPY_NAMES);
     }
   }
 
@@ -110,9 +122,12 @@ function resolveContext(cwd = process.cwd(), options = {}) {
       ? path.dirname(productPath)
       : designPath
         ? path.dirname(designPath)
-        : envContextDir || project.projectRoot,
+        : copyPath
+          ? path.dirname(copyPath)
+          : envContextDir || project.projectRoot,
     productPath,
     designPath,
+    copyPath,
     projectRoot: project.projectRoot,
     repoRoot: project.repoRoot,
     isMonorepo: project.isMonorepo,
@@ -181,12 +196,12 @@ function isPathInside(candidate, root) {
 }
 
 function resolveLocalContextDir(root) {
-  if (firstExisting(root, [...PRODUCT_NAMES, ...DESIGN_NAMES])) {
+  if (firstExisting(root, CONTEXT_FILE_NAMES)) {
     return root;
   }
   for (const rel of FALLBACK_DIRS) {
     const candidate = path.resolve(root, rel);
-    if (firstExisting(candidate, [...PRODUCT_NAMES, ...DESIGN_NAMES])) {
+    if (firstExisting(candidate, CONTEXT_FILE_NAMES)) {
       return candidate;
     }
   }
@@ -300,11 +315,13 @@ function discoverTargetCandidates(repoRoot) {
 function resolveCandidateContextSummary(repoRoot, projectRoot, targetPath) {
   const ctx = resolveContext(repoRoot, { targetPath });
   return {
-    productStatus: contextSourceStatus(ctx.productPath, repoRoot, projectRoot),
-    productPath: contextSourcePath(ctx.productPath, repoRoot),
-    designStatus: contextSourceStatus(ctx.designPath, repoRoot, projectRoot),
-    designPath: contextSourcePath(ctx.designPath, repoRoot),
-  };
+        productStatus: contextSourceStatus(ctx.productPath, repoRoot, projectRoot),
+        productPath: contextSourcePath(ctx.productPath, repoRoot),
+        designStatus: contextSourceStatus(ctx.designPath, repoRoot, projectRoot),
+        designPath: contextSourcePath(ctx.designPath, repoRoot),
+        copyStatus: contextSourceStatus(ctx.copyPath, repoRoot, projectRoot),
+        copyPath: contextSourcePath(ctx.copyPath, repoRoot),
+      };
 }
 
 // Selection candidates surface one of four statuses: 'child' (a canonical
@@ -405,7 +422,7 @@ function walkDirs(root, visit) {
 function isCandidateProjectRoot(dir) {
   return !!(
     fs.existsSync(path.join(dir, 'package.json'))
-    || firstExisting(dir, [...PRODUCT_NAMES, ...DESIGN_NAMES])
+    || firstExisting(dir, CONTEXT_FILE_NAMES)
     || fs.existsSync(path.join(dir, 'src'))
     || fs.existsSync(path.join(dir, 'app'))
     || fs.existsSync(path.join(dir, 'pages'))
@@ -473,7 +490,7 @@ function nearestProjectLikeRoot(repoRoot, targetDir) {
   const stop = path.resolve(repoRoot);
   while (dir && dir !== stop) {
     if (
-      firstExisting(dir, [...PRODUCT_NAMES, ...DESIGN_NAMES])
+      firstExisting(dir, CONTEXT_FILE_NAMES)
       || fs.existsSync(path.join(dir, 'package.json'))
     ) {
       return dir;
@@ -875,6 +892,9 @@ async function cli() {
   if (ctx.hasDesign) {
     parts.push(`# DESIGN.md\n\n${ctx.design.trim()}`);
   }
+  if (ctx.hasCopy) {
+    parts.push(`# COPY.md\n\n${ctx.copy.trim()}`);
+  }
   parts.push(buildResolvedContextDirective(ctx, cliOptions, { targetExists }));
   if (shouldWarnMissingTarget(ctx, targetProvided, targetExists)) {
     parts.push(buildMissingTargetDirective());
@@ -910,6 +930,7 @@ function buildResolvedContextDirective(ctx, options, { targetExists = null } = {
     repoRoot: ctx.repoRoot,
     productPath: ctx.productPath,
     designPath: ctx.designPath,
+    copyPath: ctx.copyPath,
   }, null, 2)}`;
 }
 
@@ -936,7 +957,7 @@ function buildMissingTargetDirective() {
 function buildTargetSelectionDirective(selection) {
   return (
     `TARGET_SELECTION_REQUIRED:\n${JSON.stringify(selection, null, 2)}\n\n` +
-    'Show each app with its productStatus/productPath and designStatus/designPath so the user can see child overrides, inherited root files, fallback files, or missing files before choosing. ' +
+    'Show each app with its productStatus/productPath, designStatus/designPath, and copyStatus/copyPath so the user can see child overrides, inherited root files, fallback files, or missing files before choosing. ' +
     'Ask the user which app Impeccable should use, then rerun Impeccable helper commands from that child app cwd using this same scripts directory. ' +
     'Use `--target <path>` only as a fallback when changing cwd is not possible, or when the user explicitly named a file/path.'
   );

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -92,20 +92,15 @@ export function loadContext(cwd = process.cwd(), options = {}) {
 function resolveContext(cwd = process.cwd(), options = {}) {
   const absCwd = path.resolve(cwd);
   const project = resolveProject(absCwd, options);
-  const projectContextDir = resolveLocalContextDir(project.projectRoot);
-  const rootContextDir = project.isMonorepo && project.repoRoot !== project.projectRoot
-    ? resolveLocalContextDir(project.repoRoot)
-    : null;
+  let productPath = resolveContextFileInTree(project.projectRoot, PRODUCT_NAMES);
+  let designPath = resolveContextFileInTree(project.projectRoot, DESIGN_NAMES);
+  let copyPath = resolveContextFileInTree(project.projectRoot, COPY_NAMES);
 
-  let productPath =
-    (projectContextDir ? firstExisting(projectContextDir, PRODUCT_NAMES) : null)
-    || (rootContextDir ? firstExisting(rootContextDir, PRODUCT_NAMES) : null);
-  let designPath =
-    (projectContextDir ? firstExisting(projectContextDir, DESIGN_NAMES) : null)
-    || (rootContextDir ? firstExisting(rootContextDir, DESIGN_NAMES) : null);
-  let copyPath =
-    (projectContextDir ? firstExisting(projectContextDir, COPY_NAMES) : null)
-    || (rootContextDir ? firstExisting(rootContextDir, COPY_NAMES) : null);
+  if (project.isMonorepo && project.repoRoot !== project.projectRoot) {
+    productPath = productPath || resolveContextFileInTree(project.repoRoot, PRODUCT_NAMES);
+    designPath = designPath || resolveContextFileInTree(project.repoRoot, DESIGN_NAMES);
+    copyPath = copyPath || resolveContextFileInTree(project.repoRoot, COPY_NAMES);
+  }
 
   let envContextDir = null;
   if (!productPath && !designPath && !copyPath) {
@@ -204,6 +199,16 @@ function resolveLocalContextDir(root) {
     if (firstExisting(candidate, CONTEXT_FILE_NAMES)) {
       return candidate;
     }
+  }
+  return null;
+}
+
+function resolveContextFileInTree(root, fileNames) {
+  const found = firstExisting(root, fileNames);
+  if (found) return found;
+  for (const rel of FALLBACK_DIRS) {
+    const hit = firstExisting(path.resolve(root, rel), fileNames);
+    if (hit) return hit;
   }
   return null;
 }

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -315,13 +315,13 @@ function discoverTargetCandidates(repoRoot) {
 function resolveCandidateContextSummary(repoRoot, projectRoot, targetPath) {
   const ctx = resolveContext(repoRoot, { targetPath });
   return {
-        productStatus: contextSourceStatus(ctx.productPath, repoRoot, projectRoot),
-        productPath: contextSourcePath(ctx.productPath, repoRoot),
-        designStatus: contextSourceStatus(ctx.designPath, repoRoot, projectRoot),
-        designPath: contextSourcePath(ctx.designPath, repoRoot),
-        copyStatus: contextSourceStatus(ctx.copyPath, repoRoot, projectRoot),
-        copyPath: contextSourcePath(ctx.copyPath, repoRoot),
-      };
+    productStatus: contextSourceStatus(ctx.productPath, repoRoot, projectRoot),
+    productPath: contextSourcePath(ctx.productPath, repoRoot),
+    designStatus: contextSourceStatus(ctx.designPath, repoRoot, projectRoot),
+    designPath: contextSourcePath(ctx.designPath, repoRoot),
+    copyStatus: contextSourceStatus(ctx.copyPath, repoRoot, projectRoot),
+    copyPath: contextSourcePath(ctx.copyPath, repoRoot),
+  };
 }
 
 // Selection candidates surface one of four statuses: 'child' (a canonical

--- a/skill/scripts/pin.mjs
+++ b/skill/scripts/pin.mjs
@@ -27,7 +27,7 @@ const HARNESS_DIRS = [
 
 // Valid sub-command names
 const VALID_COMMANDS = [
-  'craft', 'init', 'extract', 'document', 'shape',
+  'craft', 'init', 'extract', 'document', 'document-copy', 'shape',
   'critique', 'audit',
   'polish', 'bolder', 'quieter', 'distill', 'harden', 'onboard', 'live',
   'animate', 'colorize', 'typeset', 'layout', 'delight', 'overdrive',

--- a/skill/scripts/scan-copy.mjs
+++ b/skill/scripts/scan-copy.mjs
@@ -25,20 +25,25 @@ function parseArgs(argv) {
   return { target, sampleLimit };
 }
 
-function isLocaleFile(name, parentDir) {
+function hasLocaleAncestor(ancestorDirs) {
+  return ancestorDirs.some((d) => d === 'locales' || d === 'text');
+}
+
+function isLocaleFile(name, ancestorDirs) {
   if (LOCALE_FILE_RE.test(name)) return true;
+  const parentDir = ancestorDirs.at(-1) ?? '';
   if (parentDir === 'text' && /^[a-z]{2}(-[A-Z]{2})?\.json$/.test(name)) return true;
-  if (parentDir === 'locales' && name.endsWith('.json')) return true;
+  if (hasLocaleAncestor(ancestorDirs) && name.endsWith('.json')) return true;
   return false;
 }
 
-function walk(dir, files = [], parentName = '') {
+function walk(dir, files = [], ancestorDirs = []) {
   if (!fs.existsSync(dir)) return files;
   for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
     if (IGNORE.has(ent.name)) continue;
     const p = path.join(dir, ent.name);
-    if (ent.isDirectory()) walk(p, files, ent.name);
-    else if (isLocaleFile(ent.name, parentName)) files.push(p);
+    if (ent.isDirectory()) walk(p, files, [...ancestorDirs, ent.name]);
+    else if (isLocaleFile(ent.name, ancestorDirs)) files.push(p);
   }
   return files;
 }

--- a/skill/scripts/scan-copy.mjs
+++ b/skill/scripts/scan-copy.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Scan locale / i18n string files for COPY.md evidence.
+ * Output is i18n metadata + samples — NOT voice. Pair with document-copy interview.
+ * Usage: node scan-copy.mjs [--target <path>] [--limit N]
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']);
+
+const LOCALE_FILE_RE =
+  /^(text\.[a-z]{2}(-[A-Z]{2})?\.json|messages\.(en|en-US)\.(json|ts)|en\.json|en-US\.json)$/i;
+
+function parseArgs(argv) {
+  let target = process.cwd();
+  let sampleLimit = 3;
+  for (let i = 0; i < argv.length; i++) {
+    if ((argv[i] === '--target' || argv[i] === '-t') && argv[i + 1]) {
+      target = path.resolve(argv[++i]);
+    } else if (argv[i] === '--limit' && argv[i + 1]) {
+      sampleLimit = Number(argv[++i]) || 3;
+    }
+  }
+  return { target, sampleLimit };
+}
+
+function isLocaleFile(name, parentDir) {
+  if (LOCALE_FILE_RE.test(name)) return true;
+  if (parentDir === 'text' && /^[a-z]{2}(-[A-Z]{2})?\.json$/.test(name)) return true;
+  if (parentDir === 'locales' && name.endsWith('.json')) return true;
+  return false;
+}
+
+function walk(dir, files = [], parentName = '') {
+  if (!fs.existsSync(dir)) return files;
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (IGNORE.has(ent.name)) continue;
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory()) walk(p, files, ent.name);
+    else if (isLocaleFile(ent.name, parentName)) files.push(p);
+  }
+  return files;
+}
+
+function categorizeKey(key) {
+  const k = key.toLowerCase();
+  if (k.includes('error') || k.endsWith('.error')) return 'errors';
+  if (k.includes('modal') || k.includes('confirm')) return 'confirmations';
+  if (k.includes('empty') || k.includes('noresult')) return 'empty';
+  if (k.includes('loading') || k.includes('spinner')) return 'loading';
+  if (k.includes('success') || k.includes('saved')) return 'success';
+  if (k.includes('label') || k.includes('description') || k.includes('placeholder')) return 'forms';
+  if (k.includes('submit') || k.includes('cancel') || k === 'ok' || k.includes('button')) return 'buttons';
+  if (k.includes('title') || k.includes('heading')) return 'headings';
+  if (k.includes('aria')) return 'aria';
+  if (k.includes('ai') || k.includes('suggest') || k.includes('generated')) return 'ai';
+  return 'other';
+}
+
+function topValues(map, n = 15) {
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([value, count]) => ({ value, count }));
+}
+
+function main() {
+  const { target, sampleLimit } = parseArgs(process.argv.slice(2));
+  const files = walk(target);
+  const valueCounts = new Map();
+  const keySuffixes = new Map();
+  const categories = {};
+  const samples = {};
+  let keyCount = 0;
+  let icuCount = 0;
+  let variantKeyCount = 0;
+
+  for (const file of files) {
+    const rel = path.relative(target, file);
+    let json;
+    try {
+      json = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+      continue;
+    }
+
+    for (const [key, value] of Object.entries(json)) {
+      if (typeof value !== 'string') continue;
+      keyCount++;
+      valueCounts.set(value, (valueCounts.get(value) || 0) + 1);
+
+      if (key.includes('@')) {
+        variantKeyCount++;
+        const suffix = key.split('@').slice(1).join('@');
+        keySuffixes.set(suffix, (keySuffixes.get(suffix) || 0) + 1);
+      }
+      if (value.includes('{') && (value.includes('plural') || value.includes('#'))) icuCount++;
+
+      const cat = categorizeKey(key);
+      categories[cat] = (categories[cat] || 0) + 1;
+      if (!samples[cat]) samples[cat] = [];
+      if (samples[cat].length < sampleLimit) {
+        samples[cat].push({ key, value: value.slice(0, 120), file: rel });
+      }
+    }
+  }
+
+  const result = {
+    target,
+    scannedAt: new Date().toISOString(),
+    disclaimer:
+      'Evidence for i18n mechanics and debt signals only. Do NOT treat frequentStrings as voice. Run document-copy interview for experience promise and journeys.',
+    stats: {
+      localeFiles: files.length,
+      totalKeys: keyCount,
+      variantKeys: variantKeyCount,
+      icuStrings: icuCount,
+      byCategory: categories,
+    },
+    detectedFilePatterns: [...new Set(files.map((f) => path.basename(f)))].slice(0, 20),
+    topVariantSuffixes: topValues(keySuffixes, 12),
+    frequentStrings: topValues(valueCounts, 15),
+    debtSignals: {
+      genericErrorTitles: valueCounts.get('Error') || valueCounts.get('Something went wrong') || 0,
+      bareSuccess: valueCounts.get('Success') || 0,
+      bareCancel: valueCounts.get('Cancel') || 0,
+      bareLoading: valueCounts.get('Loading...') || valueCounts.get('Loading') || 0,
+    },
+    samples,
+    nextSteps: [
+      'Map 5-8 journeys from PRODUCT.md — walk locale files in flow order',
+      'Run experience interview (document-copy.md Step 4)',
+      'Build journey playbooks — not frequency tables',
+    ],
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main();

--- a/skill/scripts/scan-copy.mjs
+++ b/skill/scripts/scan-copy.mjs
@@ -43,6 +43,20 @@ function walk(dir, files = [], parentName = '') {
   return files;
 }
 
+function keyTokens(key) {
+  return key
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function isAiKey(key) {
+  const k = key.toLowerCase();
+  if (k.includes('suggest') || k.includes('generated')) return true;
+  return keyTokens(key).includes('ai');
+}
+
 function categorizeKey(key) {
   const k = key.toLowerCase();
   if (k.includes('error') || k.endsWith('.error')) return 'errors';
@@ -54,8 +68,21 @@ function categorizeKey(key) {
   if (k.includes('submit') || k.includes('cancel') || k === 'ok' || k.includes('button')) return 'buttons';
   if (k.includes('title') || k.includes('heading')) return 'headings';
   if (k.includes('aria')) return 'aria';
-  if (k.includes('ai') || k.includes('suggest') || k.includes('generated')) return 'ai';
+  if (isAiKey(key)) return 'ai';
   return 'other';
+}
+
+function collectStringEntries(obj, prefix = '') {
+  const entries = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'string') {
+      entries.push([fullKey, value]);
+    } else if (value && typeof value === 'object' && !Array.isArray(value)) {
+      entries.push(...collectStringEntries(value, fullKey));
+    }
+  }
+  return entries;
 }
 
 function topValues(map, n = 15) {
@@ -85,8 +112,7 @@ function main() {
       continue;
     }
 
-    for (const [key, value] of Object.entries(json)) {
-      if (typeof value !== 'string') continue;
+    for (const [key, value] of collectStringEntries(json)) {
       keyCount++;
       valueCounts.set(value, (valueCounts.get(value) || 0) + 1);
 

--- a/skill/scripts/scan-copy.mjs
+++ b/skill/scripts/scan-copy.mjs
@@ -10,7 +10,7 @@ import path from 'node:path';
 const IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']);
 
 const LOCALE_FILE_RE =
-  /^(text\.[a-z]{2}(-[A-Z]{2})?\.json|messages\.(en|en-US)\.(json|ts)|en\.json|en-US\.json)$/i;
+  /^(text\.[a-z]{2}(-[A-Z]{2})?\.json|messages\.(en|en-US)\.json|en\.json|en-US\.json)$/i;
 
 function parseArgs(argv) {
   let target = process.cwd();
@@ -52,9 +52,8 @@ function keyTokens(key) {
 }
 
 function isAiKey(key) {
-  const k = key.toLowerCase();
-  if (k.includes('suggest') || k.includes('generated')) return true;
-  return keyTokens(key).includes('ai');
+  const tokens = keyTokens(key);
+  return tokens.includes('ai') || tokens.includes('suggest') || tokens.includes('generated');
 }
 
 function categorizeKey(key) {

--- a/skill/scripts/scan-copy.mjs
+++ b/skill/scripts/scan-copy.mjs
@@ -121,7 +121,7 @@ function main() {
         const suffix = key.split('@').slice(1).join('@');
         keySuffixes.set(suffix, (keySuffixes.get(suffix) || 0) + 1);
       }
-      if (value.includes('{') && (value.includes('plural') || value.includes('#'))) icuCount++;
+      if (value.includes('{') && value.includes('plural')) icuCount++;
 
       const cat = categorizeKey(key);
       categories[cat] = (categories[cat] || 0) + 1;

--- a/skill/scripts/scan-copy.mjs
+++ b/skill/scripts/scan-copy.mjs
@@ -9,8 +9,11 @@ import path from 'node:path';
 
 const IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']);
 
-const LOCALE_FILE_RE =
-  /^(text\.[a-z]{2}(-[A-Z]{2})?\.json|messages\.(en|en-US)\.json|en\.json|en-US\.json)$/i;
+const LOCALE_CODE_RE = '[a-z]{2}(-[A-Z]{2})?';
+const LOCALE_FILE_RE = new RegExp(
+  `^(text\\.${LOCALE_CODE_RE}\\.json|messages\\.${LOCALE_CODE_RE}\\.json|${LOCALE_CODE_RE}\\.json)$`,
+  'i',
+);
 
 function parseArgs(argv) {
   let target = process.cwd();

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -1,5 +1,5 @@
 /**
- * Tests for the shared context loader (PRODUCT.md / DESIGN.md resolver).
+ * Tests for the shared context loader (PRODUCT.md / DESIGN.md / COPY.md resolver).
  * Run with: node --test tests/load-context.test.mjs
  *
  * Covers the resolution order:
@@ -128,11 +128,22 @@ describe('loadContext', () => {
     const ctx = loadContext(scratch);
     assert.equal(ctx.hasProduct, true);
     assert.equal(ctx.hasDesign, true);
+    assert.equal(ctx.hasCopy, false);
     assert.match(ctx.product, /product content/);
     assert.match(ctx.design, /design content/);
     assert.equal(ctx.productPath, 'PRODUCT.md');
     assert.equal(ctx.designPath, 'DESIGN.md');
     assert.equal(ctx.contextDir, scratch);
+  });
+
+  it('reads COPY.md from the root alongside PRODUCT.md', () => {
+    write('PRODUCT.md', '# product content\n');
+    write('COPY.md', '# copy content\n');
+    const ctx = loadContext(scratch);
+    assert.equal(ctx.hasProduct, true);
+    assert.equal(ctx.hasCopy, true);
+    assert.match(ctx.copy, /copy content/);
+    assert.equal(ctx.copyPath, 'COPY.md');
   });
 
   it('reads from .agents/context/ when the root is clean', () => {
@@ -761,6 +772,16 @@ describe('context.mjs CLI', () => {
     assert.match(res.stdout, /\n---\n/);
     assert.match(res.stdout, /# DESIGN\.md\n\n# Acme design/);
     assert.match(res.stdout, /NEXT STEP:/);
+  });
+
+  it('includes COPY.md when present', async () => {
+    write('PRODUCT.md', '# Acme product\n');
+    write('COPY.md', '# Acme copy\n');
+    const { spawnSync } = await import('node:child_process');
+    const res = spawnSync(process.execPath, [SCRIPT_PATH], { cwd: scratch, encoding: 'utf8', env: { ...process.env, IMPECCABLE_NO_UPDATE_CHECK: '1' } });
+    assert.equal(res.status, 0);
+    assert.match(res.stdout, /# COPY\.md\n\n# Acme copy/);
+    assert.match(res.stdout, /"copyPath": "COPY\.md"/);
   });
 
   it('reads from a fallback dir when cwd is clean', async () => {

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -146,6 +146,18 @@ describe('loadContext', () => {
     assert.equal(ctx.copyPath, 'COPY.md');
   });
 
+  it('finds PRODUCT.md in fallback dirs when only COPY.md is at the root', () => {
+    write('COPY.md', '# copy at root\n');
+    write('.agents/context/PRODUCT.md', '# product in agents\n');
+    const ctx = loadContext(scratch);
+    assert.equal(ctx.hasProduct, true);
+    assert.equal(ctx.hasCopy, true);
+    assert.match(ctx.product, /product in agents/);
+    assert.match(ctx.copy, /copy at root/);
+    assert.equal(ctx.productPath, path.join('.agents', 'context', 'PRODUCT.md'));
+    assert.equal(ctx.copyPath, 'COPY.md');
+  });
+
   it('reads from .agents/context/ when the root is clean', () => {
     write('.agents/context/PRODUCT.md', '# product in agents\n');
     write('.agents/context/DESIGN.md', '# design in agents\n');

--- a/tests/scan-copy.test.mjs
+++ b/tests/scan-copy.test.mjs
@@ -170,6 +170,29 @@ describe('scan-copy.mjs', () => {
     assert.equal(data.stats.totalKeys, 4);
   });
 
+  it('scans flat locale code json outside locales/ (i18n/de.json not just en)', () => {
+    const i18nDir = path.join(scratch, 'i18n');
+    fs.mkdirSync(i18nDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(i18nDir, 'en.json'),
+      JSON.stringify({ 'app.title': 'Taskflow' }),
+    );
+    fs.writeFileSync(
+      path.join(i18nDir, 'de.json'),
+      JSON.stringify({ 'app.title': 'Aufgaben' }),
+    );
+    fs.writeFileSync(
+      path.join(i18nDir, 'fr-CA.json'),
+      JSON.stringify({ 'app.title': 'Flux de tâches' }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.localeFiles, 3);
+    assert.equal(data.stats.totalKeys, 3);
+  });
+
   it('ignores typescript locale modules (json-only scanner)', () => {
     const localeDir = path.join(scratch, 'locales');
     fs.mkdirSync(localeDir, { recursive: true });

--- a/tests/scan-copy.test.mjs
+++ b/tests/scan-copy.test.mjs
@@ -54,4 +54,51 @@ describe('scan-copy.mjs', () => {
     assert.equal(data.stats.localeFiles, 0);
     assert.equal(data.stats.totalKeys, 0);
   });
+
+  it('scans nested locale json (i18next-style catalogs)', () => {
+    const localeDir = path.join(scratch, 'locales');
+    fs.mkdirSync(localeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localeDir, 'en.json'),
+      JSON.stringify({
+        common: {
+          save: 'Save',
+          cancel: 'Cancel',
+        },
+        errors: {
+          network: 'Network error',
+        },
+      }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.localeFiles, 1);
+    assert.equal(data.stats.totalKeys, 3);
+  });
+
+  it('does not classify email/detail/paid keys as ai', () => {
+    const localeDir = path.join(scratch, 'locales');
+    fs.mkdirSync(localeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localeDir, 'en.json'),
+      JSON.stringify({
+        'user.email': 'Email',
+        'order.detail': 'Details',
+        'invoice.paid': 'Paid',
+        'feature.ai.summary': 'AI summary',
+      }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.byCategory.ai, 1);
+    const aiKeys = (data.samples.ai || []).map((s) => s.key);
+    assert.ok(aiKeys.includes('feature.ai.summary'));
+    assert.ok(!aiKeys.includes('user.email'));
+    assert.ok(!aiKeys.includes('order.detail'));
+    assert.ok(!aiKeys.includes('invoice.paid'));
+  });
 });

--- a/tests/scan-copy.test.mjs
+++ b/tests/scan-copy.test.mjs
@@ -1,0 +1,57 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'skill',
+  'scripts',
+  'scan-copy.mjs',
+);
+
+let scratch;
+
+beforeEach(() => {
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-scan-copy-'));
+});
+
+afterEach(() => {
+  fs.rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('scan-copy.mjs', () => {
+  it('scans locale json files and reports evidence metadata', () => {
+    const localeDir = path.join(scratch, 'locales');
+    fs.mkdirSync(localeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localeDir, 'en.json'),
+      JSON.stringify({
+        'app.title': 'Taskflow',
+        'form.email.error': 'Enter a valid email address',
+        'empty.projects': 'No projects yet',
+        'button.save': 'Save',
+      }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.localeFiles, 1);
+    assert.equal(data.stats.totalKeys, 4);
+    assert.match(data.disclaimer, /Do NOT treat frequentStrings as voice/);
+    assert.ok(data.samples.errors || data.samples.forms || data.samples.empty);
+  });
+
+  it('returns empty stats when no locale files exist', () => {
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.localeFiles, 0);
+    assert.equal(data.stats.totalKeys, 0);
+  });
+});

--- a/tests/scan-copy.test.mjs
+++ b/tests/scan-copy.test.mjs
@@ -142,6 +142,34 @@ describe('scan-copy.mjs', () => {
     assert.ok(!aiKeys.includes('search.suggestions.title'));
   });
 
+  it('scans nested locale subdirectories (locales/en/*.json)', () => {
+    const enDir = path.join(scratch, 'locales', 'en');
+    fs.mkdirSync(enDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(enDir, 'common.json'),
+      JSON.stringify({
+        'app.title': 'Taskflow',
+        'button.save': 'Save',
+      }),
+    );
+
+    const enUsDir = path.join(scratch, 'locales', 'en-US');
+    fs.mkdirSync(enUsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(enUsDir, 'translation.json'),
+      JSON.stringify({
+        'nav.home': 'Home',
+        'nav.settings': 'Settings',
+      }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.localeFiles, 2);
+    assert.equal(data.stats.totalKeys, 4);
+  });
+
   it('ignores typescript locale modules (json-only scanner)', () => {
     const localeDir = path.join(scratch, 'locales');
     fs.mkdirSync(localeDir, { recursive: true });

--- a/tests/scan-copy.test.mjs
+++ b/tests/scan-copy.test.mjs
@@ -78,6 +78,24 @@ describe('scan-copy.mjs', () => {
     assert.equal(data.stats.totalKeys, 3);
   });
 
+  it('does not count hashtag template strings as ICU plurals', () => {
+    const localeDir = path.join(scratch, 'locales');
+    fs.mkdirSync(localeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localeDir, 'en.json'),
+      JSON.stringify({
+        'user.created': 'User #{username} created',
+        'achievement.rank': 'Top #{rank} achievement',
+        'items.count': '{count, plural, one {# item} other {# items}}',
+      }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.icuStrings, 1);
+  });
+
   it('does not classify email/detail/paid keys as ai', () => {
     const localeDir = path.join(scratch, 'locales');
     fs.mkdirSync(localeDir, { recursive: true });

--- a/tests/scan-copy.test.mjs
+++ b/tests/scan-copy.test.mjs
@@ -119,4 +119,42 @@ describe('scan-copy.mjs', () => {
     assert.ok(!aiKeys.includes('order.detail'));
     assert.ok(!aiKeys.includes('invoice.paid'));
   });
+
+  it('does not classify suggestion keys as ai', () => {
+    const localeDir = path.join(scratch, 'locales');
+    fs.mkdirSync(localeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localeDir, 'en.json'),
+      JSON.stringify({
+        'form.suggestion.label': 'Suggestion',
+        'search.suggestions.title': 'Suggestions',
+        'copilot.suggest.action': 'Suggest with AI',
+      }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.byCategory.ai, 1);
+    const aiKeys = (data.samples.ai || []).map((s) => s.key);
+    assert.ok(aiKeys.includes('copilot.suggest.action'));
+    assert.ok(!aiKeys.includes('form.suggestion.label'));
+    assert.ok(!aiKeys.includes('search.suggestions.title'));
+  });
+
+  it('ignores typescript locale modules (json-only scanner)', () => {
+    const localeDir = path.join(scratch, 'locales');
+    fs.mkdirSync(localeDir, { recursive: true });
+    fs.writeFileSync(path.join(localeDir, 'messages.en.ts'), "export default { title: 'App' };");
+    fs.writeFileSync(
+      path.join(localeDir, 'en.json'),
+      JSON.stringify({ 'app.title': 'Taskflow' }),
+    );
+
+    const res = spawnSync(process.execPath, [SCRIPT_PATH, '--target', scratch], { encoding: 'utf8' });
+    assert.equal(res.status, 0);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.stats.localeFiles, 1);
+    assert.equal(data.stats.totalKeys, 1);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds **`document-copy`** — a new Impeccable build command that generates `COPY.md`, an experience language system (voice, journey playbooks, microcopy patterns, i18n rules) complementing the existing `PRODUCT.md` + `DESIGN.md` trio.
- Extends **`context.mjs`** and **`context-signals.mjs`** to load and surface `COPY.md` alongside product and design context.
- Ships **`scan-copy.mjs`** for locale/i18n evidence gathering (mechanics and debt signals — not voice), plus register references (`product-copy.md`, `brand-copy.md`) and supporting docs (`copy-journeys.md`, `copy-decision-trees.md`, `copy-ai-trust.md`).
- Wires **`init`**, **`clarify`**, and routing to recommend `document-copy` when code exists but COPY.md is missing.

**Impeccable trio:** `PRODUCT.md` = who/why · `DESIGN.md` = how it looks · **`COPY.md` = how it reads across journeys.**

All examples and reference content use generic SaaS patterns (task apps, billing, analytics, workspace admin). No customer-specific copy or fixtures are included.

## Test plan

- [ ] `node --test tests/context.test.mjs` — COPY.md resolution and CLI output
- [ ] `node --test tests/scan-copy.test.mjs` — locale scanner
- [ ] On any repo with `PRODUCT.md` and i18n files: run `/impeccable document-copy` and confirm interview + COPY.md generation flow
- [ ] Run `node skill/scripts/context.mjs` and verify `# COPY.md` block appears when file exists
- [ ] Run `node skill/scripts/scan-copy.mjs --target <app>` and confirm JSON evidence output (not voice rules)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are skill docs, context loading, and a read-only locale scanner with tests—no auth, payments, or production runtime paths beyond agent guidance.
> 
> **Overview**
> Adds **`document-copy`** as the 24th Impeccable command and introduces **`COPY.md`** as the experience-language counterpart to `PRODUCT.md` and `DESIGN.md` (voice, journeys, patterns—not a string dump).
> 
> **`context.mjs`** now resolves, loads, and prints `COPY.md` (including fallback dirs and monorepo selection); **`context-signals.mjs`** exposes `hasCopy` / `copyPath`. New **`scan-copy.mjs`** gathers locale/i18n evidence for the command flow, with **`tests/scan-copy.test.mjs`** in the core suite.
> 
> Skill wiring: router table and metadata, **`init`** offers `document-copy`, **`clarify`** defers to `COPY.md` for voice, and no-arg routing suggests `document-copy` when code exists but copy context is missing. Reference docs cover **`document-copy.md`** plus product/brand copy registers and journey/decision-tree/AI-trust guides.
> 
> Site/plugin/README counts move **23 → 24** commands; sub-page data, placeholders, pin list, and homepage viz include `document-copy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f8a4bb8da45ad3c14b18bfaec3f6fb26d25c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->