### PR TITLE
feat(vscode): Phase 1 - skill bundle + Marketplace-ready extension shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Run `bun run build` after changing anything in `skill/`, transformer code, or us
 
 ## Generated Provider Output Policy
 
-The root harness folders (`.agents/skills/`, `.claude/skills/`, `.cursor/skills/`, `.gemini/skills/`, `.github/skills/`, `.kiro/skills/`, `.opencode/skills/`, `.pi/skills/`, `.qoder/skills/`, `.rovodev/skills/`, `.trae*/skills/`) and `plugin/` stay tracked so `main` remains installable for direct GitHub, `npx skills`, and submodule users. They are still generated artifacts.
+The root harness folders (`.agents/skills/`, `.claude/skills/`, `.cursor/skills/`, `.gemini/skills/`, `.github/skills/`, `.kiro/skills/`, `.opencode/skills/`, `.pi/skills/`, `.qoder/skills/`, `.rovodev/skills/`, `.trae*/skills/`) and `plugin/` stay tracked so `main` remains installable for direct GitHub, `npx skills`, and submodule users. They are still generated artifacts. The VS Code extension distributes separately as `dist/vscode/` (a packageable VSIX layout); it has no root harness folder.
 
 Normal development should be source-first: stage changes in `skill/`, `scripts/`, `cli/`, `site/`, `extension/`, `functions/`, and `tests/`; leave generated harness churn unstaged unless the user asked for it. After source changes land on `main`, `.github/workflows/sync-generated-output.yml` runs `bun run build:release` and commits generated provider output directly back to `main`. Treat generated harness diffs as release artifacts and keep them out of feature PRs unless they are the point of the PR.
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "build:release": "bun run build:skills:release && bun run build:site && cp -R dist build/_data/dist",
     "build:browser": "node scripts/build-browser-detector.js",
     "build:extension": "node scripts/build-extension.js",
+    "build:extension:vscode": "bun run scripts/build.js --skip-root-sync",
     "clean": "rm -rf dist build",
     "rebuild": "bun run clean && bun run build",
     "rebuild:release": "bun run clean && bun run build:release",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -489,8 +489,9 @@ const BUILD_OPTIONS = parseBuildOptions();
  * 1.90) for a full interactive participant, which is Phase 3 scope. For Phase 1
  * (Marketplace presence + skill delivery), extension.js exposes a command that
  * copies the bundled skill tree (SKILL.md + reference/ + scripts/) into the
- * workspace at .github/skills/impeccable/ and writes the SKILL.md content into
- * .github/copilot-instructions.md, which Copilot Chat reads automatically.
+ * workspace at .github/skills/impeccable/ and merges the SKILL.md content into
+ * a managed block in .github/copilot-instructions.md (preserving any existing
+ * user-authored content), which Copilot Chat reads automatically.
  * Materializing the full tree (not just SKILL.md) is required because the
  * skill references node scripts and reference/*.md siblings by relative path.
  */
@@ -549,25 +550,68 @@ function buildVSCodeExtension(distDir, rootDir, skills, skillsVersion) {
 // register a chat skill that Copilot Chat consumes directly. The convention
 // Copilot Chat honors is .github/copilot-instructions.md. On invoking the
 // install command we materialize the bundled skill tree (SKILL.md + reference/
-// + scripts/) into the workspace at .github/skills/impeccable/ and write
-// .github/copilot-instructions.md with the SKILL.md content so Copilot Chat
-// picks it up automatically. The full tree (not just SKILL.md) is required
-// because the skill text references node scripts and reference/*.md siblings
-// by paths that are only valid once those files exist on disk.
+// + scripts/) into the workspace at .github/skills/impeccable/ and write the
+// SKILL.md content into a managed block in .github/copilot-instructions.md so
+// Copilot Chat picks it up automatically. The full tree (not just SKILL.md) is
+// required because the skill text references node scripts and reference/*.md
+// siblings by paths that are only valid once those files exist on disk.
+//
+// All file I/O uses fs.promises so the extension host event loop is never
+// blocked. The copilot-instructions.md write preserves any pre-existing
+// user-authored content: the skill is wrapped in IMPECCABLE markers and only
+// that managed block is replaced on re-install.
 
 'use strict';
 
 const path = require('path');
-const fs = require('fs');
+const fsp = require('fs').promises;
 
-function copyDirSync(src, dest) {
-  fs.mkdirSync(dest, { recursive: true });
-  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+const IMPECCABLE_BEGIN = '<!-- IMPECCABLE:BEGIN (managed by the Impeccable VS Code extension; edits inside this block are overwritten on re-install) -->';
+const IMPECCABLE_END = '<!-- IMPECCABLE:END -->';
+
+async function copyDir(src, dest) {
+  await fsp.mkdir(dest, { recursive: true });
+  for (const entry of await fsp.readdir(src, { withFileTypes: true })) {
     const s = path.join(src, entry.name);
     const d = path.join(dest, entry.name);
-    if (entry.isDirectory()) copyDirSync(s, d);
-    else if (entry.isFile()) fs.copyFileSync(s, d);
+    if (entry.isDirectory()) await copyDir(s, d);
+    else if (entry.isFile()) await fsp.copyFile(s, d);
   }
+}
+
+async function pathExists(p) {
+  try {
+    await fsp.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Merge the Impeccable skill block into an existing copilot-instructions.md
+ * body without destroying user-authored content.
+ *
+ * - No existing file: returns just the managed block.
+ * - Existing file with a prior Impeccable block: replaces only that block.
+ * - Existing file without a block: appends the block, preserving prior content.
+ *
+ * Pure string logic, exported for unit testing.
+ */
+function mergeInstructions(existing, skillContent) {
+  const block = \`\${IMPECCABLE_BEGIN}\\n\${skillContent.trim()}\\n\${IMPECCABLE_END}\`;
+  if (!existing || existing.trim() === '') {
+    return block + '\\n';
+  }
+  const begin = existing.indexOf(IMPECCABLE_BEGIN);
+  const end = existing.indexOf(IMPECCABLE_END);
+  if (begin !== -1 && end !== -1 && end > begin) {
+    const before = existing.slice(0, begin);
+    const after = existing.slice(end + IMPECCABLE_END.length);
+    return before + block + after;
+  }
+  const trimmed = existing.replace(/\\s+$/, '');
+  return \`\${trimmed}\\n\\n\${block}\\n\`;
 }
 
 /**
@@ -582,21 +626,24 @@ function copyDirSync(src, dest) {
  *   vscode.ExtensionContext.extensionPath.
  * @param {string} workspaceRoot - absolute path of the target workspace folder.
  */
-function installSkill(extensionPath, workspaceRoot) {
+async function installSkill(extensionPath, workspaceRoot) {
   const bundleSrc = path.join(extensionPath, 'skills', 'impeccable');
-  if (!fs.existsSync(bundleSrc)) {
+  if (!(await pathExists(bundleSrc))) {
     throw new Error(\`bundled skill not found at \${bundleSrc}\`);
   }
   const githubDir = path.join(workspaceRoot, '.github');
   const skillDest = path.join(githubDir, 'skills', 'impeccable');
   const instructionsPath = path.join(githubDir, 'copilot-instructions.md');
 
-  fs.mkdirSync(path.dirname(skillDest), { recursive: true });
-  if (fs.existsSync(skillDest)) fs.rmSync(skillDest, { recursive: true });
-  copyDirSync(bundleSrc, skillDest);
+  await fsp.mkdir(path.dirname(skillDest), { recursive: true });
+  if (await pathExists(skillDest)) await fsp.rm(skillDest, { recursive: true });
+  await copyDir(bundleSrc, skillDest);
 
-  const skillContent = fs.readFileSync(path.join(skillDest, 'SKILL.md'), 'utf-8');
-  fs.writeFileSync(instructionsPath, skillContent);
+  const skillContent = await fsp.readFile(path.join(skillDest, 'SKILL.md'), 'utf-8');
+  const existing = (await pathExists(instructionsPath))
+    ? await fsp.readFile(instructionsPath, 'utf-8')
+    : '';
+  await fsp.writeFile(instructionsPath, mergeInstructions(existing, skillContent));
 }
 
 function activate(context) {
@@ -608,7 +655,7 @@ function activate(context) {
       return;
     }
     try {
-      installSkill(context.extensionPath, folders[0].uri.fsPath);
+      await installSkill(context.extensionPath, folders[0].uri.fsPath);
       vscode.window.showInformationMessage(
         'Impeccable: skill installed to .github/skills/impeccable/ and .github/copilot-instructions.md'
       );
@@ -624,7 +671,7 @@ function activate(context) {
 
 function deactivate() {}
 
-module.exports = { activate, deactivate, installSkill };
+module.exports = { activate, deactivate, installSkill, mergeInstructions };
 `;
   fs.writeFileSync(path.join(vscodeDir, 'extension.js'), extensionJs);
 
@@ -649,8 +696,9 @@ After installing the extension, run the command palette command:
 **Impeccable: Install Skill to Workspace**
 
 This installs the Impeccable skill tree (SKILL.md, reference/, scripts/)
-into \`.github/skills/impeccable/\` in your current workspace and writes
-the skill content to \`.github/copilot-instructions.md\` so GitHub Copilot
+into \`.github/skills/impeccable/\` in your current workspace and adds the
+skill content to a managed block in \`.github/copilot-instructions.md\`
+(preserving any instructions you already have there) so GitHub Copilot
 Chat picks it up automatically.
 
 ## Commands

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -468,6 +468,184 @@ const BUILD_OPTIONS = parseBuildOptions();
 // buildStaticSite (Bun HTML bundler) removed — now handled by Astro.
 
 /**
+ * Build VS Code extension structure at dist/vscode/.
+ *
+ * The factory transformer emits skill files under dist/vscode/.vscode-ext/skills/.
+ * This function assembles the packageable extension layout on top:
+ *   dist/vscode/
+ *     package.json       (VS Code extension manifest)
+ *     extension.js       (activation entrypoint)
+ *     skills/            (skill content, copied from .vscode-ext/skills/)
+ *     LICENSE
+ *     README.md
+ *     .vscodeignore
+ *
+ * API note: VS Code 1.95 does not expose a first-class "registerChatSkill" API
+ * for injecting a SKILL.md into Copilot Chat context from an extension. The
+ * closest available path is vscode.chat.createChatParticipant (available since
+ * 1.90) for a full interactive participant, which is Phase 3 scope. For Phase 1
+ * (Marketplace presence + skill delivery), extension.js exposes a command that
+ * copies the bundled skill content into the workspace's
+ * .github/copilot-instructions.md, which GitHub Copilot Chat reads automatically.
+ */
+function buildVSCodeExtension(distDir, rootDir, skills, skillsVersion) {
+  const vscodeDir = path.join(distDir, 'vscode');
+
+  const impeccableSkill = skills.find(s => s.name === 'impeccable');
+  const description = impeccableSkill?.description ||
+    'Design fluency for AI coding agents. Anti-pattern detection and 23 design commands.';
+
+  // package.json — VS Code extension manifest
+  const packageJson = {
+    name: 'impeccable',
+    displayName: 'Impeccable',
+    description,
+    version: skillsVersion || '0.0.1',
+    publisher: 'pbakaus',
+    engines: { vscode: '^1.95.0' },
+    categories: ['Chat', 'AI'],
+    license: 'Apache-2.0',
+    repository: {
+      type: 'git',
+      url: 'https://github.com/pbakaus/impeccable',
+    },
+    main: './extension.js',
+    activationEvents: ['onStartupFinished'],
+    contributes: {
+      commands: [
+        {
+          command: 'impeccable.installSkill',
+          title: 'Impeccable: Install Skill to Workspace',
+        },
+      ],
+    },
+  };
+  fs.writeFileSync(
+    path.join(vscodeDir, 'package.json'),
+    JSON.stringify(packageJson, null, 2) + '\n',
+  );
+
+  // Copy skills from .vscode-ext/skills/ to skills/ at the extension root
+  const skillsSrc = path.join(vscodeDir, '.vscode-ext', 'skills');
+  const skillsDest = path.join(vscodeDir, 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    if (fs.existsSync(skillsDest)) fs.rmSync(skillsDest, { recursive: true });
+    copyDirSync(skillsSrc, skillsDest);
+  }
+
+  // extension.js — minimal CommonJS activation entrypoint
+  // API choice documented in the JSDoc above this function.
+  const extensionJs = `// SPDX-License-Identifier: Apache-2.0
+// Impeccable VS Code Extension — Phase 1 (skill delivery)
+//
+// API choice: VS Code 1.95 does not expose a first-class registerChatSkill API
+// that injects a SKILL.md into Copilot Chat context automatically. The full
+// chat-participant path (vscode.chat.createChatParticipant) is Phase 3 scope.
+// For Phase 1, the command below copies the bundled SKILL.md into the
+// workspace's .github/copilot-instructions.md, which GitHub Copilot Chat
+// reads automatically without further configuration.
+
+'use strict';
+
+const vscode = require('vscode');
+const path = require('path');
+const fs = require('fs');
+
+function activate(context) {
+  const skillPath = path.join(context.extensionPath, 'skills', 'impeccable', 'SKILL.md');
+
+  const disposable = vscode.commands.registerCommand('impeccable.installSkill', async () => {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+      vscode.window.showErrorMessage('Impeccable: No workspace folder open.');
+      return;
+    }
+    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    const githubDir = path.join(workspaceRoot, '.github');
+    const instructionsPath = path.join(githubDir, 'copilot-instructions.md');
+
+    try {
+      fs.mkdirSync(githubDir, { recursive: true });
+      const skillContent = fs.readFileSync(skillPath, 'utf-8');
+      fs.writeFileSync(instructionsPath, skillContent);
+      vscode.window.showInformationMessage(
+        'Impeccable: Skill installed to .github/copilot-instructions.md'
+      );
+    } catch (err) {
+      vscode.window.showErrorMessage(
+        \`Impeccable: Failed to install skill: \${err.message}. Check that the workspace directory is writable.\`
+      );
+    }
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };
+`;
+  fs.writeFileSync(path.join(vscodeDir, 'extension.js'), extensionJs);
+
+  // LICENSE — copy from repo root
+  const licenseSrc = path.join(rootDir, 'LICENSE');
+  if (fs.existsSync(licenseSrc)) {
+    fs.copyFileSync(licenseSrc, path.join(vscodeDir, 'LICENSE'));
+  }
+
+  // README.md — short Marketplace-facing readme
+  const readmeMd = `# Impeccable
+
+Design fluency for AI coding agents in VS Code.
+
+Impeccable bundles 23 design commands and a visual anti-pattern detector for
+GitHub Copilot Chat and other AI coding assistants.
+
+## Getting started
+
+After installing the extension, run the command palette command:
+
+**Impeccable: Install Skill to Workspace**
+
+This copies the Impeccable skill file into \`.github/copilot-instructions.md\`
+in your current workspace, where GitHub Copilot Chat picks it up automatically.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| \`/impeccable polish\` | Visual quality pass |
+| \`/impeccable audit\` | Accessibility and quality checks |
+| \`/impeccable critique\` | Design critique |
+| \`/impeccable bolder\` | Make the design more distinctive |
+| \`/impeccable quieter\` | Reduce visual noise |
+
+See the [full command list](https://impeccable.style/docs) for all 23 commands.
+
+## License
+
+Apache 2.0. See [LICENSE](LICENSE).
+
+## Links
+
+- [impeccable.style](https://impeccable.style)
+- [GitHub](https://github.com/pbakaus/impeccable)
+- [Issue tracker](https://github.com/pbakaus/impeccable/issues)
+`;
+  fs.writeFileSync(path.join(vscodeDir, 'README.md'), readmeMd);
+
+  // .vscodeignore — exclude build-internal files from the packaged VSIX
+  const vscodeignore = `.vscode-ext/**
+node_modules/**
+.gitignore
+*.vsix
+`;
+  fs.writeFileSync(path.join(vscodeDir, '.vscodeignore'), vscodeignore);
+
+  console.log('✓ VS Code: assembled dist/vscode/ extension package');
+}
+
+/**
  * Assemble universal directory from all provider outputs
  */
 function assembleUniversal(distDir) {
@@ -478,7 +656,10 @@ function assembleUniversal(distDir) {
     fs.rmSync(universalDir, { recursive: true, force: true });
   }
 
-  const providerConfigs = Object.values(PROVIDERS);
+  // VS Code extension ships as a self-contained package in dist/vscode/; its
+  // .vscode-ext/ harness folder is intentionally excluded from the universal
+  // bundle, which is meant for direct workspace installs via dotfile folders.
+  const providerConfigs = Object.values(PROVIDERS).filter(config => !config.buildVSCodeExtension);
 
   for (const { provider, configDir } of providerConfigs) {
     const src = path.join(distDir, provider, configDir);
@@ -658,6 +839,9 @@ async function build() {
     transform(skills, DIST_DIR, { skillsVersion });
   }
 
+  // Assemble VS Code extension package from the generated skill files
+  buildVSCodeExtension(DIST_DIR, ROOT_DIR, skills, skillsVersion);
+
   // Assemble universal directory
   assembleUniversal(DIST_DIR);
 
@@ -676,7 +860,11 @@ async function build() {
     // Copy all provider outputs to project root for direct GitHub installs and
     // submodule users. `.codex/` is intentionally excluded: Codex no longer
     // consumes that layout; keep generated Codex bundles under dist/ only.
-    const syncConfigs = Object.values(PROVIDERS).filter(({ configDir }) => configDir !== '.codex');
+    // `.vscode-ext/` is excluded: the VS Code extension ships as a self-contained
+    // package in dist/vscode/, not as a dotfile harness in the repo root.
+    const syncConfigs = Object.values(PROVIDERS).filter(
+      ({ configDir }) => configDir !== '.codex' && configDir !== '.vscode-ext'
+    );
 
     for (const { provider, configDir } of syncConfigs) {
       const skillsSrc = path.join(DIST_DIR, provider, configDir, 'skills');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -470,23 +470,29 @@ const BUILD_OPTIONS = parseBuildOptions();
 /**
  * Build VS Code extension structure at dist/vscode/.
  *
- * The factory transformer emits skill files under dist/vscode/.vscode-ext/skills/.
- * This function assembles the packageable extension layout on top:
+ * The factory transformer emits skill files under dist/vscode/.github/skills/
+ * (configDir = '.github' so {{scripts_path}} inside SKILL.md bakes in as
+ * .github/skills/impeccable/scripts, matching the layout the install command
+ * materializes in the user's workspace). This function assembles the
+ * packageable extension layout on top:
  *   dist/vscode/
  *     package.json       (VS Code extension manifest)
- *     extension.js       (activation entrypoint)
- *     skills/            (skill content, copied from .vscode-ext/skills/)
+ *     extension.js       (activation entrypoint + install helper)
+ *     skills/            (skill content, copied from .github/skills/)
  *     LICENSE
  *     README.md
- *     .vscodeignore
+ *     .vscodeignore      (excludes .github/ staging from the VSIX)
  *
  * API note: VS Code 1.95 does not expose a first-class "registerChatSkill" API
  * for injecting a SKILL.md into Copilot Chat context from an extension. The
  * closest available path is vscode.chat.createChatParticipant (available since
  * 1.90) for a full interactive participant, which is Phase 3 scope. For Phase 1
  * (Marketplace presence + skill delivery), extension.js exposes a command that
- * copies the bundled skill content into the workspace's
- * .github/copilot-instructions.md, which GitHub Copilot Chat reads automatically.
+ * copies the bundled skill tree (SKILL.md + reference/ + scripts/) into the
+ * workspace at .github/skills/impeccable/ and writes the SKILL.md content into
+ * .github/copilot-instructions.md, which Copilot Chat reads automatically.
+ * Materializing the full tree (not just SKILL.md) is required because the
+ * skill references node scripts and reference/*.md siblings by relative path.
  */
 function buildVSCodeExtension(distDir, rootDir, skills, skillsVersion) {
   const vscodeDir = path.join(distDir, 'vscode');
@@ -525,8 +531,9 @@ function buildVSCodeExtension(distDir, rootDir, skills, skillsVersion) {
     JSON.stringify(packageJson, null, 2) + '\n',
   );
 
-  // Copy skills from .vscode-ext/skills/ to skills/ at the extension root
-  const skillsSrc = path.join(vscodeDir, '.vscode-ext', 'skills');
+  // Copy skills from .github/skills/ (factory staging) to skills/ at the
+  // extension root so the install command can find them under skills/impeccable/.
+  const skillsSrc = path.join(vscodeDir, '.github', 'skills');
   const skillsDest = path.join(vscodeDir, 'skills');
   if (fs.existsSync(skillsSrc)) {
     if (fs.existsSync(skillsDest)) fs.rmSync(skillsDest, { recursive: true });
@@ -538,42 +545,76 @@ function buildVSCodeExtension(distDir, rootDir, skills, skillsVersion) {
   const extensionJs = `// SPDX-License-Identifier: Apache-2.0
 // Impeccable VS Code Extension — Phase 1 (skill delivery)
 //
-// API choice: VS Code 1.95 does not expose a first-class registerChatSkill API
-// that injects a SKILL.md into Copilot Chat context automatically. The full
-// chat-participant path (vscode.chat.createChatParticipant) is Phase 3 scope.
-// For Phase 1, the command below copies the bundled SKILL.md into the
-// workspace's .github/copilot-instructions.md, which GitHub Copilot Chat
-// reads automatically without further configuration.
+// API choice: VS Code does not expose a first-class API for an extension to
+// register a chat skill that Copilot Chat consumes directly. The convention
+// Copilot Chat honors is .github/copilot-instructions.md. On invoking the
+// install command we materialize the bundled skill tree (SKILL.md + reference/
+// + scripts/) into the workspace at .github/skills/impeccable/ and write
+// .github/copilot-instructions.md with the SKILL.md content so Copilot Chat
+// picks it up automatically. The full tree (not just SKILL.md) is required
+// because the skill text references node scripts and reference/*.md siblings
+// by paths that are only valid once those files exist on disk.
 
 'use strict';
 
-const vscode = require('vscode');
 const path = require('path');
 const fs = require('fs');
 
-function activate(context) {
-  const skillPath = path.join(context.extensionPath, 'skills', 'impeccable', 'SKILL.md');
+function copyDirSync(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDirSync(s, d);
+    else if (entry.isFile()) fs.copyFileSync(s, d);
+  }
+}
 
+/**
+ * Install the bundled Impeccable skill into a workspace.
+ *
+ * Pure file-system logic with no vscode-API dependency so it can be unit-tested
+ * directly against a tmpdir. The activate() wrapper below adds the vscode UI
+ * affordances (workspace lookup, user-facing messages).
+ *
+ * @param {string} extensionPath - root of the installed extension (i.e. the
+ *   directory containing skills/impeccable/SKILL.md). Typically
+ *   vscode.ExtensionContext.extensionPath.
+ * @param {string} workspaceRoot - absolute path of the target workspace folder.
+ */
+function installSkill(extensionPath, workspaceRoot) {
+  const bundleSrc = path.join(extensionPath, 'skills', 'impeccable');
+  if (!fs.existsSync(bundleSrc)) {
+    throw new Error(\`bundled skill not found at \${bundleSrc}\`);
+  }
+  const githubDir = path.join(workspaceRoot, '.github');
+  const skillDest = path.join(githubDir, 'skills', 'impeccable');
+  const instructionsPath = path.join(githubDir, 'copilot-instructions.md');
+
+  fs.mkdirSync(path.dirname(skillDest), { recursive: true });
+  if (fs.existsSync(skillDest)) fs.rmSync(skillDest, { recursive: true });
+  copyDirSync(bundleSrc, skillDest);
+
+  const skillContent = fs.readFileSync(path.join(skillDest, 'SKILL.md'), 'utf-8');
+  fs.writeFileSync(instructionsPath, skillContent);
+}
+
+function activate(context) {
+  const vscode = require('vscode');
   const disposable = vscode.commands.registerCommand('impeccable.installSkill', async () => {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
-      vscode.window.showErrorMessage('Impeccable: No workspace folder open.');
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+      vscode.window.showErrorMessage('Impeccable: no workspace folder open.');
       return;
     }
-    const workspaceRoot = workspaceFolders[0].uri.fsPath;
-    const githubDir = path.join(workspaceRoot, '.github');
-    const instructionsPath = path.join(githubDir, 'copilot-instructions.md');
-
     try {
-      fs.mkdirSync(githubDir, { recursive: true });
-      const skillContent = fs.readFileSync(skillPath, 'utf-8');
-      fs.writeFileSync(instructionsPath, skillContent);
+      installSkill(context.extensionPath, folders[0].uri.fsPath);
       vscode.window.showInformationMessage(
-        'Impeccable: Skill installed to .github/copilot-instructions.md'
+        'Impeccable: skill installed to .github/skills/impeccable/ and .github/copilot-instructions.md'
       );
     } catch (err) {
       vscode.window.showErrorMessage(
-        \`Impeccable: Failed to install skill: \${err.message}. Check that the workspace directory is writable.\`
+        \`Impeccable: failed to install skill: \${err.message}. Check that the workspace directory is writable.\`
       );
     }
   });
@@ -583,7 +624,7 @@ function activate(context) {
 
 function deactivate() {}
 
-module.exports = { activate, deactivate };
+module.exports = { activate, deactivate, installSkill };
 `;
   fs.writeFileSync(path.join(vscodeDir, 'extension.js'), extensionJs);
 
@@ -607,8 +648,10 @@ After installing the extension, run the command palette command:
 
 **Impeccable: Install Skill to Workspace**
 
-This copies the Impeccable skill file into \`.github/copilot-instructions.md\`
-in your current workspace, where GitHub Copilot Chat picks it up automatically.
+This installs the Impeccable skill tree (SKILL.md, reference/, scripts/)
+into \`.github/skills/impeccable/\` in your current workspace and writes
+the skill content to \`.github/copilot-instructions.md\` so GitHub Copilot
+Chat picks it up automatically.
 
 ## Commands
 
@@ -634,8 +677,11 @@ Apache 2.0. See [LICENSE](LICENSE).
 `;
   fs.writeFileSync(path.join(vscodeDir, 'README.md'), readmeMd);
 
-  // .vscodeignore — exclude build-internal files from the packaged VSIX
-  const vscodeignore = `.vscode-ext/**
+  // .vscodeignore — exclude build-internal files from the packaged VSIX.
+  // .github/ is the factory staging directory whose contents are already
+  // copied into skills/ at the extension root; shipping it twice would just
+  // bloat the VSIX.
+  const vscodeignore = `.github/**
 node_modules/**
 .gitignore
 *.vsix
@@ -656,9 +702,11 @@ function assembleUniversal(distDir) {
     fs.rmSync(universalDir, { recursive: true, force: true });
   }
 
-  // VS Code extension ships as a self-contained package in dist/vscode/; its
-  // .vscode-ext/ harness folder is intentionally excluded from the universal
-  // bundle, which is meant for direct workspace installs via dotfile folders.
+  // VS Code extension ships as a self-contained package in dist/vscode/; it
+  // is intentionally excluded from the universal bundle (which is meant for
+  // direct workspace installs via dotfile folders) via its buildVSCodeExtension
+  // flag rather than by configDir name, since its configDir is `.github` and
+  // would otherwise overlap with the github provider's bundle here.
   const providerConfigs = Object.values(PROVIDERS).filter(config => !config.buildVSCodeExtension);
 
   for (const { provider, configDir } of providerConfigs) {
@@ -860,10 +908,13 @@ async function build() {
     // Copy all provider outputs to project root for direct GitHub installs and
     // submodule users. `.codex/` is intentionally excluded: Codex no longer
     // consumes that layout; keep generated Codex bundles under dist/ only.
-    // `.vscode-ext/` is excluded: the VS Code extension ships as a self-contained
-    // package in dist/vscode/, not as a dotfile harness in the repo root.
+    // The VS Code extension is also excluded (buildVSCodeExtension flag): it
+    // ships as a self-contained package in dist/vscode/, not as a dotfile
+    // harness in the repo root. Excluding by flag rather than configDir name
+    // matters because vscode's configDir is `.github`, which collides with
+    // the github provider's tracked harness output if synced.
     const syncConfigs = Object.values(PROVIDERS).filter(
-      ({ configDir }) => configDir !== '.codex' && configDir !== '.vscode-ext'
+      (config) => config.configDir !== '.codex' && !config.buildVSCodeExtension
     );
 
     for (const { provider, configDir } of syncConfigs) {

--- a/scripts/lib/transformers/index.js
+++ b/scripts/lib/transformers/index.js
@@ -15,5 +15,6 @@ export const transformOpenCode = createTransformer(PROVIDERS.opencode);
 export const transformPi = createTransformer(PROVIDERS.pi);
 export const transformQoder = createTransformer(PROVIDERS.qoder);
 export const transformRovoDev = createTransformer(PROVIDERS['rovo-dev']);
+export const transformVSCode = createTransformer(PROVIDERS.vscode);
 
 export { createTransformer, PROVIDERS };

--- a/scripts/lib/transformers/providers.js
+++ b/scripts/lib/transformers/providers.js
@@ -125,13 +125,18 @@ export const PROVIDERS = {
   vscode: {
     provider: 'vscode',
     providerTags: ['github', 'agents'],
-    configDir: '.vscode-ext',
+    // configDir is .github so {{scripts_path}} bakes in as
+    // .github/skills/impeccable/scripts, matching the layout the extension's
+    // install command materializes in the user's workspace. The staged tree
+    // lives at dist/vscode/.github/ during the build and is excluded from the
+    // packaged VSIX via .vscodeignore.
+    configDir: '.github',
     displayName: 'VS Code',
     placeholderProvider: 'agents',
     frontmatterFields: ['user-invocable', 'argument-hint', 'license', 'compatibility', 'metadata'],
     // buildVSCodeExtension in build.js assembles the final extension structure
     // (package.json, extension.js, README.md, etc.) from the skill files generated
-    // here under .vscode-ext/skills/.
+    // here under .github/skills/.
     buildVSCodeExtension: true,
   },
 };

--- a/scripts/lib/transformers/providers.js
+++ b/scripts/lib/transformers/providers.js
@@ -122,4 +122,16 @@ export const PROVIDERS = {
     displayName: 'Rovo Dev',
     frontmatterFields: ['user-invocable', 'argument-hint', 'license', 'compatibility', 'metadata', 'allowed-tools'],
   },
+  vscode: {
+    provider: 'vscode',
+    providerTags: ['github', 'agents'],
+    configDir: '.vscode-ext',
+    displayName: 'VS Code',
+    placeholderProvider: 'agents',
+    frontmatterFields: ['user-invocable', 'argument-hint', 'license', 'compatibility', 'metadata'],
+    // buildVSCodeExtension in build.js assembles the final extension structure
+    // (package.json, extension.js, README.md, etc.) from the skill files generated
+    // here under .vscode-ext/skills/.
+    buildVSCodeExtension: true,
+  },
 };

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -627,6 +627,12 @@ export const PROVIDER_PLACEHOLDERS = {
     config_file: 'AGENTS.md',
     ask_instruction: 'ask the user directly to clarify what you cannot infer.',
     command_prefix: '/'
+  },
+  'vscode': {
+    model: 'Copilot',
+    config_file: '.github/copilot-instructions.md',
+    ask_instruction: 'ask the user directly to clarify what you cannot infer.',
+    command_prefix: '/'
   }
 };
 
@@ -645,6 +651,7 @@ export const PROVIDER_BLOCK_TAGS = new Set([
   'rovo-dev',
   'trae',
   'trae-cn',
+  'vscode',
 ]);
 
 /**

--- a/scripts/test-suites.mjs
+++ b/scripts/test-suites.mjs
@@ -29,7 +29,7 @@ export const SUITES = {
       /^site\/(pages|content|components|layouts)\//,
       /^README(\.npm)?\.md$/,
       /^cli\/bin\//,
-      /^tests\/(build|cleanup-deprecated|cli-ignores|context|context-signals|critique-storage|design-parser|docs-integrity|hook|hook-build|impeccable-paths|shiki-theme|skills-cli|target-args|test-suites|windows-path-fix|zip)\.test\.(js|mjs)$/,
+      /^tests\/(build|cleanup-deprecated|cli-ignores|context|context-signals|critique-storage|design-parser|docs-integrity|hook|hook-build|impeccable-paths|shiki-theme|skills-cli|target-args|test-suites|vscode-extension|windows-path-fix|zip)\.test\.(js|mjs)$/,
       /^tests\/lib\//,
     ],
     commands: [
@@ -48,6 +48,7 @@ export const SUITES = {
           'tests/docs-integrity.test.js',
           'tests/skills-cli.test.js',
           'tests/validate-plugin-versions.test.js',
+          'tests/vscode-extension.test.js',
         ],
       },
       {

--- a/tests/vscode-extension.test.js
+++ b/tests/vscode-extension.test.js
@@ -3,16 +3,31 @@
  * Integration tests for the VS Code extension output in dist/vscode/.
  *
  * These tests assert on the generated extension package layout produced by
- * buildVSCodeExtension() in scripts/build.js. They require `bun run build`
- * (or `bun run build:extension:vscode`) to have been run first.
+ * buildVSCodeExtension() in scripts/build.js. The suite is order-independent:
+ * if dist/vscode/ has not been built yet (e.g. CI runs test:core before the
+ * Build step on a clean checkout), beforeAll builds it once.
  */
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeAll } from 'bun:test';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
 const ROOT = process.cwd();
 const VSCODE_DIST = path.join(ROOT, 'dist', 'vscode');
+
+beforeAll(() => {
+  // dist/ is gitignored, so on a clean checkout the extension package does not
+  // exist yet. CI runs `bun run test:core` before the `Build` step, so these
+  // tests must build their own fixture rather than assume a prior build.
+  // Guarded so a local run after `bun run build` is a no-op.
+  if (!fs.existsSync(path.join(VSCODE_DIST, 'extension.js'))) {
+    execFileSync('bun', ['run', 'scripts/build.js', '--skip-root-sync'], {
+      cwd: ROOT,
+      stdio: 'inherit',
+    });
+  }
+});
 
 describe('VS Code extension output (dist/vscode/)', () => {
   test('dist/vscode/ exists after build', () => {
@@ -74,9 +89,9 @@ describe('VS Code extension output (dist/vscode/)', () => {
 
   test('package.json engines.vscode targets ^1.95.0 or later', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(VSCODE_DIST, 'package.json'), 'utf-8'));
-    // Must be a caret-pinned VS Code version (^1.X.Y) with minor >= 95
-    // Pattern: ^1. followed by two-digit minor 95-99 or three-digit minor 100+
-    const VSCODE_ENGINES_MIN_1_95 = /^\^1\.(9[5-9]|\d{3,})\./;
+    // Must be a caret-pinned VS Code version at 1.95.0 or later (or any 2.x+).
+    // Accepts ^1.95.0, ^1.100.0, ^2.0.0, etc.; rejects ^1.90.0, ^0.x.x.
+    const VSCODE_ENGINES_MIN_1_95 = /^\^(?:1\.(9[5-9]|\d{3,})|[2-9]\d*)\./;
     expect(pkg.engines?.vscode).toMatch(VSCODE_ENGINES_MIN_1_95);
   });
 
@@ -104,19 +119,22 @@ describe('VS Code extension output (dist/vscode/)', () => {
 describe('VS Code extension install command (installSkill helper)', () => {
   // Load the built extension.js. require('vscode') is lazy inside activate(),
   // so loading the module without a vscode stub is safe; we only exercise the
-  // pure-fs installSkill helper here.
+  // pure-fs installSkill / mergeInstructions helpers here.
   const extPath = path.join(VSCODE_DIST, 'extension.js');
+  const IMPECCABLE_BEGIN = '<!-- IMPECCABLE:BEGIN';
+  const IMPECCABLE_END = '<!-- IMPECCABLE:END -->';
 
-  test('extension.js exports installSkill', () => {
+  test('extension.js exports installSkill and mergeInstructions', () => {
     const ext = require(extPath);
     expect(typeof ext.installSkill).toBe('function');
+    expect(typeof ext.mergeInstructions).toBe('function');
   });
 
-  test('installSkill materializes SKILL.md + reference/ + scripts/ in the workspace .github/ tree', () => {
+  test('installSkill materializes SKILL.md + reference/ + scripts/ in the workspace .github/ tree', async () => {
     const ext = require(extPath);
     const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
     try {
-      ext.installSkill(VSCODE_DIST, tmpWorkspace);
+      await ext.installSkill(VSCODE_DIST, tmpWorkspace);
 
       const skillRoot = path.join(tmpWorkspace, '.github', 'skills', 'impeccable');
       expect(fs.existsSync(path.join(skillRoot, 'SKILL.md'))).toBe(true);
@@ -139,11 +157,11 @@ describe('VS Code extension install command (installSkill helper)', () => {
     }
   });
 
-  test('installSkill writes .github/copilot-instructions.md mirroring SKILL.md content', () => {
+  test('installSkill writes a managed Impeccable block into .github/copilot-instructions.md', async () => {
     const ext = require(extPath);
     const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
     try {
-      ext.installSkill(VSCODE_DIST, tmpWorkspace);
+      await ext.installSkill(VSCODE_DIST, tmpWorkspace);
 
       const instructionsPath = path.join(tmpWorkspace, '.github', 'copilot-instructions.md');
       expect(fs.existsSync(instructionsPath)).toBe(true);
@@ -151,15 +169,78 @@ describe('VS Code extension install command (installSkill helper)', () => {
       const skillContent = fs.readFileSync(
         path.join(tmpWorkspace, '.github', 'skills', 'impeccable', 'SKILL.md'),
         'utf-8',
-      );
+      ).trim();
       const instructionsContent = fs.readFileSync(instructionsPath, 'utf-8');
-      expect(instructionsContent).toBe(skillContent);
+      expect(instructionsContent).toContain(IMPECCABLE_BEGIN);
+      expect(instructionsContent).toContain(IMPECCABLE_END);
+      expect(instructionsContent).toContain(skillContent);
     } finally {
       fs.rmSync(tmpWorkspace, { recursive: true, force: true });
     }
   });
 
-  test('installSkill replaces any prior install rather than merging', () => {
+  test('installSkill preserves pre-existing user-authored copilot-instructions.md content', async () => {
+    const ext = require(extPath);
+    const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
+    try {
+      const instructionsPath = path.join(tmpWorkspace, '.github', 'copilot-instructions.md');
+      fs.mkdirSync(path.dirname(instructionsPath), { recursive: true });
+      const userContent = '# My project rules\n\nAlways use tabs. Never delete this line.\n';
+      fs.writeFileSync(instructionsPath, userContent);
+
+      await ext.installSkill(VSCODE_DIST, tmpWorkspace);
+
+      const after = fs.readFileSync(instructionsPath, 'utf-8');
+      // User content survives, and the managed block is appended after it.
+      expect(after).toContain('Always use tabs. Never delete this line.');
+      expect(after).toContain(IMPECCABLE_BEGIN);
+      expect(after.indexOf('Always use tabs')).toBeLessThan(after.indexOf(IMPECCABLE_BEGIN));
+    } finally {
+      fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  test('installSkill is idempotent: re-install replaces the managed block without duplicating it', async () => {
+    const ext = require(extPath);
+    const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
+    try {
+      const instructionsPath = path.join(tmpWorkspace, '.github', 'copilot-instructions.md');
+      fs.mkdirSync(path.dirname(instructionsPath), { recursive: true });
+      fs.writeFileSync(instructionsPath, '# Keep me\n');
+
+      await ext.installSkill(VSCODE_DIST, tmpWorkspace);
+      await ext.installSkill(VSCODE_DIST, tmpWorkspace);
+
+      const after = fs.readFileSync(instructionsPath, 'utf-8');
+      const beginCount = after.split(IMPECCABLE_BEGIN).length - 1;
+      const endCount = after.split(IMPECCABLE_END).length - 1;
+      expect(beginCount).toBe(1);
+      expect(endCount).toBe(1);
+      expect(after).toContain('# Keep me');
+    } finally {
+      fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  test('mergeInstructions handles empty, blockless, and prior-block inputs', () => {
+    const ext = require(extPath);
+    const skill = 'SKILL BODY';
+
+    const fromEmpty = ext.mergeInstructions('', skill);
+    expect(fromEmpty).toContain(IMPECCABLE_BEGIN);
+    expect(fromEmpty).toContain('SKILL BODY');
+
+    const fromUser = ext.mergeInstructions('user stuff\n', skill);
+    expect(fromUser.indexOf('user stuff')).toBeLessThan(fromUser.indexOf(IMPECCABLE_BEGIN));
+
+    const reMerged = ext.mergeInstructions(fromUser, 'NEW BODY');
+    expect(reMerged).toContain('user stuff');
+    expect(reMerged).toContain('NEW BODY');
+    expect(reMerged).not.toContain('SKILL BODY');
+    expect(reMerged.split(IMPECCABLE_END).length - 1).toBe(1);
+  });
+
+  test('installSkill replaces any prior skill-tree install rather than merging', async () => {
     const ext = require(extPath);
     const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
     try {
@@ -168,7 +249,7 @@ describe('VS Code extension install command (installSkill helper)', () => {
       fs.mkdirSync(path.dirname(staleFile), { recursive: true });
       fs.writeFileSync(staleFile, 'stale');
 
-      ext.installSkill(VSCODE_DIST, tmpWorkspace);
+      await ext.installSkill(VSCODE_DIST, tmpWorkspace);
 
       expect(fs.existsSync(staleFile)).toBe(false);
       expect(fs.existsSync(path.join(tmpWorkspace, '.github', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);

--- a/tests/vscode-extension.test.js
+++ b/tests/vscode-extension.test.js
@@ -8,6 +8,7 @@
  */
 import { describe, test, expect } from 'bun:test';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 const ROOT = process.cwd();
@@ -77,5 +78,102 @@ describe('VS Code extension output (dist/vscode/)', () => {
     // Pattern: ^1. followed by two-digit minor 95-99 or three-digit minor 100+
     const VSCODE_ENGINES_MIN_1_95 = /^\^1\.(9[5-9]|\d{3,})\./;
     expect(pkg.engines?.vscode).toMatch(VSCODE_ENGINES_MIN_1_95);
+  });
+
+  test('bundled SKILL.md and reference files use .github/skills/impeccable/scripts paths', () => {
+    // Critical regression check (PR #312 bugbot finding): the install command
+    // materializes the skill into the workspace at .github/skills/impeccable/,
+    // so {{scripts_path}} must resolve to .github/skills/impeccable/scripts in
+    // the bundled SKILL.md. The previous .vscode-ext/ configDir baked in paths
+    // that did not exist in the target workspace, breaking every setup step.
+    const skillContent = fs.readFileSync(
+      path.join(VSCODE_DIST, 'skills', 'impeccable', 'SKILL.md'),
+      'utf-8',
+    );
+    expect(skillContent).toContain('.github/skills/impeccable/scripts');
+    expect(skillContent).not.toContain('.vscode-ext');
+
+    const auditContent = fs.readFileSync(
+      path.join(VSCODE_DIST, 'skills', 'impeccable', 'reference', 'audit.md'),
+      'utf-8',
+    );
+    expect(auditContent).not.toContain('.vscode-ext');
+  });
+});
+
+describe('VS Code extension install command (installSkill helper)', () => {
+  // Load the built extension.js. require('vscode') is lazy inside activate(),
+  // so loading the module without a vscode stub is safe; we only exercise the
+  // pure-fs installSkill helper here.
+  const extPath = path.join(VSCODE_DIST, 'extension.js');
+
+  test('extension.js exports installSkill', () => {
+    const ext = require(extPath);
+    expect(typeof ext.installSkill).toBe('function');
+  });
+
+  test('installSkill materializes SKILL.md + reference/ + scripts/ in the workspace .github/ tree', () => {
+    const ext = require(extPath);
+    const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
+    try {
+      ext.installSkill(VSCODE_DIST, tmpWorkspace);
+
+      const skillRoot = path.join(tmpWorkspace, '.github', 'skills', 'impeccable');
+      expect(fs.existsSync(path.join(skillRoot, 'SKILL.md'))).toBe(true);
+      expect(fs.existsSync(path.join(skillRoot, 'reference', 'audit.md'))).toBe(true);
+      expect(fs.existsSync(path.join(skillRoot, 'scripts'))).toBe(true);
+      const scriptFiles = fs.readdirSync(path.join(skillRoot, 'scripts'));
+      expect(scriptFiles.length).toBeGreaterThan(0);
+
+      // Every node script path referenced inside the installed SKILL.md must
+      // resolve to a file that actually exists under the workspace .github/.
+      const installedSkill = fs.readFileSync(path.join(skillRoot, 'SKILL.md'), 'utf-8');
+      const scriptRefs = [...installedSkill.matchAll(/\.github\/skills\/impeccable\/scripts\/([\w.-]+)/g)];
+      expect(scriptRefs.length).toBeGreaterThan(0);
+      for (const [, scriptName] of scriptRefs) {
+        const scriptPath = path.join(skillRoot, 'scripts', scriptName);
+        expect(fs.existsSync(scriptPath)).toBe(true);
+      }
+    } finally {
+      fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  test('installSkill writes .github/copilot-instructions.md mirroring SKILL.md content', () => {
+    const ext = require(extPath);
+    const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
+    try {
+      ext.installSkill(VSCODE_DIST, tmpWorkspace);
+
+      const instructionsPath = path.join(tmpWorkspace, '.github', 'copilot-instructions.md');
+      expect(fs.existsSync(instructionsPath)).toBe(true);
+
+      const skillContent = fs.readFileSync(
+        path.join(tmpWorkspace, '.github', 'skills', 'impeccable', 'SKILL.md'),
+        'utf-8',
+      );
+      const instructionsContent = fs.readFileSync(instructionsPath, 'utf-8');
+      expect(instructionsContent).toBe(skillContent);
+    } finally {
+      fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  test('installSkill replaces any prior install rather than merging', () => {
+    const ext = require(extPath);
+    const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-vscode-install-'));
+    try {
+      // Seed a stale file the new install should not preserve.
+      const staleFile = path.join(tmpWorkspace, '.github', 'skills', 'impeccable', 'STALE.md');
+      fs.mkdirSync(path.dirname(staleFile), { recursive: true });
+      fs.writeFileSync(staleFile, 'stale');
+
+      ext.installSkill(VSCODE_DIST, tmpWorkspace);
+
+      expect(fs.existsSync(staleFile)).toBe(false);
+      expect(fs.existsSync(path.join(tmpWorkspace, '.github', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
+    } finally {
+      fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/vscode-extension.test.js
+++ b/tests/vscode-extension.test.js
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Integration tests for the VS Code extension output in dist/vscode/.
+ *
+ * These tests assert on the generated extension package layout produced by
+ * buildVSCodeExtension() in scripts/build.js. They require `bun run build`
+ * (or `bun run build:extension:vscode`) to have been run first.
+ */
+import { describe, test, expect } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = process.cwd();
+const VSCODE_DIST = path.join(ROOT, 'dist', 'vscode');
+
+describe('VS Code extension output (dist/vscode/)', () => {
+  test('dist/vscode/ exists after build', () => {
+    expect(fs.existsSync(VSCODE_DIST)).toBe(true);
+  });
+
+  test('package.json exists, parses, and has required fields', () => {
+    const pkgPath = path.join(VSCODE_DIST, 'package.json');
+    expect(fs.existsSync(pkgPath)).toBe(true);
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    expect(pkg.publisher).toBe('pbakaus');
+    expect(pkg.name).toBe('impeccable');
+    expect(pkg.main).toBe('./extension.js');
+    expect(pkg.engines?.vscode).toBeTruthy();
+    expect(pkg.categories).toContain('Chat');
+    expect(pkg.categories).toContain('AI');
+    expect(pkg.license).toBe('Apache-2.0');
+    expect(pkg.repository?.url).toContain('pbakaus/impeccable');
+  });
+
+  test('extension.js exists and is non-empty', () => {
+    const extPath = path.join(VSCODE_DIST, 'extension.js');
+    expect(fs.existsSync(extPath)).toBe(true);
+    const content = fs.readFileSync(extPath, 'utf-8');
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).toContain('activate');
+    expect(content).toContain('deactivate');
+  });
+
+  test('skills/impeccable/SKILL.md exists and has frontmatter', () => {
+    const skillPath = path.join(VSCODE_DIST, 'skills', 'impeccable', 'SKILL.md');
+    expect(fs.existsSync(skillPath)).toBe(true);
+    const content = fs.readFileSync(skillPath, 'utf-8');
+    // Frontmatter present
+    expect(content.startsWith('---')).toBe(true);
+    expect(content).toContain('name: impeccable');
+  });
+
+  test('at least one reference file is bundled under skills/impeccable/reference/', () => {
+    const refDir = path.join(VSCODE_DIST, 'skills', 'impeccable', 'reference');
+    expect(fs.existsSync(refDir)).toBe(true);
+    const files = fs.readdirSync(refDir);
+    expect(files.length).toBeGreaterThan(0);
+    // audit.md is a well-known reference file
+    expect(fs.existsSync(path.join(refDir, 'audit.md'))).toBe(true);
+  });
+
+  test('LICENSE exists', () => {
+    expect(fs.existsSync(path.join(VSCODE_DIST, 'LICENSE'))).toBe(true);
+  });
+
+  test('README.md exists', () => {
+    expect(fs.existsSync(path.join(VSCODE_DIST, 'README.md'))).toBe(true);
+  });
+
+  test('.vscodeignore exists', () => {
+    expect(fs.existsSync(path.join(VSCODE_DIST, '.vscodeignore'))).toBe(true);
+  });
+
+  test('package.json engines.vscode targets ^1.95.0 or later', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(VSCODE_DIST, 'package.json'), 'utf-8'));
+    // Must be a caret-pinned VS Code version (^1.X.Y) with minor >= 95
+    // Pattern: ^1. followed by two-digit minor 95-99 or three-digit minor 100+
+    const VSCODE_ENGINES_MIN_1_95 = /^\^1\.(9[5-9]|\d{3,})\./;
+    expect(pkg.engines?.vscode).toMatch(VSCODE_ENGINES_MIN_1_95);
+  });
+});


### PR DESCRIPTION
Phase 1 of the VS Code extension plan in #311: a new `vscode` provider that emits a Marketplace-packageable extension shell from the same transformer factory as the other harnesses.

Closes nothing yet - leaves #311 open for Phases 2-4.

## What's in this PR

8 files, no behavior change for existing providers:

- `scripts/lib/transformers/providers.js` - adds the `vscode` provider entry. Uses configDir `.vscode-ext` for the harness folder name; the literal `.vscode` is reserved for workspace settings.
- `scripts/lib/transformers/index.js` - exports the new transformer.
- `scripts/build.js` - wires the vscode provider through the existing factory; emits `dist/vscode/` with `package.json`, `extension.js`, `skills/impeccable/SKILL.md` + `reference/*.md`, `LICENSE`, `README.md`, `.vscodeignore`.
- `scripts/lib/utils.js`, `scripts/test-suites.mjs` - small wiring.
- `tests/vscode-extension.test.js` - asserts the emitted extension shape (publisher, name, main, engines, bundled skill files).
- `package.json` - adds `build:extension:vscode` script that just routes to `scripts/build.js`.
- `AGENTS.md` - one-line addition of `vscode` to the Generated Provider Output Policy list.

## Generated extension shape

`dist/vscode/`:
- `package.json` - publisher `pbakaus`, name `impeccable`, displayName `Impeccable`, engines.vscode `^1.95.0`, categories `["Chat", "AI"]`, license `Apache-2.0`, activationEvents `["onStartupFinished"]`, main `./extension.js`.
- `extension.js` - minimal CommonJS entrypoint. Registers the bundled SKILL.md so Copilot Chat picks it up; top-of-file comment documents the API choice for the targeted engines version.
- `skills/impeccable/SKILL.md` + `reference/*.md` - same transform output the github provider produces.
- `LICENSE`, `README.md`, `.vscodeignore`.

## Verification

Build + test was run by the coding agent on the original PR in the PhillyUrbs fork (PhillyUrbs/impeccable#1). After rebasing onto current `main`, the changes were re-pushed - the rebase was conflict-free and none of the 7 intervening upstream commits touch the Phase 1 files. I'll let this PR's CI re-run `bun run build` and `bun run test` as the live verification; happy to attach local logs if useful.

I also smoke-tested the built VSIX locally in VS Code Insiders - extension loads cleanly and `/impeccable` shows up in Copilot Chat.

## Confirmed NOT touched

Per the issue's "no behavior fork" principle:

- `cli/engine/detect-antipatterns.mjs` and the rest of `cli/engine/`
- `.github/hooks/`
- The Chrome extension at `extension/`
- `site/`, `functions/`
- Other provider configs
- `plugin/` and any tracked `.claude/`, `.cursor/`, `.codex/` etc. harness folders

## Deferred to later phases

Phases 2-4 from #311 are intentionally out of scope here:

- **Phase 2** - Detector as `vscode.DiagnosticCollection` provider, populated on save, honoring `.impeccable/config.json` and inline `<!-- impeccable-disable -->` comments.
- **Phase 3** - Save-time hook via `workspace.onWillSaveTextDocument`, matching the Cursor `hook-before-edit.mjs` consent model. Off by default.
- **Phase 4** - Detector as a Copilot Chat tool (`vscode.lm.registerTool`), command-palette wrappers for high-traffic sub-commands, and an `Impeccable: Init` command.

## Notes for review

- **Publisher / extension id / display name** - open questions from #311 (1, 3). Current shell uses `pbakaus.impeccable` + display name `Impeccable`; happy to change either before publish.
- **Engines field** - targeting `^1.95.0` (Copilot Chat APIs stable). Lower if you want broader reach.
- **No marketplace icon yet** - placeholder is fine for now; can pull from the Chrome extension's `icons/` or generate a fresh one before publish.
- **Marketplace publish** - not done in this PR. Once you're happy with the shape and the publisher question, the existing `scripts/release.mjs` pattern from Chrome can be extended for `vsce publish`.

Refs #311.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New generated extension and workspace file writes on install, but existing providers are gated by flags and covered by integration tests; no changes to detector/CLI runtime.
> 
> **Overview**
> Adds a **`vscode` provider** and build step that emits a VSIX-ready package at **`dist/vscode/`** (documented in **AGENTS.md** as separate from root harness folders).
> 
> **`buildVSCodeExtension`** writes the extension manifest, generated **`extension.js`**, Marketplace README/LICENSE, and copies transformed skills from staging **`.github/skills/`** into **`skills/`**. The **`impeccable.installSkill`** command installs the full skill tree under **`.github/skills/impeccable/`** and merges **SKILL.md** into a managed block in **`.github/copilot-instructions.md`** (preserving user content outside the markers).
> 
> The vscode provider uses **`configDir: '.github'`** so **`{{scripts_path}}`** resolves to workspace paths the install step creates; **`buildVSCodeExtension: true`** keeps it out of the universal zip and root harness sync (avoiding collision with the GitHub Copilot provider). **`package.json`** adds **`build:extension:vscode`**; core CI includes **`tests/vscode-extension.test.js`** for package layout, path baking, and install/merge idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca56d83a752d2f6390dd3b8a4129b8fe22d0c79d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->