### PR TITLE
Fix designing phase nav jump

### DIFF
--- a/site/styles/designing-kinpaku.css
+++ b/site/styles/designing-kinpaku.css
@@ -33,6 +33,8 @@
      per-page remap. Only the --ks-muted alias (still read by name here) and
      the page shell remain. */
   --ks-muted: var(--ks-text-muted);
+  --designing-phase-nav-top: 95px;
+  --designing-phase-anchor-offset: 149px;
 
   background:
     linear-gradient(180deg, oklch(7% 0.006 95), oklch(4% 0.004 95));
@@ -455,7 +457,7 @@
 
 .designing-kinpaku .designing-phasenav {
   position: sticky;
-  top: 95px; /* sits directly under the sticky .site-header (95px, z 100) */
+  top: var(--designing-phase-nav-top); /* sits directly under the sticky .site-header */
   z-index: 40; /* above page content, below the header */
   display: flex;
   justify-content: center;
@@ -495,8 +497,12 @@
 }
 
 @media (max-width: 600px) {
+  .designing-kinpaku {
+    --designing-phase-nav-top: 70px;
+    --designing-phase-anchor-offset: 116px;
+  }
+
   .designing-kinpaku .designing-phasenav {
-    top: 70px;
     gap: 0.7rem;
     padding: 12px 14px;
   }
@@ -513,9 +519,11 @@
 }
 
 /* Anchor jumps (compass nodes + phase nav) must clear the sticky header +
-   nav. The base .designing-phase scroll-margin (80px) is too short here. */
+   nav. The base .designing-phase scroll-margin (80px) is too short here.
+   Keep this tied to the sticky nav breakpoint values so #start lands after
+   the nav has pinned instead of stopping in the nav's in-flow position. */
 .designing-kinpaku .designing-loop-track .designing-phase {
-  scroll-margin-top: 152px;
+  scroll-margin-top: var(--designing-phase-anchor-offset);
 }
 
 /* One deliberate, consistent break between the loop spine and the context


### PR DESCRIPTION
## Summary


<img width="1606" height="720" alt="trimmed-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/a5cde667-0ec1-4098-89e4-f9fb417b46e6" />



- Fixes the `/designing` phase nav anchor offset so Start, Iterate, Polish, and Maintain land with the same sticky-nav position.
- Replaces the hard-coded `152px` scroll margin with breakpoint-aware variables that match the nav's sticky top on desktop and narrow mobile widths.

## Root Cause

At the narrow breakpoint, the phase nav sticks at `top: 70px`, but phase sections still used the desktop `152px` anchor offset. Clicking `#start` stopped while the nav was still in its in-flow position, then later phase links made the nav snap upward into its sticky position.



Fixes #335.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweak on the designing page; no auth, data, or shared runtime behavior.
> 
> **Overview**
> Fixes **inconsistent hash navigation** on `/designing` when the sticky phase nav uses a different `top` on narrow viewports than on desktop.
> 
> Introduces paired CSS variables on `.designing-kinpaku`: `--designing-phase-nav-top` and `--designing-phase-anchor-offset` (desktop **95px** / **149px**). At `max-width: 600px` they switch to **70px** / **116px** so `scroll-margin-top` on loop-track phases matches where the nav actually sticks. The phase nav and phase sections now reference those variables instead of hard-coded `top` and the old **152px** scroll margin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c3f72f5b54f9a46c7cb716913758b04a08b9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->