### PR TITLE
Prefer CLAUDE_PROJECT_DIR / CURSOR_PROJECT_DIR in resolveCacheCwd()

### DIFF
--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -143,14 +143,21 @@ function looksLikeProjectRoot(dir) {
   });
 }
 
-// Where `.impeccable/` (cache + config) lives for this event. Normally the
-// session cwd, untouched. But when the agent was launched from an umbrella
-// directory that is not itself a project (no .git, package.json, or
-// .impeccable), key to the edited file's nearest project root instead, so a
-// multi-project launch dir doesn't accumulate a shared cross-project cache
-// (issue #305). Climbing stops at the home dir, falling back to the session
-// cwd when no marker is found.
+// Where `.impeccable/` (cache + config) lives for this event. When the
+// harness tells us the project root directly (CLAUDE_PROJECT_DIR,
+// CURSOR_PROJECT_DIR), trust it outright — it's authoritative even when the
+// session cwd is itself a marker-bearing directory, which matters in
+// monorepos where a package nested under the real project root has its own
+// package.json and would otherwise look like a project root in its own
+// right. Otherwise, key to the session cwd, untouched. But when the agent
+// was launched from an umbrella directory that is not itself a project (no
+// .git, package.json, or .impeccable), key to the edited file's nearest
+// project root instead, so a multi-project launch dir doesn't accumulate a
+// shared cross-project cache (issue #305). Climbing stops at the home dir,
+// falling back to the session cwd when no marker is found.
 export function resolveCacheCwd(primaryFile, sessionCwd) {
+  const envRoot = envProjectDir(null);
+  if (typeof envRoot === 'string' && envRoot) return path.resolve(envRoot);
   const base = path.resolve(sessionCwd || process.cwd());
   if (!primaryFile || typeof primaryFile !== 'string' || hasPathTraversal(primaryFile)) return base;
   if (looksLikeProjectRoot(base)) return base;
@@ -1172,6 +1179,9 @@ export function normalizeHookEvent(event, projectCwd, harness = 'claude') {
 }
 
 function envProjectDir(fallback) {
+  if (typeof process.env.CLAUDE_PROJECT_DIR === 'string' && process.env.CLAUDE_PROJECT_DIR) {
+    return process.env.CLAUDE_PROJECT_DIR;
+  }
   if (typeof process.env.CURSOR_PROJECT_DIR === 'string' && process.env.CURSOR_PROJECT_DIR) {
     return process.env.CURSOR_PROJECT_DIR;
   }

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -144,20 +144,28 @@ function looksLikeProjectRoot(dir) {
 }
 
 // Where `.impeccable/` (cache + config) lives for this event. When the
-// harness tells us the project root directly (CLAUDE_PROJECT_DIR,
-// CURSOR_PROJECT_DIR), trust it outright — it's authoritative even when the
-// session cwd is itself a marker-bearing directory, which matters in
-// monorepos where a package nested under the real project root has its own
-// package.json and would otherwise look like a project root in its own
-// right. Otherwise, key to the session cwd, untouched. But when the agent
-// was launched from an umbrella directory that is not itself a project (no
-// .git, package.json, or .impeccable), key to the edited file's nearest
-// project root instead, so a multi-project launch dir doesn't accumulate a
-// shared cross-project cache (issue #305). Climbing stops at the home dir,
-// falling back to the session cwd when no marker is found.
+// harness names the project root directly (CLAUDE_PROJECT_DIR,
+// CURSOR_PROJECT_DIR) *and* that directory looks like a real project root,
+// trust it outright — it wins even when the session cwd is itself a
+// marker-bearing directory, which matters in monorepos where a package
+// nested under the real project root has its own package.json and would
+// otherwise look like a project root in its own right (issue #351). The
+// looksLikeProjectRoot gate matters because Claude Code sets
+// CLAUDE_PROJECT_DIR on every hook invocation to the *launch* dir: when that
+// launch dir is a bare umbrella (no .git/package.json/.impeccable), trusting
+// it blindly would scatter the cache back into the umbrella — the exact
+// regression #305 fixed. Otherwise, key to the session cwd, untouched. But
+// when the agent was launched from an umbrella directory that is not itself a
+// project, key to the edited file's nearest project root instead, so a
+// multi-project launch dir doesn't accumulate a shared cross-project cache
+// (issue #305). Climbing stops at the home dir, falling back to the session
+// cwd when no marker is found.
 export function resolveCacheCwd(primaryFile, sessionCwd) {
   const envRoot = envProjectDir(null);
-  if (typeof envRoot === 'string' && envRoot) return path.resolve(envRoot);
+  if (typeof envRoot === 'string' && envRoot) {
+    const resolvedEnvRoot = path.resolve(envRoot);
+    if (looksLikeProjectRoot(resolvedEnvRoot)) return resolvedEnvRoot;
+  }
   const base = path.resolve(sessionCwd || process.cwd());
   if (!primaryFile || typeof primaryFile !== 'string' || hasPathTraversal(primaryFile)) return base;
   if (looksLikeProjectRoot(base)) return base;

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -1469,8 +1469,9 @@ describe('runHook() — cache write gating (issues #344, #305)', () => {
     // project root on its own and would otherwise short-circuit
     // resolveCacheCwd() at cwd itself (see resolveCacheCwd()'s own describe
     // block for the same case at the unit level). CLAUDE_PROJECT_DIR — a
-    // distinct directory — must still win.
+    // distinct, marker-bearing directory — must still win.
     const monorepoRoot = mkTmp();
+    fs.writeFileSync(path.join(monorepoRoot, 'package.json'), '{"name":"monorepo"}');
     write('package.json', '{"name":"nested-package"}');
     const file = write('src/Card.tsx', 'noop');
     const before = process.env.CLAUDE_PROJECT_DIR;
@@ -1529,7 +1530,13 @@ describe('resolveCacheCwd()', () => {
     fs.mkdirSync(pkgDir, { recursive: true });
     fs.writeFileSync(path.join(pkgDir, 'package.json'), '{}');
     const file = path.join(pkgDir, 'src', 'Card.tsx');
+    // The env-projected root is trusted only when it looks like a real project
+    // root — Claude Code sets CLAUDE_PROJECT_DIR to the launch dir on every
+    // hook, so a marker-bearing gate keeps a bare-umbrella launch dir from
+    // scattering the cache (issue #305). Give it a marker here.
     const root = path.join(cwd, 'root');
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), '{}');
 
     const beforeClaude = process.env.CLAUDE_PROJECT_DIR;
     const beforeCursor = process.env.CURSOR_PROJECT_DIR;
@@ -1544,6 +1551,31 @@ describe('resolveCacheCwd()', () => {
 
       process.env.CLAUDE_PROJECT_DIR = root;
       assert.equal(resolveCacheCwd(file, pkgDir), root, 'CLAUDE_PROJECT_DIR should take precedence when both are set');
+    } finally {
+      if (beforeClaude === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+      else process.env.CLAUDE_PROJECT_DIR = beforeClaude;
+      if (beforeCursor === undefined) delete process.env.CURSOR_PROJECT_DIR;
+      else process.env.CURSOR_PROJECT_DIR = beforeCursor;
+    }
+  });
+
+  it('ignores a marker-less env project dir so an umbrella launch dir still climbs (issue #305)', () => {
+    // Claude Code sets CLAUDE_PROJECT_DIR to the launch dir on every hook. When
+    // that launch dir is a bare umbrella (no .git/package.json/.impeccable),
+    // trusting it would scatter the cache there; instead we must fall through
+    // to the edited file's nearest marker root.
+    const umbrella = path.join(cwd, 'umbrella');
+    const child = path.join(umbrella, 'app');
+    fs.mkdirSync(path.join(child, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(child, 'package.json'), '{}');
+    const file = path.join(child, 'src', 'Card.tsx');
+
+    const beforeClaude = process.env.CLAUDE_PROJECT_DIR;
+    const beforeCursor = process.env.CURSOR_PROJECT_DIR;
+    try {
+      delete process.env.CURSOR_PROJECT_DIR;
+      process.env.CLAUDE_PROJECT_DIR = umbrella;
+      assert.equal(resolveCacheCwd(file, umbrella), child, 'a marker-less CLAUDE_PROJECT_DIR must not short-circuit the climb');
     } finally {
       if (beforeClaude === undefined) delete process.env.CLAUDE_PROJECT_DIR;
       else process.env.CLAUDE_PROJECT_DIR = beforeClaude;

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -1462,6 +1462,34 @@ describe('runHook() — cache write gating (issues #344, #305)', () => {
     assert.ok(fs.existsSync(path.join(child, '.impeccable', 'hook.cache.json')), 'cache should land in the child project');
     assert.ok(!fs.existsSync(path.join(cwd, '.impeccable')), 'umbrella root should stay clean');
   });
+
+  it('CLAUDE_PROJECT_DIR pins the cache to the monorepo root, not a nested package', async () => {
+    // cwd (the session/tool-call cwd) is a package nested under the real
+    // monorepo root and has its own package.json, so it "looks like" a
+    // project root on its own and would otherwise short-circuit
+    // resolveCacheCwd() at cwd itself (see resolveCacheCwd()'s own describe
+    // block for the same case at the unit level). CLAUDE_PROJECT_DIR — a
+    // distinct directory — must still win.
+    const monorepoRoot = mkTmp();
+    write('package.json', '{"name":"nested-package"}');
+    const file = write('src/Card.tsx', 'noop');
+    const before = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = monorepoRoot;
+    try {
+      const r = await runHook({
+        stdinJson: JSON.stringify(eventFor(file)),
+        env: {}, cwd, detector: fakeDetector([finding('side-tab', 1)]),
+      });
+      assert.match(r.stdout, /Design hook findings requiring review/);
+      assert.equal(r.audit.cwd, monorepoRoot);
+      assert.ok(fs.existsSync(path.join(monorepoRoot, '.impeccable', 'hook.cache.json')), 'cache should land at CLAUDE_PROJECT_DIR');
+      assert.ok(!fs.existsSync(path.join(cwd, '.impeccable')), 'nested package should stay clean');
+    } finally {
+      if (before === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+      else process.env.CLAUDE_PROJECT_DIR = before;
+      fs.rmSync(monorepoRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('resolveCacheCwd()', () => {
@@ -1494,6 +1522,34 @@ describe('resolveCacheCwd()', () => {
     assert.equal(resolveCacheCwd(file, cwd), cwd);
     assert.equal(resolveCacheCwd('', cwd), cwd);
     assert.equal(resolveCacheCwd(`${cwd}/../etc/Card.tsx`, cwd), cwd);
+  });
+
+  it('prefers CLAUDE_PROJECT_DIR / CURSOR_PROJECT_DIR over the session cwd, even when the session cwd already looks like a project root', () => {
+    const pkgDir = path.join(cwd, 'pkg');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), '{}');
+    const file = path.join(pkgDir, 'src', 'Card.tsx');
+    const root = path.join(cwd, 'root');
+
+    const beforeClaude = process.env.CLAUDE_PROJECT_DIR;
+    const beforeCursor = process.env.CURSOR_PROJECT_DIR;
+    try {
+      delete process.env.CURSOR_PROJECT_DIR;
+      process.env.CLAUDE_PROJECT_DIR = root;
+      assert.equal(resolveCacheCwd(file, pkgDir), root, 'CLAUDE_PROJECT_DIR should win over a package.json-bearing session cwd');
+
+      delete process.env.CLAUDE_PROJECT_DIR;
+      process.env.CURSOR_PROJECT_DIR = root;
+      assert.equal(resolveCacheCwd(file, pkgDir), root, 'CURSOR_PROJECT_DIR should win when CLAUDE_PROJECT_DIR is unset');
+
+      process.env.CLAUDE_PROJECT_DIR = root;
+      assert.equal(resolveCacheCwd(file, pkgDir), root, 'CLAUDE_PROJECT_DIR should take precedence when both are set');
+    } finally {
+      if (beforeClaude === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+      else process.env.CLAUDE_PROJECT_DIR = beforeClaude;
+      if (beforeCursor === undefined) delete process.env.CURSOR_PROJECT_DIR;
+      else process.env.CURSOR_PROJECT_DIR = beforeCursor;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

`resolveCacheCwd()` (added in #346 for #305) climbs from the edited file to
the nearest `.git`/`package.json`/`.impeccable` marker when the session cwd
doesn't itself look like a project root. In a monorepo, though, a package
nested under the real project root often has its own `package.json`, so the
session cwd short-circuits *there* before the climb ever runs, and the cache
still scatters across packages instead of converging on the actual project
root.

`envProjectDir()` already special-cases `CURSOR_PROJECT_DIR`, but it's wired
into `normalizeHookEvent()`'s cursor branch and `resolveProjectCwd()` only,
never into `resolveCacheCwd()`. So neither Cursor's env var nor Claude Code's
equivalent (`CLAUDE_PROJECT_DIR`, set on every hook invocation) had any way to
override the cache/config location.

This has `resolveCacheCwd()` consult `envProjectDir()` first, and teaches it
about `CLAUDE_PROJECT_DIR` alongside the existing `CURSOR_PROJECT_DIR` check.
When the harness names the project root **and that directory looks like a real
project root**, trust it outright: it wins even when the session cwd is itself
a marker-bearing directory (the monorepo nested-package case).

### Why the `looksLikeProjectRoot` gate

Claude Code sets `CLAUDE_PROJECT_DIR` on every hook invocation, to the
directory Claude was *launched* from. Trusting it unconditionally would make
the #305 umbrella-climb branch dead code, and in the #305 scenario (a bare
umbrella launch dir with no `.git`/`package.json`/`.impeccable`) it would
scatter the cache back into that umbrella, the exact regression #305 fixed. So
the env root wins only when it is itself a marker-bearing project root:

- Monorepo root (`.git` + `package.json`): trusted, so a nested package with
  its own `package.json` no longer captures the cache (#351).
- Bare umbrella launch dir (no markers): not trusted, so the climb still keys
  the cache to the edited file's nearest project root (#305 preserved).

Source-only diff: `skill/scripts/hook-lib.mjs` and `tests/hook.test.mjs`, same
convention as #346. No generated harness sync in this PR.

## Test plan

- [x] `node --test tests/hook.test.mjs` — 148/149 pass. The one failure
      (`Cursor hook scripts > preToolUse routes configured html-engine
      templates through the HTML engine (issue #316)`) reproduces identically
      on unmodified `main` (verified via `git stash`), unrelated to this
      change.
- [x] Unit tests in `resolveCacheCwd()`'s own describe block: `CLAUDE_PROJECT_DIR`
      and `CURSOR_PROJECT_DIR` (both marker-bearing) win over a
      `package.json`-bearing session cwd, with `CLAUDE_PROJECT_DIR` taking
      precedence when both are set; and a **marker-less** env project dir does
      **not** short-circuit the climb, so an umbrella launch dir still keys to
      the edited file's project root (#305).
- [x] Integration test in `runHook()`'s cache-write-gating describe block: a
      package nested under a monorepo root (each with its own `package.json`)
      still gets its cache pinned to a marker-bearing `CLAUDE_PROJECT_DIR`
      instead of the nested package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
