### PR TITLE
Fix: file-scoped wildcard ignores suppress non-value-bearing rules (#296)

### DIFF
--- a/cli/lib/impeccable-config.mjs
+++ b/cli/lib/impeccable-config.mjs
@@ -459,11 +459,13 @@ export function filterDetectionFindings(findings, config) {
 function isIgnoredFindingValue(finding, ignoreValues) {
   if (!Array.isArray(ignoreValues) || ignoreValues.length === 0) return false;
   const rule = normalizeIgnoreRule(finding.antipattern);
+  if (!rule) return false;
+  // File-scoped wildcards suppress rules with no extractable value, such as side-tab.
   const value = extractFindingIgnoreValue(finding);
-  if (!rule || !value) return false;
   return ignoreValues.some((entry) => {
+    if (entry.rule !== rule) return false;
     const wildcardValue = entry.value === '*';
-    if (entry.rule !== rule || (!wildcardValue && !ignoreValueMatches(rule, entry.value, value))) return false;
+    if (!wildcardValue && (!value || !ignoreValueMatches(rule, entry.value, value))) return false;
     if (!Array.isArray(entry.files) || entry.files.length === 0) return !wildcardValue;
     return findingMatchesScopedIgnoreFile(finding, entry.files);
   });

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -628,11 +628,13 @@ export function filterFindings(findings, _content, _ext, config) {
 function isIgnoredFindingValue(finding, ignoreValues) {
   if (!Array.isArray(ignoreValues) || ignoreValues.length === 0) return false;
   const rule = normalizeIgnoreRule(finding.antipattern);
+  if (!rule) return false;
+  // File-scoped wildcards suppress rules with no extractable value, such as side-tab.
   const value = extractFindingIgnoreValue(finding);
-  if (!rule || !value) return false;
   return ignoreValues.some((entry) => {
+    if (entry.rule !== rule) return false;
     const wildcardValue = entry.value === '*';
-    if (entry.rule !== rule || (!wildcardValue && !ignoreValueMatches(rule, entry.value, value))) return false;
+    if (!wildcardValue && (!value || !ignoreValueMatches(rule, entry.value, value))) return false;
     if (!Array.isArray(entry.files) || entry.files.length === 0) return !wildcardValue;
     return findingMatchesScopedIgnoreFile(finding, entry.files);
   });

--- a/tests/cli-ignores.test.js
+++ b/tests/cli-ignores.test.js
@@ -27,6 +27,16 @@ describe('impeccable ignores CLI', () => {
     return result;
   }
 
+  function detect(args, options = {}) {
+    const result = spawnSync(process.execPath, [CLI, 'detect', '--json', ...args], {
+      cwd: root,
+      encoding: 'utf-8',
+      ...options,
+    });
+    if (result.error) throw result.error;
+    return result;
+  }
+
   function readConfig(name = 'config.json') {
     return JSON.parse(readFileSync(join(root, '.impeccable', name), 'utf-8'));
   }
@@ -63,6 +73,39 @@ describe('impeccable ignores CLI', () => {
     expect(run(['remove-value', 'design-system-color', '*', '--file', 'site/styles/demo.css']).status).toBe(0);
     raw = readConfig();
     expect(raw.detector.ignoreValues).toEqual([]);
+  });
+
+  test('file-scoped wildcard value ignores suppress non-value-bearing rules only in matching files', () => {
+    mkdirSync(join(root, 'components'), { recursive: true });
+    const triangle = [
+      'export function TopicCard() {',
+      '  return (',
+      '    <div style={{',
+      '      width: 0, height: 0,',
+      "      borderLeft: '7px solid transparent',",
+      "      borderRight: '7px solid transparent',",
+      "      borderTop: '7px solid #fff',",
+      '    }} />',
+      '  );',
+      '}',
+      '',
+    ].join('\n');
+    writeFileSync(join(root, 'components', 'TopicCard.jsx'), triangle);
+    writeFileSync(join(root, 'components', 'Other.jsx'), triangle.replace('TopicCard', 'Other'));
+
+    const before = detect(['components/TopicCard.jsx']);
+    expect(before.status).toBe(2);
+    expect(before.stdout).toContain('side-tab');
+
+    expect(run(['add-value', 'side-tab', '*', '--file', '**/TopicCard.jsx']).status).toBe(0);
+
+    const afterTarget = detect(['components/TopicCard.jsx']);
+    expect(afterTarget.status).toBe(0);
+    expect(afterTarget.stdout.trim()).toBe('[]');
+
+    const afterOther = detect(['components/Other.jsx']);
+    expect(afterOther.status).toBe(2);
+    expect(afterOther.stdout).toContain('side-tab');
   });
 
   test('rejects broad wildcard value ignores', () => {

--- a/tests/lib/impeccable-config.test.js
+++ b/tests/lib/impeccable-config.test.js
@@ -199,6 +199,18 @@ describe('cli/lib/impeccable-config', () => {
     ]);
   });
 
+  test('filterDetectionFindings honors file-scoped wildcard ignores for non-value-bearing rules', () => {
+    const findings = [
+      { antipattern: 'side-tab', file: join(root, 'components', 'TopicCard.jsx'), line: 331, snippet: "borderLeft: '7px solid" },
+      { antipattern: 'side-tab', file: join(root, 'components', 'Other.jsx'), line: 12, snippet: "borderLeft: '7px solid" },
+    ];
+    const filtered = filterDetectionFindings(findings, {
+      ignoreRules: [],
+      ignoreValues: [{ rule: 'side-tab', value: '*', files: ['**/TopicCard.jsx'] }],
+    });
+    expect(filtered.map((f) => `${f.antipattern}:${f.line}`)).toEqual(['side-tab:12']);
+  });
+
   test('filterDetectionFindings matches equivalent design-system color values', () => {
     const findings = [
       { antipattern: 'design-system-color', file: join(root, 'src', 'rgb.css'), line: 1, ignoreValue: 'rgb(139, 92, 246)' },


### PR DESCRIPTION
Closes #296.

## What users hit
`side-tab` flags a thick colored side border (a common AI-UI tell). A legitimate CSS-triangle arrow built from inline React styles (`borderLeft: '7px solid transparent'`) trips it as a false positive. The intended narrow suppression silently did nothing:

```bash
impeccable ignores add-value side-tab "*" --file "**/TopicCard.jsx"
impeccable detect components/TopicCard.jsx
```

Only `add-rule side-tab` or `add-file` worked, both broader than needed for one file-scoped false positive.

## Root cause
`isIgnoredFindingValue` extracted a finding value and returned early when that value was empty. `extractFindingIgnoreValue` only produces values for the value-bearing rules (`overused-font`, `bounce-easing`, and `design-system-{font,color,radius}`), so non-value-bearing rules like `side-tab` never reached the wildcard + file-scope branch.

The issue mentioned stored value lowercasing, but that is not the failure mode here: comparable finding values are normalized with the same helper. `side-tab` simply has no extracted value, so no comparison was reached.

## The fix
Move the empty-value guard so it only applies to specific-value ignores. A file-scoped wildcard now matches on rule + file even when the rule has no extractable value:

```js
if (!wildcardValue && (!value || !ignoreValueMatches(rule, entry.value, value))) return false;
```

The same change is mirrored in `cli/lib/impeccable-config.mjs` and `skill/scripts/hook-lib.mjs` for CLI/hook parity.

## Scope
This intentionally does not make `side-tab` value-bearing. Specific-value ignores for `side-tab` would need fragile snippet extraction and are out of scope. The intended narrow config primitive is:

```bash
impeccable ignores add-value side-tab "*" --file "**/TopicCard.jsx"
```

Inline directives such as `{/* impeccable-disable-next-line side-tab */}` remain available for single-line waivers.

## Tests
- Added a unit regression in `tests/lib/impeccable-config.test.js` for file-scoped wildcard ignores on a non-value-bearing rule.
- Added a CLI regression in `tests/cli-ignores.test.js` that mirrors the reporter command path and verifies the sibling file still flags.

## Test plan
- [x] `bun test tmp/issue-296/repro.test.mjs`
- [x] `bun test tests/lib/impeccable-config.test.js tests/cli-ignores.test.js`
- [x] `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to ignore-filter matching with mirrored CLI/hook logic and new tests; unscoped wildcards remain rejected.
> 
> **Overview**
> **File-scoped wildcard value ignores** (`add-value <rule> "*" --file <glob>`) now suppress findings for rules that have no extractable ignore value (e.g. `side-tab`), but only in paths that match the glob.
> 
> Previously `isIgnoredFindingValue` bailed out when value extraction returned empty, so rules outside the value-bearing set never reached the wildcard + file-scope branch. The empty-value check now applies only to **specific** value ignores; wildcards match on rule + file alone. The same logic is applied in **`impeccable-config.mjs`** (CLI/`detect`) and **`hook-lib.mjs`** (design hook).
> 
> Regressions cover `filterDetectionFindings` and an end-to-end `ignores add-value` + `detect` path (target file clean, sibling still flags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97529ef10a1c1f318ee60ab68ad7640bc460071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->