### PR TITLE
Polish website spacing and control alignment

### DIFF
--- a/site/pages/tutorials/index.astro
+++ b/site/pages/tutorials/index.astro
@@ -38,7 +38,7 @@ const tutorials = (await getCollection('tutorials'))
     .tutorials-index-header { margin-bottom: 2rem; }
     .tutorials-list { display: flex; flex-direction: column; gap: 1rem; }
     .tutorial-card {
-      display: flex; gap: 1.25rem; align-items: flex-start;
+      display: flex; gap: 0.75rem; align-items: flex-start;
       padding: 1.25rem; border-radius: 8px; border: 1px solid var(--color-mist);
       text-decoration: none; color: inherit;
       transition: border-color 0.15s ease;

--- a/site/styles/designing-kinpaku.css
+++ b/site/styles/designing-kinpaku.css
@@ -1532,8 +1532,8 @@
 }
 .designing-kinpaku .designing-avoid li {
   display: grid;
-  grid-template-columns: 28px 1fr;
-  gap: 14px;
+  grid-template-columns: 20px 1fr;
+  gap: 12px;
   padding: 22px 0;
   background: transparent;
   border: 0;
@@ -1544,11 +1544,18 @@
   border-bottom: 0;
 }
 .designing-kinpaku .designing-avoid-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: oklch(58% 0.15 35 / 0.1);
+  border-radius: 50%;
   color: var(--ks-vermilion);
   font-family: var(--ks-mono);
-  font-size: 1.2rem;
-  line-height: 1.4;
-  text-align: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  line-height: 1;
 }
 .designing-kinpaku .designing-avoid-title {
   display: block;

--- a/site/styles/designing-kinpaku.css
+++ b/site/styles/designing-kinpaku.css
@@ -976,8 +976,13 @@
   cursor: pointer;
 }
 .designing-kinpaku .docs-viz-live-ctx-discard {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 28px;
   color: var(--ks-muted);
-  padding: 4px 6px;
+  padding: 0;
+  line-height: 1;
 }
 .designing-kinpaku .docs-viz-live-ctx-accept {
   background: var(--ks-kinpaku);
@@ -995,7 +1000,7 @@
   width: 1px;
   height: 14px;
   background: var(--ks-rule);
-  margin: 0 4px;
+  margin: 0 0 0 4px;
 }
 /* Global picker bar — mirrors the real Impeccable live bar: carved-tile mark,
    Pick/Insert/Detect/DESIGN.md controls, exit. Lacquer-deep fill + 1.5px gold

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -429,9 +429,9 @@ html.light .docs-kinpaku {
 }
 
 .docs-kinpaku .docs-start-rail-steps--number-gutter .docs-start-rail-step {
-  grid-template-columns: minmax(34px, auto) minmax(0, 1fr);
+  grid-template-columns: minmax(28px, auto) minmax(0, 1fr);
   grid-template-rows: auto auto auto;
-  column-gap: 16px;
+  column-gap: 12px;
   row-gap: 9px;
   padding: 18px 20px 20px;
 }

--- a/site/styles/docs-visuals.css
+++ b/site/styles/docs-visuals.css
@@ -221,7 +221,20 @@
   width: 1px;
   height: 14px;
   background: var(--color-mist);
-  margin: 0 2px;
+  margin: 0 0 0 2px;
+}
+
+.docs-viz-live-ctx-discard {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: var(--color-ash);
+  font-size: 12px;
+  line-height: 1;
 }
 
 .docs-viz-live-ctx-accept {

--- a/site/styles/light-mode.css
+++ b/site/styles/light-mode.css
@@ -44,6 +44,10 @@
   display: block;
 }
 
+.theme-toggle .theme-toggle-icon--dark {
+  transform: translate(-1.5px, 1.5px);
+}
+
 /* Three-way switcher: show the icon for the active preference (auto / light /
    dark), not the resolved theme. Keyed on data-theme-pref so the icon reflects
    that "auto" is its own state rather than collapsing into whatever the OS picked. */


### PR DESCRIPTION
Fixes small website alignment details:

- `/designing/` live context discard icon
- dark theme toggle crescent
- `/designing/` avoid-list icon spacing
- `/docs/` quick-start marker spacing
- `/tutorials/` card marker spacing

Most issues surfaced from [this tweet](https://x.com/gracjaan/status/2069201169269010456?s=20).

![Live context alignment](https://raw.githubusercontent.com/abdulwahabone/impeccable/pr-assets-live-ctx-alignment/.github/pr-assets/live-ctx-alignment.png)

![Dark theme toggle centered](https://raw.githubusercontent.com/abdulwahabone/impeccable/pr-assets-live-ctx-alignment/.github/pr-assets/theme-toggle-dark-centered.png)

![Avoid-list spacing](https://raw.githubusercontent.com/abdulwahabone/impeccable/pr-assets-live-ctx-alignment/.github/pr-assets/designing-avoid-spacing.png)

![Docs quick-start spacing](https://raw.githubusercontent.com/abdulwahabone/impeccable/pr-assets-live-ctx-alignment/.github/pr-assets/docs-start-rail-dark.png)

![Tutorial card spacing](https://raw.githubusercontent.com/abdulwahabone/impeccable/pr-assets-live-ctx-alignment/.github/pr-assets/tutorial-cards-dark.png)

Validation: `bun run build:site`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on static site pages; no auth, data, or application logic.
> 
> **Overview**
> This PR is **visual polish only**—spacing and alignment fixes across several marketing/docs surfaces, with no markup or behavior changes.
> 
> The **live context bar** mock (docs visuals and `/designing/`) now gives the discard (×) control a fixed square hit area with grid centering, and context dividers use **left-only** margin so they sit flush with adjacent controls.
> 
> On **`/designing/`**, the avoid-list column shrinks (20px gutter, 12px gap) and each × becomes a small **circular badge** instead of a large mono glyph. **`/docs/`** quick-start steps with a number gutter use a narrower column (28px) and 12px column gap. **`/tutorials/`** cards tighten the gap between the step number and body (0.75rem).
> 
> The header **dark-theme crescent** icon gets a slight `translate` so it reads centered in the toggle button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1562f979e6e32288d3732d9b40da3d2d83566fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->