### PR TITLE
Fix Pi global install path

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -59,6 +59,13 @@ const PROVIDER_DISPLAY = {
 };
 const PROVIDER_INPUT_ORDER = ['claude', 'codex', 'cursor', 'gemini', 'github', 'kiro', 'opencode', 'pi', 'qoder', 'trae', 'trae-cn', 'rovo-dev'];
 
+// Providers whose GLOBAL (home) skills dir is not `<provider>/skills`.
+// Pi discovers global skills from ~/.pi/agent/skills/; project scope
+// stays .pi/skills/. See issue #327.
+const HOME_SKILLS_DIR_OVERRIDES = {
+  '.pi': join('.pi', 'agent', 'skills'),
+};
+
 // When a project has no harness folder yet, infer the target from globally
 // installed harnesses (~/.claude, ~/.codex, ...). Codex reads skills from
 // .agents/skills, so ~/.codex maps to the .agents bundle variant.
@@ -69,6 +76,7 @@ const GLOBAL_HARNESS_HINTS = [
   { home: '.gemini', provider: '.gemini' },
   { home: '.kiro', provider: '.kiro' },
   { home: '.opencode', provider: '.opencode' },
+  { home: '.pi', provider: '.pi' },
   { home: '.qoder', provider: '.qoder' },
   { home: '.rovodev', provider: '.rovodev' },
 ];
@@ -110,6 +118,24 @@ const PROVIDER_HOOK_ARTIFACTS = {
     { sourceProvider: '.github', rel: 'hooks/impeccable.json', destProvider: '.github' },
   ],
 };
+
+function userProviderSkillsDir(home, provider) {
+  if (HOME_SKILLS_DIR_OVERRIDES[provider]) return join(home, HOME_SKILLS_DIR_OVERRIDES[provider]);
+  return join(home, provider, 'skills');
+}
+
+function providerSkillsDir(root, provider) {
+  if (root === homedir()) return userProviderSkillsDir(root, provider);
+  return join(root, provider, 'skills');
+}
+
+function providerSkillsDirCandidates(root, provider) {
+  return [...new Set([
+    providerSkillsDir(root, provider),
+    join(root, provider, 'skills'),
+    userProviderSkillsDir(root, provider),
+  ])];
+}
 
 let pipedAnswers = null;
 class PromptAbortError extends Error {
@@ -417,11 +443,13 @@ async function showHelp() {
  */
 function getSkillsVersion(root) {
   for (const d of PROVIDER_DIRS) {
-    const skillMd = join(root, d, 'skills', 'impeccable', 'SKILL.md');
-    if (!existsSync(skillMd)) continue;
-    const content = readFileSync(skillMd, 'utf-8');
-    const match = content.match(/^version:\s*(.+)$/m);
-    if (match) return match[1].trim().replace(/^["']|["']$/g, '');
+    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
+      const skillMd = join(skillsDir, 'impeccable', 'SKILL.md');
+      if (!existsSync(skillMd)) continue;
+      const content = readFileSync(skillMd, 'utf-8');
+      const match = content.match(/^version:\s*(.+)$/m);
+      if (match) return match[1].trim().replace(/^["']|["']$/g, '');
+    }
   }
   return null;
 }
@@ -538,11 +566,13 @@ function hashSkillFile(filePath) {
 function deduplicateProviders(root, providers) {
   const seen = new Map(); // realPath -> { provider, localSkillsDir }
   for (const provider of providers) {
-    const skillsDir = join(root, provider, 'skills');
-    if (!existsSync(skillsDir)) continue;
-    const real = realpathSync(skillsDir);
-    if (!seen.has(real)) {
-      seen.set(real, { provider, localSkillsDir: skillsDir });
+    for (const skillsDir of providerSkillsDirCandidates(root, provider)) {
+      if (!existsSync(skillsDir)) continue;
+      const real = realpathSync(skillsDir);
+      if (!seen.has(real)) {
+        seen.set(real, { provider, localSkillsDir: skillsDir });
+      }
+      break;
     }
   }
   return [...seen.values()];
@@ -623,18 +653,19 @@ async function check() {
 // Check if impeccable skills are already present in any provider folder
 function isAlreadyInstalled(root) {
   for (const d of PROVIDER_DIRS) {
-    const skillsDir = join(root, d, 'skills');
-    if (!existsSync(skillsDir)) continue;
-    try {
-      const entries = readdirSync(skillsDir);
-      // Look for 'impeccable' skill (or prefixed variant, or legacy 'teach-impeccable')
-      if (entries.some(e =>
-        e === 'impeccable' || e.endsWith('-impeccable') ||
-        e === 'teach-impeccable' || e.endsWith('-teach-impeccable')
-      )) {
-        return d;
-      }
-    } catch {}
+    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
+      if (!existsSync(skillsDir)) continue;
+      try {
+        const entries = readdirSync(skillsDir);
+        // Look for 'impeccable' skill (or prefixed variant, or legacy 'teach-impeccable')
+        if (entries.some(e =>
+          e === 'impeccable' || e.endsWith('-impeccable') ||
+          e === 'teach-impeccable' || e.endsWith('-teach-impeccable')
+        )) {
+          return d;
+        }
+      } catch {}
+    }
   }
   return null;
 }
@@ -681,23 +712,24 @@ function isRealSkillDir(skillsDir, name) {
 function migrateUnprefixImpeccable(root) {
   let migrated = 0;
   for (const d of PROVIDER_DIRS) {
-    const skillsDir = join(root, d, 'skills');
-    if (!existsSync(skillsDir)) continue;
-    let entries;
-    try { entries = readdirSync(skillsDir); } catch { continue; }
-    for (const name of entries) {
-      // A prefixed impeccable skill is `<prefix>impeccable`, not the canonical
-      // `impeccable` and not an unrelated legacy skill name.
-      if (name === 'impeccable' || name === 'teach-impeccable') continue;
-      if (!name.endsWith('-impeccable')) continue;
-      if (!isRealSkillDir(skillsDir, name)) continue;
+    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
+      if (!existsSync(skillsDir)) continue;
+      let entries;
+      try { entries = readdirSync(skillsDir); } catch { continue; }
+      for (const name of entries) {
+        // A prefixed impeccable skill is `<prefix>impeccable`, not the canonical
+        // `impeccable` and not an unrelated legacy skill name.
+        if (name === 'impeccable' || name === 'teach-impeccable') continue;
+        if (!name.endsWith('-impeccable')) continue;
+        if (!isRealSkillDir(skillsDir, name)) continue;
 
-      const dest = join(skillsDir, 'impeccable');
-      try {
-        rmSync(dest, { recursive: true, force: true });
-        renameSync(join(skillsDir, name), dest);
-        migrated++;
-      } catch {}
+        const dest = join(skillsDir, 'impeccable');
+        try {
+          rmSync(dest, { recursive: true, force: true });
+          renameSync(join(skillsDir, name), dest);
+          migrated++;
+        } catch {}
+      }
     }
   }
   return migrated;
@@ -774,7 +806,7 @@ function uniquePaths(paths) {
 
 function userSkillProbePaths(home, harnessDir, provider) {
   return uniquePaths([
-    join(home, provider, 'skills'),
+    userProviderSkillsDir(home, provider),
     join(home, harnessDir, 'skills'),
   ]);
 }
@@ -789,8 +821,8 @@ function collectInstallDetections(root, home = homedir()) {
       scope: 'project',
       foundPath,
       installRoot: root,
-      installPath: join(root, provider, 'skills'),
-      hasRealSkills: hasRealSkillEntries(join(root, provider, 'skills')),
+      installPath: providerSkillsDir(root, provider),
+      hasRealSkills: hasRealSkillEntries(providerSkillsDir(root, provider)),
       reason: 'project harness folder',
     });
   }
@@ -804,7 +836,7 @@ function collectInstallDetections(root, home = homedir()) {
       scope: 'user',
       foundPath,
       installRoot: home,
-      installPath: join(home, provider, 'skills'),
+      installPath: userProviderSkillsDir(home, provider),
       skillProbePaths,
       hasRealSkills: skillProbePaths.some(hasRealSkillEntries),
       reason: 'user harness folder',
@@ -1045,12 +1077,14 @@ function isInProjectProviderLink(localSkillsDir, root, provider) {
  * into the project. Writes real directories (copy, never symlink) so every
  * harness keeps the build that was compiled for it. Returns skills written.
  */
-function copyProviderSkills(bundleDir, root, targets) {
+function copyProviderSkills(bundleDir, root, targets, { scope } = {}) {
   let written = 0;
   for (const provider of targets) {
     const srcDir = join(bundleDir, provider, 'skills');
     if (existsSync(srcDir)) {
-      const localSkillsDir = join(root, provider, 'skills');
+      const localSkillsDir = scope === 'user'
+        ? userProviderSkillsDir(root, provider)
+        : join(root, provider, 'skills');
       // A previous `npx skills` install may have left this provider's skills dir
       // as a symlink to ANOTHER in-project provider's canonical copy. Drop only
       // that link so we write a real, provider-specific directory. A user's
@@ -1625,7 +1659,7 @@ async function install(flags) {
   let written = 0;
   let hookTargets = [];
   try {
-    written = copyProviderSkills(bundleDir, installRoot, targets);
+    written = copyProviderSkills(bundleDir, installRoot, targets, { scope });
     hookTargets = wantHooks ? copyProviderHooks(bundleDir, hookRoot, targets, { force, skillRoot: installRoot }) : [];
   } catch (e) {
     rmSync(bundleDir, { recursive: true, force: true });
@@ -1658,24 +1692,29 @@ function findProjectRoot() {
 function findInstalledProviders(root) {
   const found = [];
   for (const d of PROVIDER_DIRS) {
-    const skillsDir = join(root, d, 'skills');
-    if (!existsSync(skillsDir)) continue;
-    try {
-      const entries = readdirSync(skillsDir);
-      if (entries.some(name => isSkillDir(skillsDir, name))) found.push(d);
-    } catch {}
+    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
+      if (!existsSync(skillsDir)) continue;
+      try {
+        const entries = readdirSync(skillsDir);
+        if (entries.some(name => isSkillDir(skillsDir, name))) {
+          found.push(d);
+          break;
+        }
+      } catch {}
+    }
   }
   return found;
 }
 
 function findLinkedProviders(root, providers) {
   return providers.filter(provider => {
-    const skillDir = join(root, provider, 'skills', 'impeccable');
-    try {
-      return lstatSync(skillDir).isSymbolicLink();
-    } catch {
-      return false;
+    for (const skillsDir of providerSkillsDirCandidates(root, provider)) {
+      const skillDir = join(skillsDir, 'impeccable');
+      try {
+        if (lstatSync(skillDir).isSymbolicLink()) return true;
+      } catch {}
     }
+    return false;
   });
 }
 

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -124,6 +124,18 @@ function userProviderSkillsDir(home, provider) {
   return join(home, provider, 'skills');
 }
 
+// Compare via realpath: the project root comes from process.cwd() (symlinks
+// resolved) while homedir() reflects $HOME verbatim, so a home dir reached
+// through a symlink (e.g. /tmp -> /private/tmp) would fail a string compare.
+function isHomeDir(root) {
+  if (root === homedir()) return true;
+  try {
+    return realpathSync(root) === realpathSync(homedir());
+  } catch {
+    return false;
+  }
+}
+
 // Every layout a provider's installed skills can live in under `root`.
 // `scope` narrows the answer when the caller knows which install it is
 // acting on: 'user' means the provider's global layout, 'project' means
@@ -136,7 +148,7 @@ function userProviderSkillsDir(home, provider) {
 function providerSkillsDirCandidates(root, provider, scope) {
   if (scope === 'user') return [userProviderSkillsDir(root, provider)];
   const dirs = [join(root, provider, 'skills')];
-  if (scope !== 'project' && root === homedir() && HOME_SKILLS_DIR_OVERRIDES[provider]) {
+  if (scope !== 'project' && HOME_SKILLS_DIR_OVERRIDES[provider] && isHomeDir(root)) {
     dirs.unshift(userProviderSkillsDir(root, provider));
   }
   return dirs;
@@ -575,11 +587,14 @@ function hashSkillFile(filePath) {
 function deduplicateProviders(root, providers, scope) {
   const seen = new Map(); // realPath -> { provider, localSkillsDir }
   for (const provider of providers) {
-    const [skillsDir] = existingSkillsDirs(root, provider, scope);
-    if (!skillsDir) continue;
-    const real = realpathSync(skillsDir);
-    if (!seen.has(real)) {
-      seen.set(real, { provider, localSkillsDir: skillsDir });
+    // A provider can hold real installs in more than one layout (a home-rooted
+    // repo may carry both ~/.pi/agent/skills and ~/.pi/skills). Keep each as
+    // its own entry so update/check touch every tree, not just the first.
+    for (const skillsDir of existingSkillsDirs(root, provider, scope)) {
+      const real = realpathSync(skillsDir);
+      if (!seen.has(real)) {
+        seen.set(real, { provider, localSkillsDir: skillsDir });
+      }
     }
   }
   return [...seen.values()];

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -124,22 +124,26 @@ function userProviderSkillsDir(home, provider) {
   return join(home, provider, 'skills');
 }
 
-// Every layout a provider's installed skills can live in under `root`. The
-// standard `<provider>/skills` always applies; when `root` is the home dir,
-// an overridden provider (Pi) keeps its global skills elsewhere, and a repo
-// rooted at ~ may still hold the project layout, so both are candidates.
-// Read paths scan every existing candidate; installs write to exactly one
-// layout, chosen by the explicit scope passed to copyProviderSkills.
-function providerSkillsDirCandidates(root, provider) {
+// Every layout a provider's installed skills can live in under `root`.
+// `scope` narrows the answer when the caller knows which install it is
+// acting on: 'user' means the provider's global layout, 'project' means
+// `<provider>/skills`. Without a scope (update/check, where installs of
+// either kind may live under `root`) both layouts are candidates when
+// `root` is the home dir, since an overridden provider (Pi) keeps its
+// global skills elsewhere while a repo rooted at ~ still uses the project
+// layout. Scoping matters for the same reason: a project-scope install in
+// a home-rooted repo must not be conflated with an existing global one.
+function providerSkillsDirCandidates(root, provider, scope) {
+  if (scope === 'user') return [userProviderSkillsDir(root, provider)];
   const dirs = [join(root, provider, 'skills')];
-  if (root === homedir() && HOME_SKILLS_DIR_OVERRIDES[provider]) {
+  if (scope !== 'project' && root === homedir() && HOME_SKILLS_DIR_OVERRIDES[provider]) {
     dirs.unshift(userProviderSkillsDir(root, provider));
   }
   return dirs;
 }
 
-function existingSkillsDirs(root, provider) {
-  return providerSkillsDirCandidates(root, provider).filter(existsSync);
+function existingSkillsDirs(root, provider, scope) {
+  return providerSkillsDirCandidates(root, provider, scope).filter(existsSync);
 }
 
 let pipedAnswers = null;
@@ -446,9 +450,9 @@ async function showHelp() {
 /**
  * Read the skills version from the impeccable SKILL.md frontmatter.
  */
-function getSkillsVersion(root) {
+function getSkillsVersion(root, scope) {
   for (const d of PROVIDER_DIRS) {
-    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
+    for (const skillsDir of providerSkillsDirCandidates(root, d, scope)) {
       const skillMd = join(skillsDir, 'impeccable', 'SKILL.md');
       if (!existsSync(skillMd)) continue;
       const content = readFileSync(skillMd, 'utf-8');
@@ -568,10 +572,10 @@ function hashSkillFile(filePath) {
  * per unique real path. The first provider that maps to a real path
  * wins (so the bundle uses that provider's build).
  */
-function deduplicateProviders(root, providers) {
+function deduplicateProviders(root, providers, scope) {
   const seen = new Map(); // realPath -> { provider, localSkillsDir }
   for (const provider of providers) {
-    const [skillsDir] = existingSkillsDirs(root, provider);
+    const [skillsDir] = existingSkillsDirs(root, provider, scope);
     if (!skillsDir) continue;
     const real = realpathSync(skillsDir);
     if (!seen.has(real)) {
@@ -589,8 +593,8 @@ function deduplicateProviders(root, providers) {
  * SKILL.md, so script-only fixes and removed files are detected.
  * Returns true if every bundle skill matches the local copy.
  */
-function isUpToDate(root, providers, bundleDir) {
-  const unique = deduplicateProviders(root, providers);
+function isUpToDate(root, providers, bundleDir, scope) {
+  const unique = deduplicateProviders(root, providers, scope);
   if (unique.length === 0) return false;
 
   for (const { provider, localSkillsDir } of unique) {
@@ -654,9 +658,9 @@ async function check() {
 // ─── skills install ───────────────────────────────────────────────────────────
 
 // Check if impeccable skills are already present in any provider folder
-function isAlreadyInstalled(root) {
+function isAlreadyInstalled(root, scope) {
   for (const d of PROVIDER_DIRS) {
-    for (const skillsDir of existingSkillsDirs(root, d)) {
+    for (const skillsDir of existingSkillsDirs(root, d, scope)) {
       try {
         const entries = readdirSync(skillsDir);
         // Look for 'impeccable' skill (or prefixed variant, or legacy 'teach-impeccable')
@@ -711,10 +715,10 @@ function isRealSkillDir(skillsDir, name) {
  * by name -- never touches third-party skills that happen to start with `i-`.
  * Returns the number of skills migrated.
  */
-function migrateUnprefixImpeccable(root) {
+function migrateUnprefixImpeccable(root, scope) {
   let migrated = 0;
   for (const d of PROVIDER_DIRS) {
-    for (const skillsDir of existingSkillsDirs(root, d)) {
+    for (const skillsDir of existingSkillsDirs(root, d, scope)) {
       let entries;
       try { entries = readdirSync(skillsDir); } catch { continue; }
       for (const name of entries) {
@@ -1109,8 +1113,8 @@ function copyProviderSkills(bundleDir, root, targets, { scope } = {}) {
   return written;
 }
 
-function refreshProviderSkills(bundleDir, root, providers) {
-  const unique = deduplicateProviders(root, providers);
+function refreshProviderSkills(bundleDir, root, providers, scope) {
+  const unique = deduplicateProviders(root, providers, scope);
   let updated = 0;
   for (const { provider, localSkillsDir } of unique) {
     const srcDir = join(bundleDir, provider, 'skills');
@@ -1569,13 +1573,13 @@ async function install(flags) {
   }
 
   const { targets, installRoot, hookRoot, scope } = plan;
-  const existing = isAlreadyInstalled(installRoot);
+  const existing = isAlreadyInstalled(installRoot, scope);
 
   if (existing && !force) {
     console.log(`Impeccable skills are already installed (found in ${existing}/).`);
-    const installedTargets = findInstalledProviders(installRoot);
+    const installedTargets = findInstalledProviders(installRoot, scope);
     const selectedInstalledTargets = targets.filter(provider => installedTargets.includes(provider));
-    const linkedTargets = findLinkedProviders(installRoot, selectedInstalledTargets);
+    const linkedTargets = findLinkedProviders(installRoot, selectedInstalledTargets, scope);
     const copyTargets = selectedInstalledTargets.filter(provider => !linkedTargets.includes(provider));
     const hookTargets = selectedInstalledTargets;
     const wantHooks = installHooks && await decideHookInstall(hookRoot, hookTargets, { yes });
@@ -1602,10 +1606,10 @@ async function install(flags) {
         }
       }
 
-      if (!updateCheckSkipped && copyTargets.length > 0 && !isUpToDate(installRoot, copyTargets, bundleDir)) {
-        migrateUnprefixImpeccable(installRoot);
-        updated = refreshProviderSkills(bundleDir, installRoot, copyTargets);
-        const v = getSkillsVersion(installRoot);
+      if (!updateCheckSkipped && copyTargets.length > 0 && !isUpToDate(installRoot, copyTargets, bundleDir, scope)) {
+        migrateUnprefixImpeccable(installRoot, scope);
+        updated = refreshProviderSkills(bundleDir, installRoot, copyTargets, scope);
+        const v = getSkillsVersion(installRoot, scope);
         console.log(`Updated ${updated} skill(s)${v ? ` to v${v}` : ''}.`);
       }
 
@@ -1618,7 +1622,7 @@ async function install(flags) {
         console.log('Existing skills were left unchanged.');
         console.log('Run with --force to reinstall.\n');
       } else if (updated === 0 && writtenHookTargets.length === 0) {
-        const v = getSkillsVersion(installRoot);
+        const v = getSkillsVersion(installRoot, scope);
         console.log(`Skills are up to date${v ? ` (v${v})` : ''}.`);
         console.log('Run with --force to reinstall.\n');
       } else {
@@ -1657,7 +1661,7 @@ async function install(flags) {
 
   // Retire any old `i-`-prefixed install so the fresh copy lands on the
   // canonical `impeccable` dir instead of orphaning the prefixed one.
-  migrateUnprefixImpeccable(installRoot);
+  migrateUnprefixImpeccable(installRoot, scope);
 
   let written = 0;
   let hookTargets = [];
@@ -1692,10 +1696,10 @@ function findProjectRoot() {
   return process.cwd();
 }
 
-function findInstalledProviders(root) {
+function findInstalledProviders(root, scope) {
   const found = [];
   for (const d of PROVIDER_DIRS) {
-    for (const skillsDir of existingSkillsDirs(root, d)) {
+    for (const skillsDir of existingSkillsDirs(root, d, scope)) {
       try {
         const entries = readdirSync(skillsDir);
         if (entries.some(name => isSkillDir(skillsDir, name))) {
@@ -1708,9 +1712,9 @@ function findInstalledProviders(root) {
   return found;
 }
 
-function findLinkedProviders(root, providers) {
+function findLinkedProviders(root, providers, scope) {
   return providers.filter(provider => {
-    for (const skillsDir of providerSkillsDirCandidates(root, provider)) {
+    for (const skillsDir of providerSkillsDirCandidates(root, provider, scope)) {
       const skillDir = join(skillsDir, 'impeccable');
       try {
         if (lstatSync(skillDir).isSymbolicLink()) return true;

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -124,17 +124,22 @@ function userProviderSkillsDir(home, provider) {
   return join(home, provider, 'skills');
 }
 
-function providerSkillsDir(root, provider) {
-  if (root === homedir()) return userProviderSkillsDir(root, provider);
-  return join(root, provider, 'skills');
+// Every layout a provider's installed skills can live in under `root`. The
+// standard `<provider>/skills` always applies; when `root` is the home dir,
+// an overridden provider (Pi) keeps its global skills elsewhere, and a repo
+// rooted at ~ may still hold the project layout, so both are candidates.
+// Read paths scan every existing candidate; installs write to exactly one
+// layout, chosen by the explicit scope passed to copyProviderSkills.
+function providerSkillsDirCandidates(root, provider) {
+  const dirs = [join(root, provider, 'skills')];
+  if (root === homedir() && HOME_SKILLS_DIR_OVERRIDES[provider]) {
+    dirs.unshift(userProviderSkillsDir(root, provider));
+  }
+  return dirs;
 }
 
-function providerSkillsDirCandidates(root, provider) {
-  return [...new Set([
-    providerSkillsDir(root, provider),
-    join(root, provider, 'skills'),
-    userProviderSkillsDir(root, provider),
-  ])];
+function existingSkillsDirs(root, provider) {
+  return providerSkillsDirCandidates(root, provider).filter(existsSync);
 }
 
 let pipedAnswers = null;
@@ -566,13 +571,11 @@ function hashSkillFile(filePath) {
 function deduplicateProviders(root, providers) {
   const seen = new Map(); // realPath -> { provider, localSkillsDir }
   for (const provider of providers) {
-    for (const skillsDir of providerSkillsDirCandidates(root, provider)) {
-      if (!existsSync(skillsDir)) continue;
-      const real = realpathSync(skillsDir);
-      if (!seen.has(real)) {
-        seen.set(real, { provider, localSkillsDir: skillsDir });
-      }
-      break;
+    const [skillsDir] = existingSkillsDirs(root, provider);
+    if (!skillsDir) continue;
+    const real = realpathSync(skillsDir);
+    if (!seen.has(real)) {
+      seen.set(real, { provider, localSkillsDir: skillsDir });
     }
   }
   return [...seen.values()];
@@ -653,8 +656,7 @@ async function check() {
 // Check if impeccable skills are already present in any provider folder
 function isAlreadyInstalled(root) {
   for (const d of PROVIDER_DIRS) {
-    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
-      if (!existsSync(skillsDir)) continue;
+    for (const skillsDir of existingSkillsDirs(root, d)) {
       try {
         const entries = readdirSync(skillsDir);
         // Look for 'impeccable' skill (or prefixed variant, or legacy 'teach-impeccable')
@@ -712,8 +714,7 @@ function isRealSkillDir(skillsDir, name) {
 function migrateUnprefixImpeccable(root) {
   let migrated = 0;
   for (const d of PROVIDER_DIRS) {
-    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
-      if (!existsSync(skillsDir)) continue;
+    for (const skillsDir of existingSkillsDirs(root, d)) {
       let entries;
       try { entries = readdirSync(skillsDir); } catch { continue; }
       for (const name of entries) {
@@ -821,8 +822,8 @@ function collectInstallDetections(root, home = homedir()) {
       scope: 'project',
       foundPath,
       installRoot: root,
-      installPath: providerSkillsDir(root, provider),
-      hasRealSkills: hasRealSkillEntries(providerSkillsDir(root, provider)),
+      installPath: join(root, provider, 'skills'),
+      hasRealSkills: hasRealSkillEntries(join(root, provider, 'skills')),
       reason: 'project harness folder',
     });
   }
@@ -1076,6 +1077,8 @@ function isInProjectProviderLink(localSkillsDir, root, provider) {
  * Copy each target provider's compiled skill variant from an extracted bundle
  * into the project. Writes real directories (copy, never symlink) so every
  * harness keeps the build that was compiled for it. Returns skills written.
+ * `scope: 'user'` writes to the provider's global skills layout (see
+ * HOME_SKILLS_DIR_OVERRIDES); anything else writes `<provider>/skills`.
  */
 function copyProviderSkills(bundleDir, root, targets, { scope } = {}) {
   let written = 0;
@@ -1692,8 +1695,7 @@ function findProjectRoot() {
 function findInstalledProviders(root) {
   const found = [];
   for (const d of PROVIDER_DIRS) {
-    for (const skillsDir of providerSkillsDirCandidates(root, d)) {
-      if (!existsSync(skillsDir)) continue;
+    for (const skillsDir of existingSkillsDirs(root, d)) {
       try {
         const entries = readdirSync(skillsDir);
         if (entries.some(name => isSkillDir(skillsDir, name))) {

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -79,7 +79,7 @@ Notes:
 | GitHub Copilot | `.github/skills/` | `.agents/skills/`, `.claude/skills/` |
 | Kiro | `.kiro/skills/` | - |
 | OpenCode | `.opencode/skills/` | `.agents/skills/`, `.claude/skills/` |
-| Pi | `.pi/skills/` | `.agents/skills/` |
+| Pi | `.pi/skills/` (project), `~/.pi/agent/skills/` (global) | `.agents/skills/` |
 | Qoder | `.qoder/skills/` | `~/.qoder/skills/` (user-level) |
 | Trae China | `.trae-cn/skills/` | TBD |
 | Trae International | `.trae/skills/` | TBD |

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -859,9 +859,12 @@ describe('skills install/update: local universal bundle e2e', () => {
 
   // Project scope must stay at .pi/skills/ even when the git root IS the home
   // dir (dotfiles repos), where scope can't be inferred from the path alone.
+  // An existing global install at ~/.pi/agent/skills must not swallow the
+  // project-scope request into its already-installed refresh path.
   test('project-scope install keeps Pi skills in .pi/skills even for a home-rooted repo', () => {
     const home = mkdtempSync(join(tmpdir(), 'imp-home-rooted-project-pi-'));
     execSync('git init', { cwd: home });
+    writeSkill(join(home, '.pi'), 'agent', 'impeccable');
     const bundleRoot = createFakeUniversalBundle(home, ['.pi']);
 
     const output = run('skills install -y --providers=pi --no-hooks', {
@@ -871,7 +874,9 @@ describe('skills install/update: local universal bundle e2e', () => {
 
     expect(output).toContain('Installed impeccable into: .pi (project)');
     expect(existsSync(join(home, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
-    expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable'))).toBe(false);
+    // The pre-existing global copy is untouched, not refreshed in place.
+    expect(readFileSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'), 'utf8')).toContain('name: impeccable');
+    expect(readFileSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'), 'utf8')).not.toContain('Local deterministic bundle');
 
     rmSync(home, { recursive: true, force: true });
   }, 15000);

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -833,13 +833,17 @@ describe('skills install/update: local universal bundle e2e', () => {
     rmSync(home, { recursive: true, force: true });
   }, 15000);
 
-  test('--scope=global installs Pi skills into the Pi agent home directory', () => {
+  // Pi discovers global skills from ~/.pi/agent/skills/, not ~/.pi/skills/ (#327).
+  // Also covers the GLOBAL_HARNESS_HINTS detection: no --providers is passed, so
+  // the ~/.pi dir alone must route the install to Pi's agent skills path.
+  test('global install detects ~/.pi and writes Pi skills to ~/.pi/agent/skills', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'imp-test-scope-user-pi-'));
     const home = mkdtempSync(join(tmpdir(), 'imp-home-scope-user-pi-'));
     execSync('git init', { cwd: tmp });
+    mkdirSync(join(home, '.pi'), { recursive: true });
     const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
 
-    const output = run('skills install -y --providers=pi --scope=global --no-hooks', {
+    const output = run('skills install -y --scope=global --no-hooks', {
       cwd: tmp,
       env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
     });
@@ -853,27 +857,9 @@ describe('skills install/update: local universal bundle e2e', () => {
     rmSync(home, { recursive: true, force: true });
   }, 15000);
 
-  test('--scope=project keeps Pi skills in the project Pi skills directory', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-scope-project-pi-'));
-    const home = mkdtempSync(join(tmpdir(), 'imp-home-scope-project-pi-'));
-    execSync('git init', { cwd: tmp });
-    const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
-
-    const output = run('skills install -y --providers=pi --scope=project --no-hooks', {
-      cwd: tmp,
-      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
-    });
-
-    expect(output).toContain('Installed impeccable into: .pi (project)');
-    expect(existsSync(join(tmp, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
-    expect(existsSync(join(tmp, '.pi', 'agent', 'skills', 'impeccable'))).toBe(false);
-    expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
-
-    rmSync(tmp, { recursive: true, force: true });
-    rmSync(home, { recursive: true, force: true });
-  }, 15000);
-
-  test('home-rooted project install keeps Pi skills in the project Pi skills directory', () => {
+  // Project scope must stay at .pi/skills/ even when the git root IS the home
+  // dir (dotfiles repos), where scope can't be inferred from the path alone.
+  test('project-scope install keeps Pi skills in .pi/skills even for a home-rooted repo', () => {
     const home = mkdtempSync(join(tmpdir(), 'imp-home-rooted-project-pi-'));
     execSync('git init', { cwd: home });
     const bundleRoot = createFakeUniversalBundle(home, ['.pi']);
@@ -887,52 +873,6 @@ describe('skills install/update: local universal bundle e2e', () => {
     expect(existsSync(join(home, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
     expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable'))).toBe(false);
 
-    rmSync(home, { recursive: true, force: true });
-  }, 15000);
-
-  test('global Pi harness detection targets Pi instead of the fallback providers', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-detect-pi-'));
-    const home = mkdtempSync(join(tmpdir(), 'imp-home-detect-pi-'));
-    execSync('git init', { cwd: tmp });
-    mkdirSync(join(home, '.pi'), { recursive: true });
-    const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
-
-    const output = run('skills install -y --no-hooks', {
-      cwd: tmp,
-      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
-    });
-
-    expect(output).toContain('Installed impeccable into: .pi (project)');
-    expect(existsSync(join(tmp, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
-    expect(existsSync(join(tmp, '.claude', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
-    expect(existsSync(join(tmp, '.agents', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
-
-    rmSync(tmp, { recursive: true, force: true });
-    rmSync(home, { recursive: true, force: true });
-  }, 15000);
-
-  test('interactive Pi install defaults home detections with real skills to user scope', () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-interactive-user-pi-'));
-    const home = mkdtempSync(join(tmpdir(), 'imp-home-interactive-user-pi-'));
-    execSync('git init', { cwd: tmp });
-    const existingSkillDir = join(home, '.pi', 'agent', 'skills', 'existing-user-skill');
-    mkdirSync(existingSkillDir, { recursive: true });
-    writeFileSync(join(existingSkillDir, 'SKILL.md'), '---\nname: existing-user-skill\n---\n');
-    const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
-
-    const output = run('skills install --no-hooks', {
-      cwd: tmp,
-      input: '\n\n\n',
-      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
-    });
-
-    expect(output).toContain('Project Indigo');
-    expect(output).toContain('Installed impeccable into: .pi (global)');
-    expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
-    expect(existsSync(join(home, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
-    expect(existsSync(join(tmp, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
-
-    rmSync(tmp, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
   }, 15000);
 

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -833,6 +833,109 @@ describe('skills install/update: local universal bundle e2e', () => {
     rmSync(home, { recursive: true, force: true });
   }, 15000);
 
+  test('--scope=global installs Pi skills into the Pi agent home directory', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-scope-user-pi-'));
+    const home = mkdtempSync(join(tmpdir(), 'imp-home-scope-user-pi-'));
+    execSync('git init', { cwd: tmp });
+    const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
+
+    const output = run('skills install -y --providers=pi --scope=global --no-hooks', {
+      cwd: tmp,
+      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
+    });
+
+    expect(output).toContain('Installed impeccable into: .pi (global)');
+    expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(home, '.pi', 'skills', 'impeccable'))).toBe(false);
+    expect(existsSync(join(tmp, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
+
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }, 15000);
+
+  test('--scope=project keeps Pi skills in the project Pi skills directory', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-scope-project-pi-'));
+    const home = mkdtempSync(join(tmpdir(), 'imp-home-scope-project-pi-'));
+    execSync('git init', { cwd: tmp });
+    const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
+
+    const output = run('skills install -y --providers=pi --scope=project --no-hooks', {
+      cwd: tmp,
+      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
+    });
+
+    expect(output).toContain('Installed impeccable into: .pi (project)');
+    expect(existsSync(join(tmp, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(tmp, '.pi', 'agent', 'skills', 'impeccable'))).toBe(false);
+    expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
+
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }, 15000);
+
+  test('home-rooted project install keeps Pi skills in the project Pi skills directory', () => {
+    const home = mkdtempSync(join(tmpdir(), 'imp-home-rooted-project-pi-'));
+    execSync('git init', { cwd: home });
+    const bundleRoot = createFakeUniversalBundle(home, ['.pi']);
+
+    const output = run('skills install -y --providers=pi --no-hooks', {
+      cwd: home,
+      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
+    });
+
+    expect(output).toContain('Installed impeccable into: .pi (project)');
+    expect(existsSync(join(home, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable'))).toBe(false);
+
+    rmSync(home, { recursive: true, force: true });
+  }, 15000);
+
+  test('global Pi harness detection targets Pi instead of the fallback providers', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-detect-pi-'));
+    const home = mkdtempSync(join(tmpdir(), 'imp-home-detect-pi-'));
+    execSync('git init', { cwd: tmp });
+    mkdirSync(join(home, '.pi'), { recursive: true });
+    const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
+
+    const output = run('skills install -y --no-hooks', {
+      cwd: tmp,
+      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
+    });
+
+    expect(output).toContain('Installed impeccable into: .pi (project)');
+    expect(existsSync(join(tmp, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(tmp, '.claude', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(tmp, '.agents', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
+
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }, 15000);
+
+  test('interactive Pi install defaults home detections with real skills to user scope', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-interactive-user-pi-'));
+    const home = mkdtempSync(join(tmpdir(), 'imp-home-interactive-user-pi-'));
+    execSync('git init', { cwd: tmp });
+    const existingSkillDir = join(home, '.pi', 'agent', 'skills', 'existing-user-skill');
+    mkdirSync(existingSkillDir, { recursive: true });
+    writeFileSync(join(existingSkillDir, 'SKILL.md'), '---\nname: existing-user-skill\n---\n');
+    const bundleRoot = createFakeUniversalBundle(tmp, ['.pi']);
+
+    const output = run('skills install --no-hooks', {
+      cwd: tmp,
+      input: '\n\n\n',
+      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
+    });
+
+    expect(output).toContain('Project Indigo');
+    expect(output).toContain('Installed impeccable into: .pi (global)');
+    expect(existsSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(home, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(tmp, '.pi', 'skills', 'impeccable', 'SKILL.md'))).toBe(false);
+
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }, 15000);
+
   test('honors an existing hook in shared settings.json and never duplicates into settings.local.json', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'imp-test-local-shared-hook-'));
     execSync('git init', { cwd: tmp });

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -878,6 +878,15 @@ describe('skills install/update: local universal bundle e2e', () => {
     expect(readFileSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'), 'utf8')).toContain('name: impeccable');
     expect(readFileSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'), 'utf8')).not.toContain('Local deterministic bundle');
 
+    // An unscoped update from the same root must refresh BOTH Pi trees, not
+    // just the first layout it finds.
+    run('skills update -y --no-hooks', {
+      cwd: home,
+      env: { ...process.env, HOME: home, IMPECCABLE_BUNDLE_PATH: bundleRoot },
+    });
+    expect(readFileSync(join(home, '.pi', 'skills', 'impeccable', 'SKILL.md'), 'utf8')).toContain('Local deterministic bundle');
+    expect(readFileSync(join(home, '.pi', 'agent', 'skills', 'impeccable', 'SKILL.md'), 'utf8')).toContain('Local deterministic bundle');
+
     rmSync(home, { recursive: true, force: true });
   }, 15000);
 


### PR DESCRIPTION
Fixes #327.

## Summary
- install Pi global skills into `~/.pi/agent/skills/`
- keep project-scope Pi installs at `.pi/skills/`
- document the global Pi path

## Tests
- `bun test tests/skills-cli.test.js`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI skills path resolution and install/update behavior for Pi; no auth or data-handling impact, with regression tests added.
> 
> **Overview**
> Fixes **#327** by teaching the skills CLI that **Project Indigo (Pi)** loads global skills from `~/.pi/agent/skills/`, while **project** installs stay at `.pi/skills/`.
> 
> The installer adds **`HOME_SKILLS_DIR_OVERRIDES`** and helpers (`userProviderSkillsDir`, `providerSkillsDirCandidates`, `isHomeDir`) so install, update, detection, and copy/refresh respect **user vs project scope** and don’t treat a dotfiles repo rooted at `$HOME` as only a global install. **`~/.pi`** is included in **`GLOBAL_HARNESS_HINTS`** for auto-detection. When both Pi layouts exist under home, **update/check** can refresh **both** trees instead of stopping at the first path.
> 
> **`docs/HARNESSES.md`** documents Pi’s dual paths. New CLI tests cover global install routing and home-rooted project installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 841a03490cf87b4f3daa340650c9361456ca32b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->