### PR TITLE
Fix stale repository structure diagram in DEVELOP.md

### DIFF
--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -170,15 +170,17 @@ The skill-behavior suite runs three providers (claude-haiku-4-5, gpt-5.4-mini, g
 
 ```
 impeccable/
-  source/                          # Edit these! Source of truth
-    skills/                        # Skill definitions
-      frontend-design/
-        SKILL.md
-        reference/*.md             # Domain-specific references
-      audit/SKILL.md
-      polish/SKILL.md
-      ...
-  dist/                            # Generated output (gitignored)
+  skill/                           # Edit these! Source of truth
+    SKILL.src.md                   # Frontmatter, shared design laws, command router
+    reference/                     # One <command>.md per command + domain references
+    scripts/                       # Skill runtime scripts (hooks, context.mjs, etc.)
+    agents/                        # Nested subagent definitions
+  cli/                             # Standalone `impeccable` CLI (npm package)
+  site/                            # impeccable.style (Astro)
+  extension/                       # Chrome extension
+  functions/                       # Cloudflare Pages Functions
+  plugin/                          # Committed Claude Code plugin build output
+  dist/                            # Generated provider output (gitignored)
   scripts/
     build.js                       # Main orchestrator
     lib/


### PR DESCRIPTION
## Summary
- The "Repository Structure" diagram in `docs/DEVELOP.md` still described the pre-v3.0 multi-skill layout (`source/skills/audit/SKILL.md`, `polish/SKILL.md`, ...).
- Updated it to match the current `skill/` single-skill directory (per `CLAUDE.md`'s v3.0+ architecture notes) and the actual top-level layout (`cli/`, `site/`, `extension/`, `functions/`, `plugin/`, etc.).

## Disclosure
Prepared with AI assistance (Claude Code).

## Test plan
- Verified the new paths against the actual repo tree (`ls` on top level, `skill/`, `scripts/lib/`, `scripts/lib/transformers/`).
- Docs-only change; no build/test impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the structure diagram; no runtime or build behavior affected.
> 
> **Overview**
> **Repository Structure** in `docs/DEVELOP.md` no longer documents the old multi-skill `source/skills/{name}/SKILL.md` tree.
> 
> The diagram now reflects the **v3 single-skill** layout under `skill/` (`SKILL.src.md`, `reference/`, `scripts/`, `agents/`) and lists the other top-level packages contributors actually touch: `cli/`, `site/`, `extension/`, `functions/`, `plugin/`, plus `dist/` as generated provider output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09934dc58dc380fe15fbf89a69e3bd4a1fa900ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->