### PR TITLE
Fix light-mode command demo contrast

### DIFF
--- a/site/styles/home-kinpaku.css
+++ b/site/styles/home-kinpaku.css
@@ -1372,25 +1372,29 @@
   color: var(--demo-muted) !important;
 }
 
-/* Amber warning-card text colors hardcoded in the clarify demo (and others)
-   render as brown-on-brown when the underlying #fff8e1 / #fef3c7 panel gets
-   swapped for the dark --demo-warning-panel. Map them to readable amber tones
-   that survive the dark plinth. */
-.home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="color: #92400e"],
-.home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="color: #854d0e"],
-.home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="color: #78350f"] {
+/* In dark mode, hardcoded amber warning text becomes brown-on-brown when its
+   light panel is swapped for --demo-warning-panel. Map those colors to readable
+   amber tones on the dark plinth; light mode keeps the original brown text. */
+html.dark .home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="color: #92400e"],
+html.dark .home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="color: #854d0e"],
+html.dark .home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="color: #78350f"] {
   color: var(--ks-kinpaku-pale) !important;
 }
 
-/* Primary CTA buttons that use background: var(--color-ink) — on home-kinpaku
-   that token maps to champagne (cream) which paints the button cream-on-dark.
-   The demo wants a dark primary button, so override back to a dark ink and a
-   light label color. */
-.home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison button[style*="background: var(--color-ink)"],
-.home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="background: var(--color-ink)"] {
+/* In dark mode, primary CTAs using background: var(--color-ink) would resolve
+   to champagne on lacquer. Keep the intended dark button and light label on
+   the dark plinth; light mode already resolves the inline ink/paper pairing. */
+html.dark .home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison button[style*="background: var(--color-ink)"],
+html.dark .home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="background: var(--color-ink)"] {
   background: oklch(13% 0.008 95) !important;
   color: var(--ks-champagne) !important;
   border-color: var(--demo-border) !important;
+}
+
+/* Gold remains a fill and display accent on paper. Small demo labels use the
+   paper-safe patina text token so they retain readable contrast. */
+html.light .home-kinpaku :is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison [style*="color: var(--color-accent)"] {
+  color: var(--ks-link-on-paper) !important;
 }
 
 .home-kinpaku .ptable-tooltip {

--- a/tests/docs-integrity.test.js
+++ b/tests/docs-integrity.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import fs from 'fs';
 import path from 'path';
 import { ANTIPATTERNS } from '../cli/engine/registry/antipatterns.mjs';
+import { renderCommandDemo } from '../site/scripts/demo-renderer.js';
 
 const ROOT = process.cwd();
 
@@ -155,5 +156,49 @@ describe('docs integrity', () => {
     }
 
     expect(stale).toEqual([]);
+  });
+
+  test('command demo theme rules stay scoped to their page and theme', () => {
+    const homeCss = fs.readFileSync(path.join(ROOT, 'site/styles/home-kinpaku.css'), 'utf8');
+    const lightCss = fs.readFileSync(path.join(ROOT, 'site/styles/light-mode.css'), 'utf8');
+    const docsCss = fs.readFileSync(path.join(ROOT, 'site/styles/docs-kinpaku.css'), 'utf8');
+    const demoScope = ':is(.spread-demo-area, .terminal-preview, .mobile-demo-area) .demo-split-comparison';
+    const affectedDemos = {
+      clarify: ['Save and Continue →'],
+      quieter: ['View Plans'],
+      bolder: ['Learn More'],
+      polish: ['JD', 'Edit Profile'],
+    };
+
+    for (const [command, labels] of Object.entries(affectedDemos)) {
+      const markup = renderCommandDemo(command);
+      const darkFillCount = markup.split('background: var(--color-ink)').length - 1;
+
+      expect(darkFillCount).toBe(labels.length);
+      for (const label of labels) expect(markup).toContain(label);
+    }
+
+    expect(homeCss).toContain(
+      `html.dark .home-kinpaku ${demoScope} [style*="color: #92400e"]`
+    );
+    expect(homeCss).toContain(
+      `html.dark .home-kinpaku ${demoScope} [style*="background: var(--color-ink)"]`
+    );
+    expect(homeCss).toContain(
+      `html.light .home-kinpaku ${demoScope} [style*="color: var(--color-accent)"]`
+    );
+    expect(homeCss).not.toContain(
+      `\n.home-kinpaku ${demoScope} [style*="color: #92400e"]`
+    );
+    expect(homeCss).not.toContain(
+      `\n.home-kinpaku ${demoScope} [style*="background: var(--color-ink)"]`
+    );
+
+    expect(docsCss).toMatch(
+      /\.docs-kinpaku \.docs-command-demo \.split-after\s*\{[^}]*background:\s*var\(--ks-lacquer\);/
+    );
+    expect(lightCss).toMatch(
+      /html\.light \.docs-kinpaku \.docs-command-demo \.split-after\s*\{[^}]*background:\s*var\(--ks-lacquer-raised\);/
+    );
   });
 });


### PR DESCRIPTION

## Root cause

Dark-mode compatibility rules in `home-kinpaku.css` were not scoped to `html.dark`. When the light theme inverted `--color-ink` and `--color-paper`, those rules forced dark text onto dark CTA/avatar fills and pale warning text onto a pale warning panel.

## Clarify (Light Mode)
| Before | After |
| --- | --- |
| <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-370-screenshots/clarify-before.png" alt="Before: Clarify warning copy and primary action text disappear in light mode" width="360"> | <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-370-screenshots/clarify-after.png" alt="After: Clarify warning copy and primary action text are readable in light mode" width="360"> |


## Bolder (Light Mode)
| Before | After |
| --- | --- |
| <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-370-screenshots/bolder-before.png" alt="Before: Bolder Learn More and accent copy fail light-mode contrast" width="360"> | <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-370-screenshots/bolder-after.png" alt="After: Bolder Learn More and accent copy meet light-mode contrast" width="360"> |

## Polish (Light Mode)
| Before | After |
| --- | --- |
| <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-370-screenshots/polish-before.png" alt="Before: Polish avatar initials and Edit Profile text disappear in light mode" width="360"> | <img src="https://github.com/abdulwahabone/impeccable/releases/download/pr-370-screenshots/polish-after.png" alt="After: Polish avatar initials and Edit Profile text are readable in light mode" width="360"> |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS presentation and test-only changes in demo styling; no auth, data, or runtime logic.
> 
> **Overview**
> Fixes **light-mode contrast** on homepage command split demos by scoping kinpaku compatibility overrides to the active theme instead of applying them in both modes.
> 
> **Dark-only:** Amber warning copy (`#92400e` and related) and primary controls using `background: var(--color-ink)` are remapped only under `html.dark`, so light mode keeps inline brown warning text and natural ink/paper CTA pairing.
> 
> **Light-only:** Demo labels that use `color: var(--color-accent)` now map to `--ks-link-on-paper` under `html.light` for readable gold accent text on paper.
> 
> Adds a **docs integrity test** that renders clarify/quieter/bolder/polish demos, asserts expected CTA markup, and guards that `home-kinpaku.css` contains theme-scoped selectors and no unscoped amber/ink overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c8fc3463e3f71fb60ded509e2a9457b18f1707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->