### PR TITLE
feat: add Mistral Vibe harness support

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -24,6 +24,7 @@ assignees: ''
 - [ ] Kiro
 - [ ] OpenCode
 - [ ] Qoder
+- [ ] Mistral Vibe
 - [ ] All providers
 
 ## Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ This repo is issue-first for outside contributions. If you are not `pbakaus` or 
 - [ ] Source files updated in `source/`
 - [ ] `bun run build` ran successfully
 - [ ] `bun test` passes
-- [ ] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Kiro / OpenCode / Qoder)
+- [ ] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Kiro / OpenCode / Qoder / Mistral Vibe)
 - [ ] README / DEVELOP.md updated if needed
 - [ ] I reviewed the full diff myself before requesting human review
 - [ ] I disclosed any AI assistance in this PR and related commits/comments, or no AI assistance was used

--- a/.github/workflows/sync-generated-output.yml
+++ b/.github/workflows/sync-generated-output.yml
@@ -33,6 +33,7 @@ env:
     .rovodev
     .trae
     .trae-cn
+    .vibe
     plugin
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Run `bun run build` after changing anything in `skill/`, transformer code, or us
 
 ## Generated Provider Output Policy
 
-The root harness folders (`.agents/skills/`, `.claude/skills/`, `.cursor/skills/`, `.gemini/skills/`, `.github/skills/`, `.kiro/skills/`, `.opencode/skills/`, `.pi/skills/`, `.qoder/skills/`, `.rovodev/skills/`, `.trae*/skills/`) and `plugin/` stay tracked so `main` remains installable for direct GitHub, `npx skills`, and submodule users. They are still generated artifacts.
+The root harness folders (`.agents/skills/`, `.claude/skills/`, `.cursor/skills/`, `.gemini/skills/`, `.github/skills/`, `.kiro/skills/`, `.opencode/skills/`, `.pi/skills/`, `.qoder/skills/`, `.rovodev/skills/`, `.trae*/skills/`, `.vibe/skills/`) and `plugin/` stay tracked so `main` remains installable for direct GitHub, `npx skills`, and submodule users. They are still generated artifacts.
 
 Normal development should be source-first: stage changes in `skill/`, `scripts/`, `cli/`, `site/`, `extension/`, `functions/`, and `tests/`; leave generated harness churn unstaged unless the user asked for it. After source changes land on `main`, `.github/workflows/sync-generated-output.yml` runs `bun run build:release` and commits generated provider output directly back to `main`. Treat generated harness diffs as release artifacts and keep them out of feature PRs unless they are the point of the PR.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ git add .gitmodules .impeccable .claude .cursor
 git commit -m "Add Impeccable skills"
 ```
 
-Use the providers your project needs, for example `claude`, `cursor`, `gemini`, `codex`, `github`, `opencode`, `pi`, `qoder`, `trae`, `trae-cn`, or `rovo-dev`. The command links individual skill folders from `.impeccable/dist/universal/` and leaves existing real skill directories untouched unless you pass `--force`.
+Use the providers your project needs, for example `claude`, `cursor`, `gemini`, `codex`, `github`, `opencode`, `pi`, `qoder`, `trae`, `trae-cn`, `rovo-dev`, or `vibe`. The command links individual skill folders from `.impeccable/dist/universal/` and leaves existing real skill directories untouched unless you pass `--force`.
 
 To update later:
 
@@ -248,6 +248,15 @@ cp -r dist/qoder/.qoder your-project/
 
 # Or global (applies to all projects)
 cp -r dist/qoder/.qoder/skills/* ~/.qoder/skills/
+```
+
+**Mistral Vibe:**
+```bash
+# Project-specific
+cp -r dist/vibe/.vibe your-project/
+
+# Or global (applies to all projects)
+cp -r dist/vibe/.vibe/skills/* ~/.vibe/skills/
 ```
 
 ## Usage
@@ -379,6 +388,7 @@ Full detector docs: [impeccable.style/docs/detector](https://impeccable.style/do
 - [Trae](https://trae.ai)
 - [Rovo Dev](https://www.atlassian.com/software/rovo)
 - [Qoder](https://qoder.com)
+- [Mistral Vibe](https://docs.mistral.ai/vibe/code/overview)
 
 ## Community & Ecosystem
 

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -23,7 +23,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const API_BASE = 'https://impeccable.style';
 
 // Provider folder names in project roots
-const PROVIDER_DIRS = ['.claude', '.cursor', '.gemini', '.agents', '.github', '.kiro', '.opencode', '.pi', '.qoder', '.trae', '.trae-cn', '.rovodev'];
+const PROVIDER_DIRS = ['.claude', '.cursor', '.gemini', '.agents', '.github', '.kiro', '.opencode', '.pi', '.qoder', '.trae', '.trae-cn', '.rovodev', '.vibe'];
 const PROVIDER_ALIASES = {
   agents: '.agents',
   claude: '.claude',
@@ -41,6 +41,7 @@ const PROVIDER_ALIASES = {
   rovodev: '.rovodev',
   trae: '.trae',
   'trae-cn': '.trae-cn',
+  vibe: '.vibe',
 };
 
 const PROVIDER_DISPLAY = {
@@ -56,8 +57,9 @@ const PROVIDER_DISPLAY = {
   '.rovodev': { name: 'Rovo Dev', input: 'rovo-dev' },
   '.trae': { name: 'Trae', input: 'trae' },
   '.trae-cn': { name: 'Trae CN', input: 'trae-cn' },
+  '.vibe': { name: 'Mistral Vibe', input: 'vibe' },
 };
-const PROVIDER_INPUT_ORDER = ['claude', 'codex', 'cursor', 'gemini', 'github', 'kiro', 'opencode', 'pi', 'qoder', 'trae', 'trae-cn', 'rovo-dev'];
+const PROVIDER_INPUT_ORDER = ['claude', 'codex', 'cursor', 'gemini', 'github', 'kiro', 'opencode', 'pi', 'qoder', 'trae', 'trae-cn', 'rovo-dev', 'vibe'];
 
 // Providers whose GLOBAL (home) skills dir is not `<provider>/skills`.
 // Pi discovers global skills from ~/.pi/agent/skills/; project scope
@@ -79,6 +81,7 @@ const GLOBAL_HARNESS_HINTS = [
   { home: '.pi', provider: '.pi' },
   { home: '.qoder', provider: '.qoder' },
   { home: '.rovodev', provider: '.rovodev' },
+  { home: '.vibe', provider: '.vibe' },
 ];
 
 // Last-resort default when nothing is detected: Claude Code + the universal
@@ -568,7 +571,7 @@ async function copyOrExtractLocalBundle(sourceValue) {
  */
 function normalizeForHash(content) {
   return content
-    .replace(/\.(claude|cursor|agents|github|gemini|codex|kiro|opencode|pi|qoder|trae|trae-cn|rovodev)\/skills\//g, '.PROVIDER/skills/');
+    .replace(/\.(claude|cursor|agents|github|gemini|codex|kiro|opencode|pi|qoder|trae|trae-cn|rovodev|vibe)\/skills\//g, '.PROVIDER/skills/');
 }
 
 function hashSkillFile(filePath) {

--- a/cli/lib/download-providers.js
+++ b/cli/lib/download-providers.js
@@ -9,6 +9,7 @@ export const FILE_DOWNLOAD_PROVIDER_CONFIG_DIRS = Object.freeze({
   opencode: '.opencode',
   pi: '.pi',
   qoder: '.qoder',
+  vibe: '.vibe',
 });
 
 export const FILE_DOWNLOAD_PROVIDERS = Object.freeze(

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -165,7 +165,7 @@ The skill-behavior suite runs three providers (claude-haiku-4-5, gpt-5.4-mini, g
 - [OpenCode Skills](https://opencode.ai/docs/skills/)
 - [Pi Skills](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md)
 - [Qoder Skills](https://docs.qoder.com/extensions/skills)
-- [Mistral Vibe Skills](https://docs.mistral.ai/vibe/code/overview)
+- [Mistral Vibe Skills](https://docs.mistral.ai/vibe/code/cli/skills)
 
 ## Repository Structure
 

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -165,6 +165,7 @@ The skill-behavior suite runs three providers (claude-haiku-4-5, gpt-5.4-mini, g
 - [OpenCode Skills](https://opencode.ai/docs/skills/)
 - [Pi Skills](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md)
 - [Qoder Skills](https://docs.qoder.com/extensions/skills)
+- [Mistral Vibe Skills](https://docs.mistral.ai/vibe/code/overview)
 
 ## Repository Structure
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -3,7 +3,7 @@
 Source of truth for what each AI coding harness supports in terms of agent skills.
 Used to inform provider configs in `scripts/lib/transformers/providers.js`.
 
-Last verified: 2026-07-16 (subagent landscape spot-checked 2026-06-28)
+Last verified: 2026-04-28 (subagent landscape spot-checked 2026-06-28; Mistral Vibe row verified 2026-07-16)
 
 > This file is point-in-time. Capabilities move fast; verify live before relying
 > on any "only X supports Y" claim. Notably, the subagent table below lists
@@ -24,7 +24,7 @@ Last verified: 2026-07-16 (subagent landscape spot-checked 2026-06-28)
 | Qoder | https://docs.qoder.com/extensions/skills |
 | Trae | TBD (no official skills docs found yet) |
 | Rovo Dev | https://support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills |
-| Mistral Vibe | https://docs.mistral.ai/vibe/code/overview |
+| Mistral Vibe | https://docs.mistral.ai/vibe/code/cli/skills |
 
 ## Spec Compliance
 
@@ -46,7 +46,7 @@ Fields marked with * are spec-standard. Others are provider extensions.
 | `allowed-tools`* | Yes | No | Ignored | No | No | No | Yes | Yes | Yes | Yes | Yes |
 | `user-invocable` | Yes | No | No | No | Yes | No | Yes | No | Yes | Yes | Yes |
 | `argument-hint` | Yes | No | No | No | Yes | No | Yes | No | Yes | Yes | No |
-| `disable-model-invocation` | Yes | Yes | No | No | Yes | No | Yes | Yes | TBD | TBD | TBD |
+| `disable-model-invocation` | Yes | Yes | No | No | Yes | No | Yes | Yes | TBD | TBD | No |
 | `model` | Yes | No | No | No | No | No | Yes | No | No | No | No |
 | `effort` | Yes | No | No | No | No | No | No | No | No | No | No |
 | `context` | Yes | No | No | No | No | No | No | No | No | No | No |
@@ -85,7 +85,7 @@ Notes:
 | Trae China | `.trae-cn/skills/` | TBD |
 | Trae International | `.trae/skills/` | TBD |
 | Rovo Dev | `.rovodev/skills/` | `~/.rovodev/skills/` (user-level) |
-| Mistral Vibe | `.vibe/skills/` | `~/.vibe/skills/`, `.agents/skills/` |
+| Mistral Vibe | `.vibe/skills/` (project), `~/.vibe/skills/` (global) | `.agents/skills/` (project), `~/.agents/skills/` (global) |
 
 All harnesses support the `{skill-name}/SKILL.md` directory structure with optional `reference/`, `scripts/`, and `assets/` subdirectories.
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -3,7 +3,7 @@
 Source of truth for what each AI coding harness supports in terms of agent skills.
 Used to inform provider configs in `scripts/lib/transformers/providers.js`.
 
-Last verified: 2026-04-28 (subagent landscape spot-checked 2026-06-28)
+Last verified: 2026-07-16 (subagent landscape spot-checked 2026-06-28)
 
 > This file is point-in-time. Capabilities move fast; verify live before relying
 > on any "only X supports Y" claim. Notably, the subagent table below lists
@@ -24,6 +24,7 @@ Last verified: 2026-04-28 (subagent landscape spot-checked 2026-06-28)
 | Qoder | https://docs.qoder.com/extensions/skills |
 | Trae | TBD (no official skills docs found yet) |
 | Rovo Dev | https://support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills |
+| Mistral Vibe | https://docs.mistral.ai/vibe/code/overview |
 
 ## Spec Compliance
 
@@ -35,22 +36,22 @@ Provider-specific extensions beyond the spec: `user-invocable`, `argument-hint`,
 
 Fields marked with * are spec-standard. Others are provider extensions.
 
-| Field | Claude Code | Cursor | Gemini | Codex | Copilot | Kiro | OpenCode | Pi | Qoder | Rovo Dev |
-|-------|:-----------:|:------:|:------:|:-----:|:-------:|:----:|:--------:|:--:|:-----:|:--------:|
-| `name`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `description`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `license`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes |
-| `compatibility`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes |
-| `metadata`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes |
-| `allowed-tools`* | Yes | No | Ignored | No | No | No | Yes | Yes | Yes | Yes |
-| `user-invocable` | Yes | No | No | No | Yes | No | Yes | No | Yes | Yes |
-| `argument-hint` | Yes | No | No | No | Yes | No | Yes | No | Yes | Yes |
-| `disable-model-invocation` | Yes | Yes | No | No | Yes | No | Yes | Yes | TBD | TBD |
-| `model` | Yes | No | No | No | No | No | Yes | No | No | No |
-| `effort` | Yes | No | No | No | No | No | No | No | No | No |
-| `context` | Yes | No | No | No | No | No | No | No | No | No |
-| `agent` | Yes | No | No | No | No | No | Yes | No | No | No |
-| `hooks` | Yes | No | No | Yes | No | No | No | No | No | No |
+| Field | Claude Code | Cursor | Gemini | Codex | Copilot | Kiro | OpenCode | Pi | Qoder | Rovo Dev | Mistral Vibe |
+|-------|:-----------:|:------:|:------:|:-----:|:-------:|:----:|:--------:|:--:|:-----:|:--------:|:------------:|
+| `name`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `description`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `license`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `compatibility`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `metadata`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `allowed-tools`* | Yes | No | Ignored | No | No | No | Yes | Yes | Yes | Yes | Yes |
+| `user-invocable` | Yes | No | No | No | Yes | No | Yes | No | Yes | Yes | Yes |
+| `argument-hint` | Yes | No | No | No | Yes | No | Yes | No | Yes | Yes | No |
+| `disable-model-invocation` | Yes | Yes | No | No | Yes | No | Yes | Yes | TBD | TBD | TBD |
+| `model` | Yes | No | No | No | No | No | Yes | No | No | No | No |
+| `effort` | Yes | No | No | No | No | No | No | No | No | No | No |
+| `context` | Yes | No | No | No | No | No | No | No | No | No | No |
+| `agent` | Yes | No | No | No | No | No | Yes | No | No | No | No |
+| `hooks` | Yes | No | No | Yes | No | No | No | No | No | No | No |
 
 Notes:
 - Gemini CLI validates only `name` and `description`; other spec fields are parsed but ignored.
@@ -84,6 +85,7 @@ Notes:
 | Trae China | `.trae-cn/skills/` | TBD |
 | Trae International | `.trae/skills/` | TBD |
 | Rovo Dev | `.rovodev/skills/` | `~/.rovodev/skills/` (user-level) |
+| Mistral Vibe | `.vibe/skills/` | `~/.vibe/skills/`, `.agents/skills/` |
 
 All harnesses support the `{skill-name}/SKILL.md` directory structure with optional `reference/`, `scripts/`, and `assets/` subdirectories.
 

--- a/scripts/lib/transformers/index.js
+++ b/scripts/lib/transformers/index.js
@@ -15,5 +15,6 @@ export const transformOpenCode = createTransformer(PROVIDERS.opencode);
 export const transformPi = createTransformer(PROVIDERS.pi);
 export const transformQoder = createTransformer(PROVIDERS.qoder);
 export const transformRovoDev = createTransformer(PROVIDERS['rovo-dev']);
+export const transformVibe = createTransformer(PROVIDERS.vibe);
 
 export { createTransformer, PROVIDERS };

--- a/scripts/lib/transformers/providers.js
+++ b/scripts/lib/transformers/providers.js
@@ -122,4 +122,11 @@ export const PROVIDERS = {
     displayName: 'Rovo Dev',
     frontmatterFields: ['user-invocable', 'argument-hint', 'license', 'compatibility', 'metadata', 'allowed-tools'],
   },
+  vibe: {
+    provider: 'vibe',
+    providerTags: ['vibe'],
+    configDir: '.vibe',
+    displayName: 'Mistral Vibe',
+    frontmatterFields: ['user-invocable', 'license', 'compatibility', 'metadata', 'allowed-tools'],
+  },
 };

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -627,6 +627,12 @@ export const PROVIDER_PLACEHOLDERS = {
     config_file: 'AGENTS.md',
     ask_instruction: 'ask the user directly to clarify what you cannot infer.',
     command_prefix: '/'
+  },
+  'vibe': {
+    model: 'the model',
+    config_file: 'AGENTS.md',
+    ask_instruction: 'ask the user directly to clarify what you cannot infer.',
+    command_prefix: '/'
   }
 };
 
@@ -645,6 +651,7 @@ export const PROVIDER_BLOCK_TAGS = new Set([
   'rovo-dev',
   'trae',
   'trae-cn',
+  'vibe',
 ]);
 
 /**

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -629,7 +629,7 @@ export const PROVIDER_PLACEHOLDERS = {
     command_prefix: '/'
   },
   'vibe': {
-    model: 'the model',
+    model: 'Mistral',
     config_file: 'AGENTS.md',
     ask_instruction: 'ask the user directly to clarify what you cannot infer.',
     command_prefix: '/'


### PR DESCRIPTION
## Summary

Adds **Mistral Vibe** as a supported provider in the Impeccable build system. Vibe is Mistral AI's open-source CLI coding agent, reading skills from `.vibe/skills/{name}/SKILL.md` at the project level (and `~/.vibe/skills/` for user-level installs). The format mirrors the Agent Skills standard — YAML frontmatter including `user-invocable`, `license`, `compatibility`, `metadata`, and `allowed-tools` are all supported. (Vibe's docs do not document `argument-hint`, so it is omitted from `frontmatterFields` to avoid emitting fields the harness is not known to consume.)

#### References
- https://docs.mistral.ai/vibe/code/overview

## Changes

- **`scripts/lib/utils.js`** — Added `vibe` to `PROVIDER_PLACEHOLDERS` (`model`, `config_file: "AGENTS.md"`, `ask_instruction`, `command_prefix`) mirroring the Qoder shape, and to `PROVIDER_BLOCK_TAGS`
- **`scripts/lib/transformers/providers.js`** — Added `vibe` provider config (`configDir: ".vibe"`, `displayName: "Mistral Vibe"`) with `frontmatterFields: ['user-invocable', 'license', 'compatibility', 'metadata', 'allowed-tools']`
- **`scripts/lib/transformers/index.js`** — Exported `transformVibe` for test-spy parity with the other named providers
- **`cli/bin/commands/skills.mjs`** — Added `.vibe` to `PROVIDER_DIRS`, `PROVIDER_ALIASES`, `PROVIDER_DISPLAY`, `PROVIDER_INPUT_ORDER`, `GLOBAL_HARNESS_HINTS`, and the `normalizeForHash` provider regex so the CLI detects existing Vibe installs and the download endpoint accepts `/api/download/skill/vibe/*` → `dist/vibe/.vibe/`
- **`cli/lib/download-providers.js`** — Added `vibe: '.vibe'` to `FILE_DOWNLOAD_PROVIDER_CONFIG_DIRS`
- **`docs/HARNESSES.md`** — Added Mistral Vibe to the official docs row, frontmatter support matrix (with `argument-hint: No`), and directory structure table; bumped Last verified to 2026-07-16
- **`README.md`** — Added Vibe to the providers list, the manual install `cp -r dist/vibe/.vibe` example, and the Supported Tools section
- **`docs/DEVELOP.md`** — Added the Vibe Skills docs link
- **`.github/`** — Added Mistral Vibe to the feature-request issue template and the PR template provider checklist
- **`.github/workflows/sync-generated-output.yml`** — Added `.vibe` to the harness dirs list so the post-merge sync commits generated `.vibe/` output back to `main`
- **`AGENTS.md`** — Added `.vibe/skills/` to the tracked-harness-folders enumeration

Because the build loop iterates `Object.values(PROVIDERS)` automatically, no other code changes were needed — Vibe gets unprefixed and `i-`-prefixed variants, ZIP bundle inclusion, and full test coverage out of the box.

## Type of change

- [x] Build system / tooling
- [x] Other: New provider support (Mistral Vibe)

## Checklist

- [x] Source files updated in `scripts/`, `cli/`, `docs/`, `README.md`, `.github/`, `AGENTS.md`
- [x] `bun run build` ran successfully
- [x] `bun test` passes (160 provider cases including the new Vibe ones)
- [x] Tested with at least one provider (Mistral Vibe — verified `SKILL.md` output, placeholder resolution, and directory structure)
- [x] README / DEVELOP.md updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider wiring across build, CLI, and docs with no auth, data, or hook-surface changes; risk is mainly missing generated `.vibe/` output until the release sync runs on main.
> 
> **Overview**
> Adds **Mistral Vibe** as a first-class provider so skills build to `.vibe/skills/`, install via CLI, and download from the site like other harnesses.
> 
> The build pipeline gets a new `vibe` entry in `PROVIDERS` (output under `.vibe`, frontmatter limited to fields Vibe documents—**no** `argument-hint`), plus `PROVIDER_PLACEHOLDERS` / `<vibe>` block tags and `transformVibe` export. The skills CLI recognizes `vibe` for detection, install targets, global `~/.vibe` hints, and skill hash normalization; file downloads map `vibe` → `dist/vibe/.vibe`.
> 
> Docs and templates are updated (`README`, `HARNESSES.md`, `DEVELOP.md`, issue/PR checklists). The post-merge **sync-generated-output** workflow and `AGENTS.md` now include `.vibe` among tracked harness folders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1308d6f9cf9b99bfb8a3bd0c84373f38f2e8056d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->