### PR TITLE
Add codex-grid-background detector rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Impeccable
 
-Design guidance for AI coding agents. 1 skill, 23 commands, live browser iteration, and 44 deterministic detector rules for AI-generated frontend design.
+Design guidance for AI coding agents. 1 skill, 23 commands, live browser iteration, and 45 deterministic detector rules for AI-generated frontend design.
 
 > **Quick start:** From your project root, run `npx impeccable install`, then run `/impeccable init` inside your AI coding tool. Full docs: [impeccable.style](https://impeccable.style).
 
@@ -13,7 +13,7 @@ Every model trained on the same SaaS templates. Skip the guidance and you get th
 Impeccable adds:
 - **One setup flow.** `/impeccable init` writes `PRODUCT.md` and offers `DESIGN.md`, so later commands know the audience, brand/product lane, voice, anti-references, colors, type, and components.
 - **23 commands.** A shared design vocabulary with your AI: `polish`, `audit`, `critique`, `distill`, `animate`, `bolder`, `quieter`, and more.
-- **44 deterministic detector rules** plus LLM-only critique checks. The CLI and browser extension run the deterministic rules with no LLM and no API key.
+- **45 deterministic detector rules** plus LLM-only critique checks. The CLI and browser extension run the deterministic rules with no LLM and no API key.
 
 ## What's Included
 
@@ -341,7 +341,7 @@ npx impeccable ignores add-file "src/legacy/**"
 npx impeccable ignores add-value overused-font Inter --reason "Brand font"
 ```
 
-The detector catches 44 deterministic issues across AI slop (side-tab borders, purple gradients, bounce easing, dark glows) and general design quality (line length, cramped padding, small touch targets, skipped headings, and more).
+The detector catches 45 deterministic issues across AI slop (side-tab borders, purple gradients, bounce easing, dark glows) and general design quality (line length, cramped padding, small touch targets, skipped headings, and more).
 
 By default, `detect` respects the same `.impeccable/config.json` and `.impeccable/config.local.json` detector config as the design hook: `detector.ignoreRules`, `detector.ignoreFiles`, `detector.ignoreValues`, and `detector.designSystem.enabled`. Hook lifecycle settings such as `hook.enabled` only affect automatic hook execution.
 

--- a/README.npm.md
+++ b/README.npm.md
@@ -1,6 +1,6 @@
 # Impeccable CLI
 
-Detect UI anti-patterns and design quality issues from the command line. Scans HTML, CSS, JSX, TSX, Vue, and Svelte files for 44 deterministic rules, including AI-generated UI tells, accessibility violations, and general design quality problems.
+Detect UI anti-patterns and design quality issues from the command line. Scans HTML, CSS, JSX, TSX, Vue, and Svelte files for 45 deterministic rules, including AI-generated UI tells, accessibility violations, and general design quality problems.
 
 ## Quick Start
 
@@ -56,7 +56,7 @@ npx impeccable detect --fast src/
 
 **Quality**: tiny body text, cramped padding, long line lengths, small touch targets
 
-44 deterministic detector rules in total. See the full catalog at [impeccable.style/slop](https://impeccable.style/slop).
+45 deterministic detector rules in total. See the full catalog at [impeccable.style/slop](https://impeccable.style/slop).
 
 ## Exit Codes
 

--- a/cli/engine/detect-antipatterns-browser.js
+++ b/cli/engine/detect-antipatterns-browser.js
@@ -1185,18 +1185,23 @@ function checkHtmlPatterns(html) {
 
   // --- Provider tells (gated): two-axis grid-line background (Codex/GPT) ---
   // The Codex grid tell is two hairline `linear-gradient(... <color> 1px,
-  // transparent 1px)` layers (one per axis) plus a repeating `background-size`
-  // cell. Count hairline stops WITHIN a single background value: two is the
-  // grid; one is a legitimate ruled line, and unrelated single-axis rules on
-  // separate elements must not add up across the page. Colors like
-  // `oklch(96% 0.012 82 / 0.055)` carry nested parens, so match the stop
-  // directly rather than parsing whole gradient layers.
+  // transparent 1px)` layers (one per axis) tiled by a repeating
+  // `background-size` cell. Both signals must co-occur in the SAME style block
+  // (a CSS rule body or one inline `style="..."`): two hairline stops WITHOUT a
+  // tiling background-size is a fixed crosshair, not a grid, and a single
+  // hairline is a legitimate ruled line. Scoping to one block also stops
+  // unrelated single-axis rules on separate elements from adding up across the
+  // page. Colors like `oklch(96% 0.012 82 / 0.055)` carry nested parens, so
+  // match the hairline stop directly rather than parsing whole gradient layers.
   {
-    const bgDeclRe = /background(?:-image)?\s*:\s*([^;{}"]*)/gi;
-    let bm;
-    while ((bm = bgDeclRe.exec(html)) !== null) {
-      const hairlines = bm[1].match(/\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi);
-      if (hairlines && hairlines.length >= 2) {
+    const hairlineRe = /\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi;
+    const gridSizeRe = /background-size\s*:[^;{}"']*\b\d{1,3}px\b/i;
+    const blockRe = /\{([^{}]*)\}|style\s*=\s*"([^"]*)"|style\s*=\s*'([^']*)'/gi;
+    let blk;
+    while ((blk = blockRe.exec(html)) !== null) {
+      const block = blk[1] || blk[2] || blk[3] || '';
+      const hairlines = block.match(hairlineRe);
+      if (hairlines && hairlines.length >= 2 && gridSizeRe.test(block)) {
         findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
         break;
       }

--- a/cli/engine/detect-antipatterns-browser.js
+++ b/cli/engine/detect-antipatterns-browser.js
@@ -479,6 +479,17 @@ const ANTIPATTERNS = [
     skillGuideline: 'repeating-gradient decorative stripes',
   },
   {
+    id: 'codex-grid-background',
+    category: 'slop',
+    severity: 'advisory',
+    gated: 'gpt',
+    name: 'Decorative grid-line background',
+    description:
+      'A two-axis grid drawn with hairline linear-gradient layers ("1px, transparent 1px" on both axes) is a recurring generated-UI signature. Reserve grid overlays for actual canvas, map, blueprint, or measurement surfaces; elsewhere use product structure or a plain surface.',
+    skillSection: 'Visual Details',
+    skillGuideline: 'two-axis grid-line gradient background',
+  },
+  {
     id: 'theater-slop-phrase',
     category: 'slop',
     severity: 'advisory',
@@ -1170,6 +1181,26 @@ function checkHtmlPatterns(html) {
   // --- Provider tells (gated): repeating-gradient stripes (GPT) ---
   if (/repeating-(?:linear|radial|conic)-gradient\s*\(/i.test(html)) {
     findings.push({ id: 'repeating-stripes-gradient', snippet: 'repeating-gradient decorative stripes' });
+  }
+
+  // --- Provider tells (gated): two-axis grid-line background (Codex/GPT) ---
+  // The Codex grid tell is two hairline `linear-gradient(... <color> 1px,
+  // transparent 1px)` layers (one per axis) plus a repeating `background-size`
+  // cell. Count hairline stops WITHIN a single background value: two is the
+  // grid; one is a legitimate ruled line, and unrelated single-axis rules on
+  // separate elements must not add up across the page. Colors like
+  // `oklch(96% 0.012 82 / 0.055)` carry nested parens, so match the stop
+  // directly rather than parsing whole gradient layers.
+  {
+    const bgDeclRe = /background(?:-image)?\s*:\s*([^;{}"]*)/gi;
+    let bm;
+    while ((bm = bgDeclRe.exec(html)) !== null) {
+      const hairlines = bm[1].match(/\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi);
+      if (hairlines && hairlines.length >= 2) {
+        findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
+        break;
+      }
+    }
   }
 
   // --- Provider tells (gated): "X theater" framing copy (GPT) ---

--- a/cli/engine/detect-antipatterns-browser.js
+++ b/cli/engine/detect-antipatterns-browser.js
@@ -1191,17 +1191,28 @@ function checkHtmlPatterns(html) {
   // tiling background-size is a fixed crosshair, not a grid, and a single
   // hairline is a legitimate ruled line. Scoping to one block also stops
   // unrelated single-axis rules on separate elements from adding up across the
-  // page. Colors like `oklch(96% 0.012 82 / 0.055)` carry nested parens, so
-  // match the hairline stop directly rather than parsing whole gradient layers.
+  // page. Count hairlines only inside `background`/`background-image` values so
+  // a hairline in an unrelated property (mask-image, border-image) can't stand
+  // in for the second axis. Colors like `oklch(96% 0.012 82 / 0.055)` carry
+  // nested parens, so match the hairline stop directly rather than parsing
+  // whole gradient layers.
   {
     const hairlineRe = /\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi;
     const gridSizeRe = /background-size\s*:[^;{}"']*\b\d{1,3}px\b/i;
+    const bgDeclRe = /\bbackground(?:-image)?\s*:\s*([^;{}"']*)/gi;
     const blockRe = /\{([^{}]*)\}|style\s*=\s*"([^"]*)"|style\s*=\s*'([^']*)'/gi;
     let blk;
     while ((blk = blockRe.exec(html)) !== null) {
       const block = blk[1] || blk[2] || blk[3] || '';
-      const hairlines = block.match(hairlineRe);
-      if (hairlines && hairlines.length >= 2 && gridSizeRe.test(block)) {
+      if (!gridSizeRe.test(block)) continue;
+      let hairlineCount = 0;
+      let bm;
+      bgDeclRe.lastIndex = 0;
+      while ((bm = bgDeclRe.exec(block)) !== null) {
+        const stops = bm[1].match(hairlineRe);
+        if (stops) hairlineCount += stops.length;
+      }
+      if (hairlineCount >= 2) {
         findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
         break;
       }

--- a/cli/engine/registry/antipatterns.mjs
+++ b/cli/engine/registry/antipatterns.mjs
@@ -377,6 +377,17 @@ const ANTIPATTERNS = [
     skillGuideline: 'repeating-gradient decorative stripes',
   },
   {
+    id: 'codex-grid-background',
+    category: 'slop',
+    severity: 'advisory',
+    gated: 'gpt',
+    name: 'Decorative grid-line background',
+    description:
+      'A two-axis grid drawn with hairline linear-gradient layers ("1px, transparent 1px" on both axes) is a recurring generated-UI signature. Reserve grid overlays for actual canvas, map, blueprint, or measurement surfaces; elsewhere use product structure or a plain surface.',
+    skillSection: 'Visual Details',
+    skillGuideline: 'two-axis grid-line gradient background',
+  },
+  {
     id: 'theater-slop-phrase',
     category: 'slop',
     severity: 'advisory',

--- a/cli/engine/rules/checks.mjs
+++ b/cli/engine/rules/checks.mjs
@@ -575,18 +575,23 @@ function checkHtmlPatterns(html) {
 
   // --- Provider tells (gated): two-axis grid-line background (Codex/GPT) ---
   // The Codex grid tell is two hairline `linear-gradient(... <color> 1px,
-  // transparent 1px)` layers (one per axis) plus a repeating `background-size`
-  // cell. Count hairline stops WITHIN a single background value: two is the
-  // grid; one is a legitimate ruled line, and unrelated single-axis rules on
-  // separate elements must not add up across the page. Colors like
-  // `oklch(96% 0.012 82 / 0.055)` carry nested parens, so match the stop
-  // directly rather than parsing whole gradient layers.
+  // transparent 1px)` layers (one per axis) tiled by a repeating
+  // `background-size` cell. Both signals must co-occur in the SAME style block
+  // (a CSS rule body or one inline `style="..."`): two hairline stops WITHOUT a
+  // tiling background-size is a fixed crosshair, not a grid, and a single
+  // hairline is a legitimate ruled line. Scoping to one block also stops
+  // unrelated single-axis rules on separate elements from adding up across the
+  // page. Colors like `oklch(96% 0.012 82 / 0.055)` carry nested parens, so
+  // match the hairline stop directly rather than parsing whole gradient layers.
   {
-    const bgDeclRe = /background(?:-image)?\s*:\s*([^;{}"]*)/gi;
-    let bm;
-    while ((bm = bgDeclRe.exec(html)) !== null) {
-      const hairlines = bm[1].match(/\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi);
-      if (hairlines && hairlines.length >= 2) {
+    const hairlineRe = /\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi;
+    const gridSizeRe = /background-size\s*:[^;{}"']*\b\d{1,3}px\b/i;
+    const blockRe = /\{([^{}]*)\}|style\s*=\s*"([^"]*)"|style\s*=\s*'([^']*)'/gi;
+    let blk;
+    while ((blk = blockRe.exec(html)) !== null) {
+      const block = blk[1] || blk[2] || blk[3] || '';
+      const hairlines = block.match(hairlineRe);
+      if (hairlines && hairlines.length >= 2 && gridSizeRe.test(block)) {
         findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
         break;
       }

--- a/cli/engine/rules/checks.mjs
+++ b/cli/engine/rules/checks.mjs
@@ -581,17 +581,28 @@ function checkHtmlPatterns(html) {
   // tiling background-size is a fixed crosshair, not a grid, and a single
   // hairline is a legitimate ruled line. Scoping to one block also stops
   // unrelated single-axis rules on separate elements from adding up across the
-  // page. Colors like `oklch(96% 0.012 82 / 0.055)` carry nested parens, so
-  // match the hairline stop directly rather than parsing whole gradient layers.
+  // page. Count hairlines only inside `background`/`background-image` values so
+  // a hairline in an unrelated property (mask-image, border-image) can't stand
+  // in for the second axis. Colors like `oklch(96% 0.012 82 / 0.055)` carry
+  // nested parens, so match the hairline stop directly rather than parsing
+  // whole gradient layers.
   {
     const hairlineRe = /\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi;
     const gridSizeRe = /background-size\s*:[^;{}"']*\b\d{1,3}px\b/i;
+    const bgDeclRe = /\bbackground(?:-image)?\s*:\s*([^;{}"']*)/gi;
     const blockRe = /\{([^{}]*)\}|style\s*=\s*"([^"]*)"|style\s*=\s*'([^']*)'/gi;
     let blk;
     while ((blk = blockRe.exec(html)) !== null) {
       const block = blk[1] || blk[2] || blk[3] || '';
-      const hairlines = block.match(hairlineRe);
-      if (hairlines && hairlines.length >= 2 && gridSizeRe.test(block)) {
+      if (!gridSizeRe.test(block)) continue;
+      let hairlineCount = 0;
+      let bm;
+      bgDeclRe.lastIndex = 0;
+      while ((bm = bgDeclRe.exec(block)) !== null) {
+        const stops = bm[1].match(hairlineRe);
+        if (stops) hairlineCount += stops.length;
+      }
+      if (hairlineCount >= 2) {
         findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
         break;
       }

--- a/cli/engine/rules/checks.mjs
+++ b/cli/engine/rules/checks.mjs
@@ -573,6 +573,26 @@ function checkHtmlPatterns(html) {
     findings.push({ id: 'repeating-stripes-gradient', snippet: 'repeating-gradient decorative stripes' });
   }
 
+  // --- Provider tells (gated): two-axis grid-line background (Codex/GPT) ---
+  // The Codex grid tell is two hairline `linear-gradient(... <color> 1px,
+  // transparent 1px)` layers (one per axis) plus a repeating `background-size`
+  // cell. Count hairline stops WITHIN a single background value: two is the
+  // grid; one is a legitimate ruled line, and unrelated single-axis rules on
+  // separate elements must not add up across the page. Colors like
+  // `oklch(96% 0.012 82 / 0.055)` carry nested parens, so match the stop
+  // directly rather than parsing whole gradient layers.
+  {
+    const bgDeclRe = /background(?:-image)?\s*:\s*([^;{}"]*)/gi;
+    let bm;
+    while ((bm = bgDeclRe.exec(html)) !== null) {
+      const hairlines = bm[1].match(/\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi);
+      if (hairlines && hairlines.length >= 2) {
+        findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
+        break;
+      }
+    }
+  }
+
   // --- Provider tells (gated): "X theater" framing copy (GPT) ---
   // Lives here (regex-on-HTML) rather than in the text-content analyzers so it
   // runs in the bundled browser path too, not just the CLI/static path.

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -521,7 +521,7 @@ import '../styles/testimonials.css';
           <article class="ks-bento-tile ks-bento-tile--span-6" id="why-ci">
             <span class="ks-bento-num" data-color="patina">06</span>
             <h3 class="why-panel-title">Block slop before it ships.</h3>
-            <p class="why-panel-body">A detector you can wire into PR checks. 44 deterministic rules, no LLM, exit codes the build can read.</p>
+            <p class="why-panel-body">A detector you can wire into PR checks. 45 deterministic rules, no LLM, exit codes the build can read.</p>
               <div class="why-visual why-visual--ci">
                 <div class="why-ci-window">
                   <div class="why-ci-header">
@@ -799,7 +799,7 @@ import '../styles/testimonials.css';
         </li>
         <li>
           <strong>CLI for CI</strong>
-          <span><code>npx impeccable detect src/</code> in a PR check. 44 deterministic rules. JSON output, exit codes for build gates.</span>
+          <span><code>npx impeccable detect src/</code> in a PR check. 45 deterministic rules. JSON output, exit codes for build gates.</span>
           <a href="https://www.npmjs.com/package/impeccable" target="_blank" rel="noopener">View on npm →</a>
         </li>
         <li>

--- a/tests/detect-antipatterns-fixtures.test.mjs
+++ b/tests/detect-antipatterns-fixtures.test.mjs
@@ -744,7 +744,7 @@ describe('detectHtml — cream-palette', () => {
 });
 
 describe('detectHtml — gated provider tells (--gpt / --gemini)', () => {
-  const GPT_IDS = ['gpt-thin-border-wide-shadow', 'repeating-stripes-gradient', 'theater-slop-phrase'];
+  const GPT_IDS = ['gpt-thin-border-wide-shadow', 'repeating-stripes-gradient', 'codex-grid-background', 'theater-slop-phrase'];
 
   it('gpt-tells: gated OFF by default — none of the GPT idioms surface', async () => {
     const f = await detectHtml(path.join(FIXTURES, 'gpt-tells.html'));
@@ -756,7 +756,7 @@ describe('detectHtml — gated provider tells (--gpt / --gemini)', () => {
     }
   });
 
-  it('gpt-tells: with providers:[gpt], flag column triggers all three, pass column adds none', async () => {
+  it('gpt-tells: with providers:[gpt], each flag case triggers once, pass column adds none', async () => {
     const f = await detectHtml(path.join(FIXTURES, 'gpt-tells.html'), { providers: ['gpt'] });
     for (const id of GPT_IDS) {
       assert.equal(

--- a/tests/fixtures/antipatterns/gpt-tells.html
+++ b/tests/fixtures/antipatterns/gpt-tells.html
@@ -38,6 +38,7 @@
       <div class="stripes pass-plain-gradient" style="background: linear-gradient(180deg, #f3f4f6, #ffffff)"></div>
       <div class="grid pass-single-axis-rule" style="background: linear-gradient(180deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px); background-size: 100% 32px"></div>
       <div class="grid pass-two-color-blend" style="background: linear-gradient(90deg, #f3f4f6, #e5e7eb), linear-gradient(180deg, #eef2ff, #ffffff)"></div>
+      <div class="grid pass-crosshair-no-tiling" style="background: linear-gradient(90deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px), linear-gradient(180deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px)"></div>
       <p class="pass-no-theater">We measured real outcomes for the people who use this every day.</p>
     </section>
   </div>

--- a/tests/fixtures/antipatterns/gpt-tells.html
+++ b/tests/fixtures/antipatterns/gpt-tells.html
@@ -9,6 +9,7 @@
     .col { padding: 16px; }
     .card { padding: 24px; margin: 0 0 24px; border-radius: 12px; }
     .stripes { height: 80px; margin: 0 0 24px; border-radius: 12px; }
+    .grid { height: 80px; margin: 0 0 24px; border-radius: 12px; }
   </style>
 </head>
 <body>
@@ -19,6 +20,7 @@
         Thin hairline border paired with a wide diffuse shadow.
       </div>
       <div class="stripes flag-repeating-stripes" style="background: repeating-linear-gradient(45deg, #eee, #eee 10px, #fafafa 10px, #fafafa 20px)"></div>
+      <div class="grid flag-codex-grid" style="background: linear-gradient(90deg, oklch(96% 0.012 82 / 0.055) 1px, transparent 1px), linear-gradient(180deg, oklch(96% 0.012 82 / 0.05) 1px, transparent 1px); background-size: 78px 78px, 78px 78px;"></div>
       <p class="flag-theater">We retired the growth theater and shipped something that actually works.</p>
     </section>
 
@@ -34,6 +36,8 @@
         OKLCH shadow hue values should not be mistaken for shadow blur.
       </div>
       <div class="stripes pass-plain-gradient" style="background: linear-gradient(180deg, #f3f4f6, #ffffff)"></div>
+      <div class="grid pass-single-axis-rule" style="background: linear-gradient(180deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px); background-size: 100% 32px"></div>
+      <div class="grid pass-two-color-blend" style="background: linear-gradient(90deg, #f3f4f6, #e5e7eb), linear-gradient(180deg, #eef2ff, #ffffff)"></div>
       <p class="pass-no-theater">We measured real outcomes for the people who use this every day.</p>
     </section>
   </div>

--- a/tests/fixtures/antipatterns/gpt-tells.html
+++ b/tests/fixtures/antipatterns/gpt-tells.html
@@ -39,6 +39,7 @@
       <div class="grid pass-single-axis-rule" style="background: linear-gradient(180deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px); background-size: 100% 32px"></div>
       <div class="grid pass-two-color-blend" style="background: linear-gradient(90deg, #f3f4f6, #e5e7eb), linear-gradient(180deg, #eef2ff, #ffffff)"></div>
       <div class="grid pass-crosshair-no-tiling" style="background: linear-gradient(90deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px), linear-gradient(180deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px)"></div>
+      <div class="grid pass-bg-plus-mask-hairline" style="background: linear-gradient(90deg, rgba(15, 23, 42, 0.06) 1px, transparent 1px); background-size: 32px 32px; mask-image: linear-gradient(180deg, #000 1px, transparent 1px)"></div>
       <p class="pass-no-theater">We measured real outcomes for the people who use this every day.</p>
     </section>
   </div>


### PR DESCRIPTION
Adds a deterministic detector for the Codex **two-axis grid-line background** tell — the CSS grid overlay built from hairline `linear-gradient(... 1px, transparent 1px)` layers plus a repeating `background-size` cell. The skill-text rule for this landed in 4ac03480; this makes it enforceable by the CLI, browser extension, and site overlay.

## The rule
`codex-grid-background` (`slop`, `gated: 'gpt'`, advisory). Flags a single `background` value containing **two or more** hairline gradient stops (`Npx, transparent Npx`) — one per axis. Off by default; surfaces under `--gpt` / `providers:['gpt']`, consistent with the sibling `repeating-stripes-gradient` codex rule.

## Precision choices (false-positive guards)
- Counts hairline stops **within a single background declaration**, not globally, so two unrelated single-axis ruled lines on one page don't add up to a false flag.
- Matches the `Npx, transparent Npx` stop directly rather than splitting whole gradient layers, because colors like `oklch(96% 0.012 82 / 0.055)` carry nested parens.
- Single-axis ruled lines and plain two-color gradient fades stay silent (both in the fixture pass column).

## Verification
- `bun run test` — 198 pass
- `bun run build` / `build:browser` / `build:extension` — green
- Real-CLI scan of a fixture copy: rule fires under `--gpt`, absent by default
- Confirmed against the canonical Codex snippet (hairline grid + radial spotlights in one `background`) — the two hairline layers are still counted correctly

## Notes
- Rule count bumped 44 -> 45 across `index.astro`, `README.md`, `README.npm.md`
- Skill version intentionally **not** bumped
- Gitignored extension/site bundles regenerate at release time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive detector rule behind existing GPT gating; no auth or data paths touched, with fixture coverage for false-positive guards.
> 
> **Overview**
> Adds **`codex-grid-background`**, a new advisory slop rule (gated under `--gpt` / `providers:['gpt']`) that flags decorative two-axis grid backgrounds built from paired hairline `linear-gradient` stops plus a tiled `background-size`.
> 
> The same detection logic is wired into the **CLI static checks** (`checks.mjs`), **browser detector bundle** (`detect-antipatterns-browser.js`), and **antipattern registry**, with guards so only co-located signals in one style block count and hairlines must live in `background` / `background-image` values.
> 
> **Docs and marketing copy** bump the deterministic rule count **44 → 45** (`README.md`, `README.npm.md`, `index.astro`). Tests extend the GPT fixture and expect one hit per gated id when `--gpt` is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a334c5a16be51ac07f83cf1577d9b931ea4466b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->