### PR TITLE
Fix: allow skill's bundled node helpers under strict-permission harnesses (#301)

### DIFF
--- a/scripts/lib/transformers/factory.js
+++ b/scripts/lib/transformers/factory.js
@@ -235,7 +235,7 @@ export function createTransformer(config) {
       skillBody = skillBody.replace(/\{\{scripts_path\}\}/g, scriptsPath);
       if (bodyTransform) skillBody = bodyTransform(skillBody, skill);
 
-      const content = `${frontmatter}\n\n${skillBody}`;
+      const content = `${frontmatter}\n\n${skillBody}`.replace(/\{\{scripts_path\}\}/g, scriptsPath);
       writeFile(path.join(skillDir, 'SKILL.md'), content);
 
       if (writeOpenAIMetadata) {

--- a/skill/SKILL.src.md
+++ b/skill/SKILL.src.md
@@ -5,6 +5,7 @@ argument-hint: "[{{command_hint}}] [target]"
 user-invocable: true
 allowed-tools:
   - Bash(npx impeccable *)
+  - Bash(node {{scripts_path}}/*)
 license: Apache 2.0
 ---
 


### PR DESCRIPTION
Closes #301 

## What's wrong

The skill's `allowed-tools` only permits one Bash form:

```
ALLOWED:
  OK  npx impeccable ...
```

But Setup (every session) and the no-arg menu instruct the agent to run bundled
helper scripts directly:

```
DO THIS:
  OK  node .claude/skills/impeccable/scripts/context.mjs      (Setup step 1)
  OK  node .claude/skills/impeccable/scripts/context-signals.mjs
  OK  node .claude/skills/impeccable/scripts/detect.mjs
  OK  node .claude/skills/impeccable/scripts/palette.mjs
  OK  node .claude/skills/impeccable/scripts/pin.mjs
```

Under a strict / default-deny Claude Code permission harness, anything not on the
allowlist is blocked, so the skill dies on its first mandatory step:

```
/impeccable
   |
   v
Skill: "First, run context.mjs"
   |
   v
Agent: node .claude/skills/impeccable/scripts/context.mjs
   |
   v
Harness: BLOCKED   (not on the allowlist)
   |
   v
Setup can't complete; the skill can't follow its own instructions.
```

This is reported in #301 (repro: install into a default-deny project, run
`/impeccable` with no args; the signal-collector and detector steps fail at the
first `node` invocation).

## Why it's our bug

Strict permissions are a supported, common setup. Shipping an `allowed-tools`
field is us advertising strict-mode compatibility -- the list was just
incomplete. The bundled `node` scripts are intentional (fast, offline,
version-pinned with the skill), so the right fix is to permit them, not to ask
users to weaken their permissions.

## Root cause

`skill/SKILL.src.md` listed only `Bash(npx impeccable *)`. Separately, the build
(`scripts/lib/transformers/factory.js`) substituted the provider-aware
`{{scripts_path}}` placeholder only in the skill **body**, not the frontmatter.

## The fix (surgical, two lines)

1. `skill/SKILL.src.md` -- add one allowlist entry using the existing
   provider-aware placeholder:
   ```yaml
   allowed-tools:
     - Bash(npx impeccable *)
     - Bash(node {{scripts_path}}/*)
   ```
2. `scripts/lib/transformers/factory.js` -- resolve `{{scripts_path}}` in the
   assembled SKILL.md content (frontmatter + body) instead of body-only:
   ```js
   const content = `${frontmatter}\n\n${skillBody}`.replace(/\{\{scripts_path\}\}/g, scriptsPath);
   ```

### Why provider-aware (not the hardcoded path in the issue)

Five providers honor `allowed-tools`, each with a different scripts dir:

| Provider | Built rule |
| --- | --- |
| Claude Code | `Bash(node .claude/skills/impeccable/scripts/*)` |
| OpenCode | `Bash(node .opencode/skills/impeccable/scripts/*)` |
| Pi | `Bash(node .pi/skills/impeccable/scripts/*)` |
| Qoder | `Bash(node .qoder/skills/impeccable/scripts/*)` |
| Rovo Dev | `Bash(node .rovodev/skills/impeccable/scripts/*)` |

`{{scripts_path}}` already exists for exactly this reason; reusing it keeps every
provider correct with no per-provider code.

## Why it's surgical

- Two edited lines, two source files. No refactors, no new tracked files, no
  architectural change.
- Behavior change is limited to widening one permission allowlist.
- `yamlNeedsQuoting` leaves the new entry unquoted, identical in shape to the
  existing one -- no YAML serialization surprises.
- Generated harness dirs / `dist` are intentionally **not** in this PR; they are
  release artifacts refreshed by `build:release` / the sync workflow.

## Verification

- Strict-permission reproduction (internal): every bare `node` helper the skill
  instructs is now permitted; fails before the fix, passes after.
- `bun run build` validates and emits the correct per-provider rule with no
  `{{scripts_path}}` leftover.
- `bun run test` green.

## Follow-up (not in this PR)

`skill/reference/critique.md` runs one helper with an inline env-var prefix
(`IMPECCABLE_CRITIQUE_META=... node {{scripts_path}}/critique-storage.mjs ...`),
which a `Bash(node ...)` prefix rule won't match under strict matching. Out of
scope for the reported Setup/menu failure; can be addressed by exporting the env
var separately so the command starts with `node`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow permission allowlist widening and build-time placeholder substitution; no auth, data, or runtime logic changes.
> 
> **Overview**
> Fixes **strict default-deny** setups where `/impeccable` failed on the first mandatory step because only `Bash(npx impeccable *)` was allowlisted while Setup and the no-arg menu require direct `node …/scripts/*.mjs` runs.
> 
> Adds **`Bash(node {{scripts_path}}/*)`** to `allowed-tools` in `skill/SKILL.src.md`, and updates the skill build so **`{{scripts_path}}` is substituted in the full assembled `SKILL.md` (frontmatter + body)**, not only the body. Each provider build therefore emits a concrete scripts path (e.g. `.claude/skills/impeccable/scripts`) in the permission rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238adaf16b7b8dea2703aecc03de312736e48fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->