### PR TITLE
Fix H1 weight on key site pages

### DIFF
--- a/site/styles/designing-kinpaku.css
+++ b/site/styles/designing-kinpaku.css
@@ -183,13 +183,13 @@
   display: none;
 }
 
-/* H1 reads via the kit's display tokens — same scale and weight as the
-   homepage hero so the two pages share one display voice. The page's
+/* H1 reads via the kit's display tokens — same scale and family as the
+   homepage hero while carrying the requested 700 weight. The page's
    earlier letter-spacing: 0.02em was slightly looser than the production
    hero (-0.01em); unifying via --ks-type-display-track fixes the drift. */
 .designing-kinpaku .designing-page-title {
   font-family: var(--ks-font-display);
-  font-weight: var(--ks-type-display-weight);
+  font-weight: 700;
   font-size: var(--ks-type-display-size);
   line-height: var(--ks-type-display-line);
   letter-spacing: var(--ks-type-display-track);

--- a/site/styles/home-rebuild.css
+++ b/site/styles/home-rebuild.css
@@ -92,7 +92,7 @@
   margin: 0;
   color: var(--ks-champagne);
   font-family: var(--ks-font-display);
-  font-weight: 300;
+  font-weight: 700;
   font-size: clamp(3.4rem, 6.5vw, 5.6rem);
   line-height: 1.02;
   letter-spacing: -0.01em;

--- a/site/styles/live-mode-kinpaku.css
+++ b/site/styles/live-mode-kinpaku.css
@@ -94,7 +94,7 @@
   gap: 12px;
   font-family: var(--ks-font-display);
   font-style: normal;
-  font-weight: var(--ks-type-display-weight);
+  font-weight: 700;
   font-size: var(--ks-type-display-size);
   line-height: var(--ks-type-display-line);
   letter-spacing: var(--ks-type-display-track);

--- a/site/styles/slop-kinpaku.css
+++ b/site/styles/slop-kinpaku.css
@@ -252,11 +252,11 @@
   margin: 0 0 18px;
 }
 
-/* Hero h1 follows the Weight-Inversion Rule: display scale at weight 300. */
+/* Hero h1 uses the kit display scale with the requested heavier weight. */
 .slop-kinpaku .sub-page-title {
   font-family: var(--ks-font-display);
   font-style: normal;
-  font-weight: var(--ks-type-display-weight);
+  font-weight: 700;
   font-size: var(--ks-type-display-size);
   line-height: var(--ks-type-display-line);
   letter-spacing: var(--ks-type-display-track);


### PR DESCRIPTION
## Summary
- Updates the H1s on `/`, `/designing/`, `/slop/`, and `/live-mode/` to compute at `font-weight: 700`.
- Keeps the existing H1 font family intact; this is scoped to the H1 weight declarations only.
- Leaves screenshot assets out of the repo diff.

## Reference
- https://x.com/gracjaan/status/2069201169269010456?s=20

## Validation
- `bun run build`
- Playwright dark-mode screenshot pass for `/`, `/designing/`, `/slop/`, and `/live-mode/`
- Computed H1 styles checked in `html.dark`: each changed H1 reported existing display font family plus `font-weight: 700`
- Checked `.live-demo-frame-col` on `/` and `/live-mode/`: remains `Albert Sans` at `font-weight: 400`

Generated provider output was intentionally omitted; this PR only changes source CSS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS typography tweaks with no logic, auth, or data changes; other pages still use the 300 display token.
> 
> **Overview**
> Sets **primary page H1s** to **`font-weight: 700`** on `/`, `/designing/`, `/slop/`, and `/live-mode/`, replacing the previous light display treatment (`300` on the home hero and `var(--ks-type-display-weight)` elsewhere, which resolves to **300** in `kinpaku-tokens.css`).
> 
> **Display family, size, line-height, and letter-spacing are unchanged**—only the weight declarations and related comments (e.g. slop’s “Weight-Inversion Rule” note) are updated so these heroes read bolder while staying on the kinpaku display scale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036dfe2783855744695b0b2a42f9467933c533c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->