### PR TITLE
Add Grok Build install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ From the root of your project, run:
 npx impeccable install
 ```
 
-This shows the harness folders it detected (for example `~/.claude`, `~/.codex`, or project-local `.cursor`), lets you keep the detected set or customize providers, then asks whether to install into the current project or globally. Use `--providers=claude,codex,cursor` and `--scope=project|global` to skip those choices in scripts. On Claude Code, Cursor, and Codex, it also installs the provider-native hook manifest for the current project. Works with Cursor, Claude Code, Gemini CLI, Codex CLI, and every other supported tool. Reload your harness afterward.
+This shows the harness folders it detected (for example `~/.claude`, `~/.codex`, or project-local `.cursor`), lets you keep the detected set or customize providers, then asks whether to install into the current project or globally. Use `--providers=claude,codex,cursor` and `--scope=project|global` to skip those choices in scripts. On Claude Code, Cursor, and Codex, it also installs the provider-native hook manifest for the current project. Works with Cursor, Claude Code, Gemini CLI, Codex CLI, Grok Build, and every other supported tool. Reload your harness afterward.
 
 To refresh an existing install, run:
 
@@ -233,6 +233,27 @@ cp -r dist/qoder/.qoder your-project/
 # Or global (applies to all projects)
 cp -r dist/qoder/.qoder/skills/* ~/.qoder/skills/
 ```
+
+**Grok Build:**
+
+```bash
+# Recommended: install as a Grok plugin (skills + hooks)
+grok plugin install pbakaus/impeccable --trust
+```
+
+Grok also reads Claude Code and Codex skill paths through its compatibility layer, so these work without a separate `.grok/` build:
+
+```bash
+# Via Claude Code compat (~/.claude/skills/)
+npx impeccable install --providers=claude
+
+# Via Codex/agents compat (~/.agents/skills/)
+npx impeccable install --providers=codex
+```
+
+After install, run `/impeccable init` in a Grok session. Verify with `grok inspect`. Project hooks from Claude or Cursor compat require `/hooks-trust` (or launch with `--trust`) before they run.
+
+> [Grok Build docs](https://x.ai/cli) — skills live in `.grok/skills/` or plugins; Grok scans `.claude/skills/`, `.agents/skills/`, and `.cursor/skills/` by default.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,27 @@ git submodule update --remote .impeccable
 npx impeccable link --source=.impeccable --providers=claude,cursor
 ```
 
-### Option 3: Download from Website
+### Option 3: Plugin install
+
+**Claude Code:**
+```bash
+/plugin marketplace add pbakaus/impeccable
+```
+
+> Claude Code only. After adding the marketplace, open `/plugin` and install Impeccable from the list.
+
+**Grok Build:**
+```bash
+grok plugin install pbakaus/impeccable --trust
+```
+
+> Grok Build only. Then run `/impeccable init` in a Grok session.
+
+### Option 4: Download from Website
 
 Visit [impeccable.style](https://impeccable.style), download the ZIP for your tool, and extract to your project.
 
-### Option 4: Copy from Repository
+### Option 5: Copy from Repository
 
 **Cursor:**
 ```bash
@@ -234,27 +250,6 @@ cp -r dist/qoder/.qoder your-project/
 cp -r dist/qoder/.qoder/skills/* ~/.qoder/skills/
 ```
 
-**Grok Build:**
-
-```bash
-# Recommended: install as a Grok plugin (skills + hooks)
-grok plugin install pbakaus/impeccable --trust
-```
-
-Grok also reads Claude Code and Codex skill paths through its compatibility layer, so these work without a separate `.grok/` build:
-
-```bash
-# Via Claude Code compat (~/.claude/skills/)
-npx impeccable install --providers=claude
-
-# Via Codex/agents compat (~/.agents/skills/)
-npx impeccable install --providers=codex
-```
-
-After install, run `/impeccable init` in a Grok session. Verify with `grok inspect`. Project hooks from Claude or Cursor compat require `/hooks-trust` (or launch with `--trust`) before they run.
-
-> [Grok Build docs](https://x.ai/cli) — skills live in `.grok/skills/` or plugins; Grok scans `.claude/skills/`, `.agents/skills/`, and `.cursor/skills/` by default.
-
 ## Usage
 
 Once installed, every command runs through the single `/impeccable` skill:
@@ -337,6 +332,7 @@ Full detector docs: [impeccable.style/docs/detector](https://impeccable.style/do
 - [GitHub Copilot](https://github.com/features/copilot)
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [Codex CLI](https://github.com/openai/codex)
+- [Grok Build](https://x.ai/cli)
 - [OpenCode](https://opencode.ai)
 - [Pi](https://pi.dev)
 - [Kiro](https://kiro.dev)


### PR DESCRIPTION
## Summary

Documents how to use Impeccable with Grok Build without adding a separate \.grok/\ provider build. Grok already discovers skills via plugins and its Claude/Codex compatibility layer.

## Changes

- Mention Grok Build in the CLI installer blurb
- Add a **Grok Build** section under Option 4 with three install paths:
  - \grok plugin install pbakaus/impeccable --trust\ (recommended)
  - \
px impeccable install --providers=claude\ (Claude compat)
  - \
px impeccable install --providers=codex\ (agents compat)
- Note \/hooks-trust\ for project hooks and \grok inspect\ for verification

## Validation

- Docs-only change; no build or generated harness output touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no code, build, or harness output changes.
> 
> **Overview**
> Documents **Grok Build** as a supported harness and adds a dedicated install path alongside existing options.
> 
> The CLI installer blurb now lists Grok Build among tools that work with `npx impeccable install`. **Option 3: Plugin install** is new: Claude Code marketplace instructions stay grouped there, and Grok Build gets `grok plugin install pbakaus/impeccable --trust` plus a note to run `/impeccable init` in a Grok session. Former download/copy sections are renumbered to **Option 4** and **Option 5**. **Supported Tools** gains a Grok Build link to x.ai/cli.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed350e8c139504387509a218cbc56921ed47f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->