### PR TITLE
Fix README case study link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The skill includes explicit guidance on what to avoid:
 
 ## See It In Action
 
-Visit [impeccable.style](https://impeccable.style#casestudies) to see before/after case studies of real projects transformed with Impeccable commands.
+Visit [the Neo Mirai case study](https://impeccable.style/cases/neo-mirai) to see a before/after case study of a real project transformed with Impeccable commands.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- update the README "See It In Action" link to the canonical Neo Mirai case study page
- remove the stale homepage fragment that no longer exists

Fixes #318.

## Test
- bun test tests/docs-integrity.test.js

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL and wording change with no runtime or product behavior impact.
> 
> **Overview**
> Updates the **See It In Action** section so readers go to the dedicated Neo Mirai case study at `https://impeccable.style/cases/neo-mirai` instead of the old homepage `#casestudies` anchor.
> 
> Copy now calls out that single before/after example explicitly, matching the canonical route used on the site (`/cases/neo-mirai`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60849fea03540bbb36e33ffce65536a1abf90ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->