### PR TITLE
Fix DeepSeek Svelte live submit assertion

### DIFF
--- a/tests/live-svelte-adapter-deepseek.test.mjs
+++ b/tests/live-svelte-adapter-deepseek.test.mjs
@@ -444,7 +444,7 @@ async function assertSelectedElementChrome(page) {
       highlightVisible: highlight?.style.display !== 'none',
       hasInput: Boolean(input),
       hasCount: /×\d+/.test(bar?.textContent || ''),
-      hasGo: /Go/.test(bar?.textContent || ''),
+      hasGenerateButton: [...(bar?.querySelectorAll('button') || [])].some((button) => button.getAttribute('aria-label') === 'Generate variants'),
     };
   });
   assert.equal(result.hasBar, true);
@@ -455,7 +455,7 @@ async function assertSelectedElementChrome(page) {
   assert.equal(result.highlightVisible, true);
   assert.equal(result.hasInput, true);
   assert.equal(result.hasCount, true);
-  assert.equal(result.hasGo, true);
+  assert.equal(result.hasGenerateButton, true);
 }
 
 async function selectAction(page, label) {


### PR DESCRIPTION
## Summary
- Update the DeepSeek Svelte live test to assert the icon-only submit control by aria-label.
- Remove the stale dependency on visible `Go` text.

## Validation
- `bun run test:live-svelte-adapter-deepseek`
- `git diff --check`

Fixes #340

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change; no production or runtime behavior is modified.
> 
> **Overview**
> Updates **`assertSelectedElementChrome`** in the DeepSeek Svelte live adapter test so it matches the icon-only configure-row submit control.
> 
> Instead of requiring visible **`Go`** text in the live bar, the check now looks for a bar button whose **`aria-label`** is **`Generate variants`**, consistent with **`clickGo`** in **`tests/live-e2e/ui.mjs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 865567b16380b6417be07d86a8d7e31a33af4a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->