### PR TITLE
Fix docs UI polish

### DIFF
--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1694,6 +1694,10 @@ html.light .docs-kinpaku .prose .code-block code {
   /* Doc.astro initSplitCompare uses skewAngle: 0 — vertical seam, not the
      angled default from sub-pages.css / main.css. */
   clip-path: polygon(50% 0%, 100% 0%, 100% 100%, 50% 100%);
+  background: var(--ks-lacquer-raised);
+}
+
+html.dark .docs-kinpaku .docs-command-demo .split-after {
   background: var(--ks-lacquer-deep);
 }
 

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1694,7 +1694,7 @@ html.light .docs-kinpaku .prose .code-block code {
   /* Doc.astro initSplitCompare uses skewAngle: 0 — vertical seam, not the
      angled default from sub-pages.css / main.css. */
   clip-path: polygon(50% 0%, 100% 0%, 100% 100%, 50% 100%);
-  background: var(--ks-lacquer-deep);
+  background: oklch(4% 0.004 95);
 }
 
 .docs-kinpaku .docs-command-demo .split-divider {

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1454,6 +1454,10 @@ html.light .docs-kinpaku .prose .code-block code {
   border-bottom-color: var(--ks-kinpaku);
 }
 
+.docs-kinpaku .prose #what-goes-where + table td:first-child code {
+  white-space: nowrap;
+}
+
 @media (max-width: 760px) {
   .docs-kinpaku .prose table {
     display: block;
@@ -1690,9 +1694,7 @@ html.light .docs-kinpaku .prose .code-block code {
   /* Doc.astro initSplitCompare uses skewAngle: 0 — vertical seam, not the
      angled default from sub-pages.css / main.css. */
   clip-path: polygon(50% 0%, 100% 0%, 100% 100%, 50% 100%);
-  background:
-    linear-gradient(90deg, oklch(8% 0.006 95 / 0.92), oklch(10% 0.006 95 / 0.96)),
-    radial-gradient(circle at 82% 26%, oklch(78% 0.12 82 / 0.14), transparent 12rem);
+  background: var(--ks-lacquer-deep);
 }
 
 .docs-kinpaku .docs-command-demo .split-divider {

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1694,11 +1694,7 @@ html.light .docs-kinpaku .prose .code-block code {
   /* Doc.astro initSplitCompare uses skewAngle: 0 — vertical seam, not the
      angled default from sub-pages.css / main.css. */
   clip-path: polygon(50% 0%, 100% 0%, 100% 100%, 50% 100%);
-  background: var(--ks-lacquer-raised);
-}
-
-html.dark .docs-kinpaku .docs-command-demo .split-after {
-  background: var(--ks-lacquer-deep);
+  background: oklch(7% 0.006 95);
 }
 
 .docs-kinpaku .docs-command-demo .split-divider {

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1458,6 +1458,7 @@ html.light .docs-kinpaku .prose .code-block code {
   white-space: nowrap;
 }
 
+
 @media (max-width: 760px) {
   .docs-kinpaku .prose table {
     display: block;

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1694,7 +1694,7 @@ html.light .docs-kinpaku .prose .code-block code {
   /* Doc.astro initSplitCompare uses skewAngle: 0 — vertical seam, not the
      angled default from sub-pages.css / main.css. */
   clip-path: polygon(50% 0%, 100% 0%, 100% 100%, 50% 100%);
-  background: oklch(7% 0.006 95);
+  background: var(--ks-lacquer);
 }
 
 .docs-kinpaku .docs-command-demo .split-divider {

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1694,7 +1694,7 @@ html.light .docs-kinpaku .prose .code-block code {
   /* Doc.astro initSplitCompare uses skewAngle: 0 — vertical seam, not the
      angled default from sub-pages.css / main.css. */
   clip-path: polygon(50% 0%, 100% 0%, 100% 100%, 50% 100%);
-  background: oklch(4% 0.004 95);
+  background: var(--ks-lacquer-deep);
 }
 
 .docs-kinpaku .docs-command-demo .split-divider {

--- a/site/styles/docs-kinpaku.css
+++ b/site/styles/docs-kinpaku.css
@@ -1458,7 +1458,6 @@ html.light .docs-kinpaku .prose .code-block code {
   white-space: nowrap;
 }
 
-
 @media (max-width: 760px) {
   .docs-kinpaku .prose table {
     display: block;

--- a/site/styles/light-mode.css
+++ b/site/styles/light-mode.css
@@ -1244,7 +1244,7 @@ html.light .docs-kinpaku .docs-command-demo .split-before {
 }
 
 html.light .docs-kinpaku .docs-command-demo .split-after {
-  background: var(--ks-lacquer-raised);
+  background: oklch(4% 0.004 95);
 }
 
 html.light .docs-kinpaku .docs-command-demo .demo-caption {

--- a/site/styles/light-mode.css
+++ b/site/styles/light-mode.css
@@ -1244,7 +1244,7 @@ html.light .docs-kinpaku .docs-command-demo .split-before {
 }
 
 html.light .docs-kinpaku .docs-command-demo .split-after {
-  background: oklch(4% 0.004 95);
+  background: var(--ks-lacquer-raised);
 }
 
 html.light .docs-kinpaku .docs-command-demo .demo-caption {


### PR DESCRIPTION
## Summary
- Fix the dark-mode-only docs command demo issue by making the `.split-after` panel use the deepest lacquer surface.
- Prevent the `/docs/context` “What goes where” file labels from wrapping in the first column.
- Leave the existing light-mode override and docs Markdown content unchanged.

## Docs Command Demo (Dark Mode)
| Before | After |
| --- | --- |
| <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-358-screenshots/docs-command-demo-before.png" alt="Before: dark mode after panel is still too light" width="360"> | <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-358-screenshots/docs-command-demo-after.png" alt="After: dark mode after panel is fully dark" width="360"> |

## Docs Context Table
| Before | After |
| --- | --- |
| <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-358-screenshots/docs-context-table-before.png" alt="Before: PRODUCT.md wraps in the File column" width="360"> | <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-358-screenshots/docs-context-table-after.png" alt="After: file labels stay on one line" width="360"> |

## Validation
- `git diff --check`
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in the docs theme; no logic, auth, or data paths.
> 
> **Overview**
> Two small **docs kinpaku** CSS fixes in `docs-kinpaku.css`.
> 
> The docs **command demo** “after” split panel no longer uses stacked light gradients. It uses **`--ks-lacquer-raised`** by default, and **`html.dark`** forces **`--ks-lacquer-deep`** on `.split-after` so the right half reads as the deepest lacquer in dark mode instead of staying too bright.
> 
> For **`/docs/context`**, the table immediately after the **`#what-goes-where`** heading gets **`white-space: nowrap`** on first-column `code`, so file names like `PRODUCT.md` stay on one line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f487641c60f3bc70340fb320ef528daa8a42b962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->