### PR TITLE
Fix Google Fonts css2 family parsing

### DIFF
--- a/cli/engine/detect-antipatterns-browser.js
+++ b/cli/engine/detect-antipatterns-browser.js
@@ -628,6 +628,36 @@ function colorToHex(c) {
   return '#' + [c.r, c.g, c.b].map(v => v.toString(16).padStart(2, '0')).join('');
 }
 
+// --- cli/engine/shared/fonts.mjs ---
+const GOOGLE_FONTS_URL_RE = /fonts\.googleapis\.com\/css2?\?[^"'\s)<>]*/gi;
+
+function normalizeGoogleFontFamilyParam(value) {
+  return String(value || '')
+    .split('|')
+    .map(part => part.split(':')[0].trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function extractGoogleFontFamilies(text) {
+  const families = [];
+  if (!text) return families;
+
+  GOOGLE_FONTS_URL_RE.lastIndex = 0;
+  let urlMatch;
+  while ((urlMatch = GOOGLE_FONTS_URL_RE.exec(text)) !== null) {
+    const url = urlMatch[0];
+    const queryStart = url.indexOf('?');
+    if (queryStart === -1) continue;
+
+    const params = new URLSearchParams(url.slice(queryStart + 1).replace(/&amp;/g, '&'));
+    for (const value of params.getAll('family')) {
+      families.push(...normalizeGoogleFontFamilyParam(value));
+    }
+  }
+
+  return families;
+}
+
 // --- cli/engine/rules/checks.mjs ---
 const DETECTOR_IS_BROWSER = typeof window !== 'undefined';
 
@@ -2682,14 +2712,9 @@ function checkPageTypography(doc, win) {
 
   // Check Google Fonts links in HTML
   const html = doc.documentElement?.outerHTML || '';
-  const gfRe = /fonts\.googleapis\.com\/css2?\?family=([^&"'\s]+)/gi;
-  let m;
-  while ((m = gfRe.exec(html)) !== null) {
-    const families = m[1].split('|').map(f => f.split(':')[0].replace(/\+/g, ' ').toLowerCase());
-    for (const f of families) {
-      fonts.add(f);
-      if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
-    }
+  for (const f of extractGoogleFontFamilies(html)) {
+    fonts.add(f);
+    if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
   }
 
   // Also parse raw HTML/style content for font-family (jsdom may not expose all via CSSOM)

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -1,5 +1,6 @@
-import { GENERIC_FONTS } from '../../shared/constants.mjs';
+import { GENERIC_FONTS, OVERUSED_FONTS } from '../../shared/constants.mjs';
 import { isNeutralColor } from '../../shared/color.mjs';
+import { extractGoogleFontFamilies } from '../../shared/fonts.mjs';
 import { checkSourceDesignSystem } from '../../design-system.mjs';
 import { isFullPage } from '../../shared/page.mjs';
 import { applyInlineIgnores } from '../../shared/inline-ignores.mjs';
@@ -36,6 +37,10 @@ function shouldRunPageAnalyzers(content, filePath) {
   if (!isFullPage(content)) return false;
   const ext = extFromFilePath(filePath);
   return !ext || PAGE_ANALYZER_EXTS.has(ext);
+}
+
+function firstOverusedGoogleFont(text) {
+  return extractGoogleFontFamilies(text).find(f => OVERUSED_FONTS.has(f)) || '';
 }
 
 function isNeutralBorderColor(str) {
@@ -88,9 +93,12 @@ const REGEX_MATCHERS = [
   { id: 'overused-font', regex: /font-family\s*:\s*['"]?(Inter|Roboto|Open Sans|Lato|Montserrat|Arial|Helvetica|Fraunces|Geist Sans|Geist Mono|Geist|Mona Sans|Plus Jakarta Sans|Space Grotesk|Recoleta|Instrument Sans|Instrument Serif)\b/gi,
     test: () => true,
     fmt: (m) => m[0] },
-  { id: 'overused-font', regex: /fonts\.googleapis\.com\/css2?\?family=(Inter|Roboto|Open\+Sans|Lato|Montserrat|Fraunces|Plus\+Jakarta\+Sans|Space\+Grotesk|Instrument\+Sans|Instrument\+Serif|Mona\+Sans|Geist)\b/gi,
-    test: () => true,
-    fmt: (m) => `Google Fonts: ${m[1].replace(/\+/g, ' ')}` },
+  { id: 'overused-font', regex: /fonts\.googleapis\.com\/css2?\?[^"'\s)<>]*/gi,
+    test: (m) => {
+      m.overusedGoogleFont = firstOverusedGoogleFont(m[0]);
+      return Boolean(m.overusedGoogleFont);
+    },
+    fmt: (m) => `Google Fonts: ${m.overusedGoogleFont || firstOverusedGoogleFont(m[0])}` },
   // --- Gradient text ---
   { id: 'gradient-text', regex: /background-clip\s*:\s*text|-webkit-background-clip\s*:\s*text/gi,
     test: (m, line) => /gradient/i.test(line),
@@ -170,10 +178,7 @@ const REGEX_ANALYZERS = [
         if (f && !GENERIC_FONTS.has(f)) fonts.add(f);
       }
     }
-    const gfRe = /fonts\.googleapis\.com\/css2?\?family=([^&"'\s]+)/gi;
-    while ((m = gfRe.exec(content)) !== null) {
-      for (const f of m[1].split('|').map(f => f.split(':')[0].replace(/\+/g, ' ').toLowerCase())) fonts.add(f);
-    }
+    for (const f of extractGoogleFontFamilies(content)) fonts.add(f);
     if (fonts.size !== 1 || content.split('\n').length < 20) return [];
     const name = [...fonts][0];
     const lines = content.split('\n');

--- a/cli/engine/rules/checks.mjs
+++ b/cli/engine/rules/checks.mjs
@@ -18,6 +18,7 @@ import {
   parseRgb,
   relativeLuminance,
 } from '../shared/color.mjs';
+import { extractGoogleFontFamilies } from '../shared/fonts.mjs';
 
 const DETECTOR_IS_BROWSER = typeof window !== 'undefined';
 
@@ -2072,14 +2073,9 @@ function checkPageTypography(doc, win) {
 
   // Check Google Fonts links in HTML
   const html = doc.documentElement?.outerHTML || '';
-  const gfRe = /fonts\.googleapis\.com\/css2?\?family=([^&"'\s]+)/gi;
-  let m;
-  while ((m = gfRe.exec(html)) !== null) {
-    const families = m[1].split('|').map(f => f.split(':')[0].replace(/\+/g, ' ').toLowerCase());
-    for (const f of families) {
-      fonts.add(f);
-      if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
-    }
+  for (const f of extractGoogleFontFamilies(html)) {
+    fonts.add(f);
+    if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
   }
 
   // Also parse raw HTML/style content for font-family (jsdom may not expose all via CSSOM)

--- a/cli/engine/shared/fonts.mjs
+++ b/cli/engine/shared/fonts.mjs
@@ -1,0 +1,30 @@
+const GOOGLE_FONTS_URL_RE = /fonts\.googleapis\.com\/css2?\?[^"'\s)<>]*/gi;
+
+function normalizeGoogleFontFamilyParam(value) {
+  return String(value || '')
+    .split('|')
+    .map(part => part.split(':')[0].trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function extractGoogleFontFamilies(text) {
+  const families = [];
+  if (!text) return families;
+
+  GOOGLE_FONTS_URL_RE.lastIndex = 0;
+  let urlMatch;
+  while ((urlMatch = GOOGLE_FONTS_URL_RE.exec(text)) !== null) {
+    const url = urlMatch[0];
+    const queryStart = url.indexOf('?');
+    if (queryStart === -1) continue;
+
+    const params = new URLSearchParams(url.slice(queryStart + 1).replace(/&amp;/g, '&'));
+    for (const value of params.getAll('family')) {
+      families.push(...normalizeGoogleFontFamilyParam(value));
+    }
+  }
+
+  return families;
+}
+
+export { extractGoogleFontFamilies };

--- a/scripts/build-browser-detector.js
+++ b/scripts/build-browser-detector.js
@@ -18,6 +18,7 @@ const MODULES = [
   'cli/engine/shared/constants.mjs',
   'cli/engine/registry/antipatterns.mjs',
   'cli/engine/shared/color.mjs',
+  'cli/engine/shared/fonts.mjs',
   'cli/engine/rules/checks.mjs',
   'cli/engine/browser/injected/index.mjs',
 ];
@@ -32,6 +33,7 @@ function browserSafeModule(relPath) {
     code = match[0];
   }
   code = code.replace(/^import[\s\S]*?;\n/gm, '');
+  code = code.replace(/^export\s+\{[^}]*\};\n?/gm, '');
   code = code.replace(/^export\s+\{[\s\S]*?^};\n?/gm, '');
   return `// --- ${relPath} ---\n${code.trim()}\n`;
 }

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -28,6 +28,7 @@ const BROWSER_MODULES = [
   'cli/engine/shared/constants.mjs',
   'cli/engine/registry/antipatterns.mjs',
   'cli/engine/shared/color.mjs',
+  'cli/engine/shared/fonts.mjs',
   'cli/engine/rules/checks.mjs',
   'cli/engine/browser/injected/index.mjs',
 ];
@@ -42,6 +43,7 @@ function browserSafeModule(relPath) {
     code = match[0];
   }
   code = code.replace(/^import[\s\S]*?;\n/gm, '');
+  code = code.replace(/^export\s+\{[^}]*\};\n?/gm, '');
   code = code.replace(/^export\s+\{[\s\S]*?^};\n?/gm, '');
   return `// --- ${relPath} ---\n${code.trim()}\n`;
 }

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -12,6 +12,7 @@ import {
 } from '../cli/engine/detect-antipatterns.mjs';
 import {
   checkElementTextOverflowDOM,
+  checkPageTypography,
   isScreenReaderOnlyTextStyle,
 } from '../cli/engine/rules/checks.mjs';
 
@@ -46,6 +47,34 @@ async function withStaticFixture(files, callback) {
 
 function findingIds(findings) {
   return findings.map(f => f.antipattern);
+}
+
+function pageWithGoogleFonts(href) {
+  return [
+    '<!DOCTYPE html><html><head>',
+    `<link href="${href}" rel="stylesheet">`,
+    '</head><body>',
+    ...Array.from({ length: 22 }, (_, i) => `<p>Sample content row ${i + 1}</p>`),
+    '</body></html>',
+  ].join('\n');
+}
+
+function pageTypographyForGoogleFonts(href) {
+  const html = pageWithGoogleFonts(href);
+  const doc = {
+    styleSheets: [],
+    documentElement: { outerHTML: html },
+    querySelectorAll(selector) {
+      if (selector === '*') return Array.from({ length: 24 }, () => ({}));
+      return [];
+    },
+  };
+  const win = {
+    getComputedStyle() {
+      return { fontSize: '16px' };
+    },
+  };
+  return checkPageTypography(doc, win);
 }
 
 
@@ -198,6 +227,30 @@ describe('detectText — overused fonts', () => {
   test('does not flag distinctive fonts', () => {
     const f = detectText("body { font-family: 'Karla', sans-serif; }", 'test.css');
     expect(f.filter(r => r.antipattern === 'overused-font')).toHaveLength(0);
+  });
+
+  test('detects overused Google Fonts css2 family after first family param', () => {
+    const page = pageWithGoogleFonts('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300&family=Inter:wght@400;500;600&display=swap');
+    const f = detectText(page, 'index.html');
+    expect(f.some(r => r.antipattern === 'overused-font' && /Inter/i.test(r.snippet))).toBe(true);
+  });
+
+  test('does not flag single-font for combined Google Fonts css2 families', () => {
+    const page = pageWithGoogleFonts('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300&family=Jost:wght@300;400;500&display=swap');
+    const f = detectText(page, 'index.html');
+    expect(f.filter(r => r.antipattern === 'single-font')).toHaveLength(0);
+  });
+
+  test('keeps legacy Google Fonts css pipe-separated families multi-font', () => {
+    const page = pageWithGoogleFonts('https://fonts.googleapis.com/css?family=Cormorant+Garamond|Jost&display=swap');
+    const f = detectText(page, 'index.html');
+    expect(f.filter(r => r.antipattern === 'single-font')).toHaveLength(0);
+  });
+
+  test('page typography parses repeated Google Fonts css2 family params', () => {
+    const f = pageTypographyForGoogleFonts('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300&family=Inter:wght@400;500;600&display=swap');
+    expect(f.some(r => r.id === 'overused-font' && /inter/i.test(r.snippet))).toBe(true);
+    expect(f.filter(r => r.id === 'single-font')).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Parse all `family` query params in Google Fonts css2 URLs so combined font links are treated as multi-family input instead of only reading the first family. This fixes the `single-font` false positive from #334 and also catches overused Google Fonts when the overused face appears after the first `family=` param.

## Type of change

- [ ] New command
- [ ] New / updated skill reference
- [ ] New anti-pattern guidance
- [x] Bug fix
- [ ] Documentation update
- [x] Build system / tooling
- [ ] Other:

## Details

- Added a shared Google Fonts family parser used by regex detection and page typography checks.
- Preserved legacy `css?family=A|B` behavior while supporting repeated css2 `family=` params.
- Included the parser in browser and extension detector bundle generation.
- Added regression coverage for css2 repeated params, legacy pipe-separated families, and page typography behavior.

## Why

Fixes #334.

## Tests

- `bun test tests/detect-antipatterns.test.js`
- `bun test tests/detect-antipatterns.test.js -t "Google Fonts"`
- `bun run build:browser`
- `bun run build:extension`
- `bun run build`
- `PUPPETEER_EXECUTABLE_PATH=<local Chrome executable> node --test tests/detect-antipatterns-browser.test.mjs`
- `PUPPETEER_EXECUTABLE_PATH=<local Chrome executable> bun run test`

## Scope

- No changes to detector rule semantics beyond parsing all Google Fonts families from css/css2 URLs.
- No root provider/harness output refresh.
- No docs changes; behavior is covered by detector tests.

## Checklist

- [ ] Source files updated in `source/`
- [x] `bun run build` ran successfully
- [x] `bun test` passes
- [x] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Kiro / OpenCode / Qoder)
- [x] README / DEVELOP.md updated if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized detector parsing and bundle wiring; rule semantics change only for how Google Fonts families are extracted from URLs, with regression tests.
> 
> **Overview**
> Fixes **Google Fonts URL parsing** so multi-family `css2` links (repeated `family=` params) are read correctly instead of only the first `family=` segment.
> 
> A shared **`extractGoogleFontFamilies`** helper in `cli/engine/shared/fonts.mjs` finds `fonts.googleapis.com/css` / `css2` URLs, uses `URLSearchParams.getAll('family')`, normalizes names (strip weights, `+` → space, lowercase), and still supports legacy `css?family=A|B` via `|` splitting. **Regex text detection**, **page typography** (`checkPageTypography`), and the **bundled browser detector** now call this helper for overused-font and single-font logic.
> 
> The regex **overused-font** rule matches the full Google Fonts URL and flags when any parsed family is in `OVERUSED_FONTS`, including Inter when it appears after the first `family=` param. **Browser and extension builds** bundle `fonts.mjs` and strip single-line `export { ... }` when inlining modules.
> 
> Regression tests cover css2 repeated params, legacy pipe-separated families, and page typography behavior (fixes #334 `single-font` false positives).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2ed1dabba68f48ff6dc6bf96eac06150049bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->