### PR TITLE
Fix designing phase nav state

### DIFF
--- a/site/pages/designing/index.astro
+++ b/site/pages/designing/index.astro
@@ -55,6 +55,8 @@ import '../../styles/designing-kinpaku.css';
           <line class="designing-loop-wheel-tick designing-loop-wheel-tick--cardinal" x1="2.5" y1="50" x2="5.5" y2="50"/>
           <line class="designing-loop-wheel-tick" x1="8.7" y1="27" x2="11.4" y2="28"/>
           <line class="designing-loop-wheel-tick" x1="27" y1="8.7" x2="28" y2="11.4"/>
+        </svg>
+        <svg class="designing-loop-wheel-dot-svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
           <!-- Clockwise-orbiting accent dot, animates with offset-path. -->
           <circle class="designing-loop-wheel-dot" cx="0" cy="0" r="2.2"/>
         </svg>
@@ -473,7 +475,7 @@ import '../../styles/designing-kinpaku.css';
 <script is:inline>
   // Phase scroll-spy: highlight the active loop phase in the sticky nav as
   // the reader scrolls. The active section is the one occupying the band just
-  // under the sticky header + nav (rootMargin clears ~150px at the top).
+  // under the sticky header + nav (rootMargin clears the anchor seam).
   (function initPhaseNav() {
     const nav = document.querySelector('.designing-phasenav');
     if (!nav || !('IntersectionObserver' in window)) return;
@@ -484,9 +486,20 @@ import '../../styles/designing-kinpaku.css';
       .map((a) => document.getElementById(a.getAttribute('href').slice(1)))
       .filter(Boolean);
     if (!sections.length) return;
+    const phaseIds = new Set(sections.map((s) => s.id));
+    document.addEventListener('click', (e) => {
+      const a = e.target.closest('a[href^="#"]');
+      const id = a?.getAttribute('href')?.slice(1);
+      if (phaseIds.has(id)) setActive(id);
+    });
+    window.addEventListener('hashchange', () => {
+      const id = location.hash.slice(1);
+      if (phaseIds.has(id)) setActive(id);
+    });
+    const spyTop = matchMedia('(max-width: 600px)').matches ? 124 : 160;
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((e) => { if (e.isIntersecting) setActive(e.target.id); });
-    }, { rootMargin: '-150px 0px -55% 0px', threshold: 0 });
+    }, { rootMargin: `-${spyTop}px 0px -55% 0px`, threshold: 0 });
     sections.forEach((s) => observer.observe(s));
   })();
 

--- a/site/styles/designing-kinpaku.css
+++ b/site/styles/designing-kinpaku.css
@@ -518,6 +518,12 @@
   scroll-margin-top: 152px;
 }
 
+@media (max-width: 600px) {
+  .designing-kinpaku .designing-loop-track .designing-phase {
+    scroll-margin-top: 116px;
+  }
+}
+
 /* One deliberate, consistent break between the loop spine and the context
    tail (replaces the old maintain->appendix adjacency that fired unevenly). */
 .designing-kinpaku .designing-loop-track + .designing-phase--appendix {

--- a/site/styles/docs-visuals.css
+++ b/site/styles/docs-visuals.css
@@ -1873,12 +1873,22 @@
   justify-self: center;
 }
 
-.designing-loop-wheel-svg {
+.designing-loop-wheel-svg,
+.designing-loop-wheel-dot-svg {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   overflow: visible;
+}
+
+.designing-loop-wheel-svg {
+  z-index: 2;
+}
+
+.designing-loop-wheel-dot-svg {
+  z-index: 3;
+  pointer-events: none;
 }
 
 .designing-loop-wheel-ring {
@@ -1917,6 +1927,7 @@
 
 .designing-loop-wheel-arrow {
   position: absolute;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1940,6 +1951,7 @@
 
 .designing-loop-wheel-center {
   position: absolute;
+  z-index: 4;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
Fixes the `/designing/` phase nav so the active underline follows the clicked hash instead of getting overwritten at section seams.

Also tightens the mobile anchor offset so jumping back to Start does not create a visible layout shift.

Checked the local Chrome click sequences on desktop and mobile, plus `bun run build`.

<img width="800" height="434" alt="ScreenRecording2026-07-06at6 05 02-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/b899b84b-1566-4f72-a716-43957af758df" />


### Design Wheel
Fixed another small bug with CSS stacking, notice the arrow

| Before | After |
|--------|--------|
| <img width="663" height="497" alt="Screenshot 2026-07-06 at 12 18 06" src="https://github.com/user-attachments/assets/65984ea5-1f65-4640-9294-c2cc49ef8c65" /> | <img width="440" height="362" alt="Screenshot 2026-07-06 at 12 29 58" src="https://github.com/user-attachments/assets/45366e96-c2bf-4197-aea3-aeb4d0d95079" /> | 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to `/designing/` inline script and CSS; no auth, data, or shared app logic.
> 
> **Overview**
> **Fixes sticky phase nav on `/designing/`** so the active underline matches the phase you chose, and **tightens hash jumps** under the sticky header on mobile.
> 
> The scroll-spy now **updates on phase hash clicks and `hashchange`**, not only when `IntersectionObserver` fires—so a click is not immediately overwritten at section seams. Observer **`rootMargin` top inset** is **124px on viewports ≤600px and 160px otherwise**, aligned with kinpaku sticky header + phase nav heights.
> 
> **Mobile `scroll-margin-top`** for loop-track phases drops from **152px to 116px** at ≤600px so jumping back to **Start** avoids a visible layout shift.
> 
> The hero loop wheel **splits the orbiting dot into its own SVG** with **z-index stacking** (arrows, ring, dot, center label) so layering stays correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aeddcdee15f6f64a9b3767459a1bc66d0457bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->