### PR TITLE
Fix: preserve external ~/.claude/skills symlink on first install (#295)

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -1019,19 +1019,23 @@ async function chooseInstallPlan(projectRoot, flags, { yes } = {}) {
  * ~/.config/agents/skills`) - is preserved and written through. See issue #295.
  */
 function isInProjectProviderLink(localSkillsDir, root, provider) {
-  let real;
+  let target;
   try {
     if (!lstatSync(localSkillsDir).isSymbolicLink()) return false;
-    real = realpathSync(localSkillsDir);
+    target = readlinkSync(localSkillsDir);
   } catch {
-    return false; // missing or dangling link: not an in-project provider link
+    return false; // not a symlink, or unreadable
   }
+  // Resolve the link's TARGET lexically against the link's own directory. We
+  // deliberately do NOT realpathSync the target:
+  //   * it lets a not-yet-created in-project target still match, so a dangling
+  //     `.claude/skills -> ../.agents/skills` is still dropped;
+  //   * it compares the ACTUAL target, not a shared realpath, so two providers
+  //     pointing at the SAME external dir are never misread as in-project.
+  const resolvedTarget = resolve(dirname(localSkillsDir), target);
   for (const other of PROVIDER_DIRS) {
     if (other === provider) continue;
-    const otherSkills = join(root, other, 'skills');
-    try {
-      if (existsSync(otherSkills) && realpathSync(otherSkills) === real) return true;
-    } catch {}
+    if (resolvedTarget === join(root, other, 'skills')) return true;
   }
   return false;
 }

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -1011,6 +1011,32 @@ async function chooseInstallPlan(projectRoot, flags, { yes } = {}) {
 }
 
 /**
+ * Whether `localSkillsDir` is a symlink that points at ANOTHER in-project
+ * provider's skills dir (e.g. `.claude/skills -> ../.agents/skills`, the shape a
+ * prior `npx skills` install can leave behind). Only these get dropped so each
+ * provider can receive its own compiled variant. A symlink to anywhere else -
+ * notably a user's external shared skills dir (`~/.claude/skills ->
+ * ~/.config/agents/skills`) - is preserved and written through. See issue #295.
+ */
+function isInProjectProviderLink(localSkillsDir, root, provider) {
+  let real;
+  try {
+    if (!lstatSync(localSkillsDir).isSymbolicLink()) return false;
+    real = realpathSync(localSkillsDir);
+  } catch {
+    return false; // missing or dangling link: not an in-project provider link
+  }
+  for (const other of PROVIDER_DIRS) {
+    if (other === provider) continue;
+    const otherSkills = join(root, other, 'skills');
+    try {
+      if (existsSync(otherSkills) && realpathSync(otherSkills) === real) return true;
+    } catch {}
+  }
+  return false;
+}
+
+/**
  * Copy each target provider's compiled skill variant from an extracted bundle
  * into the project. Writes real directories (copy, never symlink) so every
  * harness keeps the build that was compiled for it. Returns skills written.
@@ -1022,10 +1048,12 @@ function copyProviderSkills(bundleDir, root, targets) {
     if (existsSync(srcDir)) {
       const localSkillsDir = join(root, provider, 'skills');
       // A previous `npx skills` install may have left this provider's skills dir
-      // as a symlink to another provider's canonical copy. Drop the link so we
-      // write a real, provider-specific directory instead of writing through it.
+      // as a symlink to ANOTHER in-project provider's canonical copy. Drop only
+      // that link so we write a real, provider-specific directory. A user's
+      // external shared-skills symlink (e.g. ~/.claude/skills ->
+      // ~/.config/agents/skills) is preserved and written through. See #295.
       try {
-        if (lstatSync(localSkillsDir).isSymbolicLink()) unlinkSync(localSkillsDir);
+        if (isInProjectProviderLink(localSkillsDir, root, provider)) unlinkSync(localSkillsDir);
       } catch {}
       for (const skill of readdirSync(srcDir, { withFileTypes: true })) {
         if (!skill.isDirectory()) continue;

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -134,6 +134,44 @@ if (WANT_CLI_REMOTE_E2E) {
 }
 const describeRemote = (WANT_CLI_REMOTE_E2E && bundleReachable) ? describe : describe.skip;
 
+describe('copyProviderSkills: symlink handling', () => {
+  test('preserves an external shared-skills symlink and writes through it (#295)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-295-ext-'));
+    const root = join(tmp, 'home');
+    const shared = join(tmp, 'shared');
+    mkdirSync(root, { recursive: true });
+    mkdirSync(join(shared, 'other-skill'), { recursive: true });
+    writeFileSync(join(shared, 'other-skill', 'SKILL.md'), '---\nname: other-skill\n---\n');
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    symlinkSync(shared, join(root, '.claude', 'skills'), 'dir');
+
+    const bundle = createFakeUniversalBundle(tmp, ['.claude']);
+    copyProviderSkills(bundle, root, ['.claude']);
+
+    const skillsPath = join(root, '.claude', 'skills');
+    expect(lstatSync(skillsPath).isSymbolicLink()).toBe(true);
+    expect(realpathSync(skillsPath)).toBe(realpathSync(shared));
+    expect(existsSync(join(skillsPath, 'other-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(shared, 'impeccable', 'SKILL.md'))).toBe(true);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('still converts an in-project cross-provider link to a real dir', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-295-inproj-'));
+    mkdirSync(join(tmp, '.agents', 'skills'), { recursive: true });
+    mkdirSync(join(tmp, '.claude'), { recursive: true });
+    symlinkSync('../.agents/skills', join(tmp, '.claude', 'skills'), 'dir');
+
+    const bundle = createFakeUniversalBundle(tmp, ['.claude']);
+    copyProviderSkills(bundle, tmp, ['.claude']);
+
+    const skillsPath = join(tmp, '.claude', 'skills');
+    expect(lstatSync(skillsPath).isSymbolicLink()).toBe(false);
+    expect(existsSync(join(skillsPath, 'impeccable', 'SKILL.md'))).toBe(true);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
 describe('skills install: already-installed detection', () => {
   test('detects impeccable sentinel and bails', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'imp-test-'));

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -170,6 +170,46 @@ describe('copyProviderSkills: symlink handling', () => {
     expect(existsSync(join(skillsPath, 'impeccable', 'SKILL.md'))).toBe(true);
     rmSync(tmp, { recursive: true, force: true });
   });
+
+  test('preserves external symlinks when two providers share one external dir (#295, multi-tool)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-295-multi-'));
+    const root = join(tmp, 'home');
+    const shared = join(tmp, 'shared');
+    mkdirSync(root, { recursive: true });
+    mkdirSync(join(shared, 'other-skill'), { recursive: true });
+    writeFileSync(join(shared, 'other-skill', 'SKILL.md'), '---\nname: other-skill\n---\n');
+    for (const provider of ['.claude', '.agents']) {
+      mkdirSync(join(root, provider), { recursive: true });
+      symlinkSync(shared, join(root, provider, 'skills'), 'dir');
+    }
+
+    const bundle = createFakeUniversalBundle(tmp, ['.claude', '.agents']);
+    copyProviderSkills(bundle, root, ['.claude', '.agents']);
+
+    for (const provider of ['.claude', '.agents']) {
+      const skillsPath = join(root, provider, 'skills');
+      expect(lstatSync(skillsPath).isSymbolicLink()).toBe(true);
+      expect(realpathSync(skillsPath)).toBe(realpathSync(shared));
+    }
+    expect(existsSync(join(shared, 'other-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(shared, 'impeccable', 'SKILL.md'))).toBe(true);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('replaces a dangling in-project cross-provider link with a real dir', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-295-dangling-'));
+    // Link to another provider's in-project skills dir that does NOT exist yet.
+    mkdirSync(join(tmp, '.claude'), { recursive: true });
+    symlinkSync('../.agents/skills', join(tmp, '.claude', 'skills'), 'dir');
+
+    const bundle = createFakeUniversalBundle(tmp, ['.claude']);
+    copyProviderSkills(bundle, tmp, ['.claude']);
+
+    const skillsPath = join(tmp, '.claude', 'skills');
+    expect(lstatSync(skillsPath).isSymbolicLink()).toBe(false);
+    expect(existsSync(join(skillsPath, 'impeccable', 'SKILL.md'))).toBe(true);
+    rmSync(tmp, { recursive: true, force: true });
+  });
 });
 
 describe('skills install: already-installed detection', () => {


### PR DESCRIPTION
## Summary

Fixes #295. On a fresh `npx impeccable install`, the installer replaced a user's
external `~/.claude/skills` symlink with a real directory containing only
`impeccable`, which silently broke every other skill the user shared through that
symlink.

## The setup that breaks

Some users keep all skills in one shared folder and point each tool at it:

```
~/.claude/skills  ->  ~/.config/agents/skills/   (other-skill/, another-skill/, ...)
```

## What went wrong

`copyProviderSkills` (the first-install copy path) unconditionally removed any
symlink at `<provider>/skills`:

```js
if (lstatSync(localSkillsDir).isSymbolicLink()) unlinkSync(localSkillsDir);
```

That line exists for a narrow case: a prior `npx skills` install pointing one
provider at another in-project provider (`.claude/skills -> ../.agents/skills`),
where writing a real per-provider dir is correct. But it also deleted a user's
external shared-skills symlink, after which the dir was recreated as a real
folder holding only `impeccable`:

```
BEFORE                                AFTER (bug)
~/.claude/skills -> shared/           ~/.claude/skills/  (real dir)
   other-skill/  (works)                 impeccable/
   another-skill/(works)              shared/ (orphaned; Claude can't see it)
```

The update / already-installed path (`refreshProviderSkills` + `deduplicateProviders`)
already handled this correctly by resolving real paths and writing through
symlinks, so only first install was affected.

## The fix (surgical)

Only drop a `<provider>/skills` symlink when it **literally targets** another
in-project provider's skills dir (e.g. `.claude/skills -> ../.agents/skills`,
the shape a prior `npx skills` install can leave). Everything else — especially
external shared-skills symlinks — is preserved and written through.

`isInProjectProviderLink` reads the symlink target with `readlinkSync` and
resolves it **lexically** (not `realpathSync`), then checks whether that path
equals `<root>/<other>/skills`. This avoids two false positives from the first
commit:

- **Multi-tool shared layout:** `.claude/skills` and `.agents/skills` both
  pointing at the same external dir no longer get misread as "in-project".
- **Dangling in-project link:** `.claude/skills -> ../.agents/skills` when the
  target doesn't exist yet is still replaced with a real per-provider dir.

```js
if (isInProjectProviderLink(localSkillsDir, root, provider)) unlinkSync(localSkillsDir);
```

After the fix:

```
~/.claude/skills -> shared/   (preserved)
   other-skill/   (still works)
   another-skill/ (still works)
   impeccable/    (newly added)
```

## Tests

Four regression tests in `tests/skills-cli.test.js`:

1. Single external shared-skills symlink preserved + write-through (#295)
2. In-project cross-provider link still converted to a real dir
3. Two providers both symlinked to the same external dir — both preserved
4. Dangling in-project cross-provider link replaced with a real dir

`bun test tests/skills-cli.test.js` and `bun run test` pass.

## Scope

CLI-only change (`cli/`). No skill rebuild, no generated harness output. The diff
is limited to one helper and one guard line in `copyProviderSkills`, plus tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only install path change with targeted symlink detection and regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **#295**: on first `impeccable install`, the CLI no longer replaces a user's external `<provider>/skills` symlink (e.g. `~/.claude/skills` → a shared config folder) with a real directory that held only `impeccable`.
> 
> **`copyProviderSkills`** previously dropped **any** symlink at the provider skills path before copying. That was meant for in-project cross-provider links (e.g. `.claude/skills` → `../.agents/skills` from `npx skills`), but it also deleted external shared-skills symlinks and orphaned the user's other skills.
> 
> The change adds **`isInProjectProviderLink`**, which is true only when the link target resolves lexically to another provider's `<root>/<provider>/skills`. **`unlinkSync`** runs only in that case; external and multi-provider shared symlinks are kept and skills are copied through the link (aligned with the update path).
> 
> **Tests** add four cases: external symlink preserved with write-through, in-project cross-provider link still becomes a real dir, two providers sharing one external dir, and dangling in-project links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc36ebbccfa5e23883a3ba4ad3d3e5d5f8e4f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
