### PR TITLE
Fix: honor --target for nested products in non-monorepo repos

### DIFF
--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -7,9 +7,13 @@
  * using the existing code as context.
  *
  * Path resolution (first match wins):
- *   1. Active project root, if PRODUCT.md or DESIGN.md is there
+ *   1. Active project root, if PRODUCT.md or DESIGN.md is there. An explicit
+ *      --target selects the active project: the workspace child in a
+ *      monorepo, or the nearest directory around the target carrying
+ *      canonical context files in an ordinary repo (issue #376).
  *   2. Active project .agents/context/ then docs/
- *   3. Monorepo root context, using the same order, as a per-file fallback
+ *   3. Repo root context, using the same order, as a per-file fallback
+ *      whenever the active project is nested below it
  *   4. $IMPECCABLE_CONTEXT_DIR (absolute or cwd-relative) — power-user
  *      escape hatch, only consulted when defaults are empty
  *   5. Active project root as a "nothing found" default
@@ -88,7 +92,10 @@ function resolveContext(cwd = process.cwd(), options = {}) {
   const absCwd = path.resolve(cwd);
   const project = resolveProject(absCwd, options);
   const projectContextDir = resolveLocalContextDir(project.projectRoot);
-  const rootContextDir = project.isMonorepo && project.repoRoot !== project.projectRoot
+  // Per-file inheritance from the repo root whenever the active project is
+  // nested below it: monorepo workspace children and explicit-target nested
+  // products in ordinary repos behave the same way.
+  const rootContextDir = project.repoRoot !== project.projectRoot
     ? resolveLocalContextDir(project.repoRoot)
     : null;
 
@@ -165,7 +172,7 @@ function resolveProject(cwd = process.cwd(), options = {}) {
   if (!repoRoot) {
     return {
       targetDir,
-      projectRoot: absCwd,
+      projectRoot: nearestTargetContextRoot(absCwd, targetDir) || absCwd,
       repoRoot: absCwd,
       isMonorepo: false,
     };
@@ -469,6 +476,30 @@ function isExcludedByWorkspacePattern(relSegments, patterns) {
     if (!pattern.startsWith('!')) return false;
     return workspacePatternMatchesRel(pattern.slice(1), relSegments);
   });
+}
+
+// An explicit --target in an ordinary (non-monorepo) repository must still
+// select a nested product's own context (issue #376). Walk from the target up
+// to — but not including — the invocation root and return the nearest
+// directory carrying canonical context files. Context files only, not
+// package.json: without the monorepo root-context fallback, a package.json
+// marker would strand targets inside plain subpackages away from the root
+// PRODUCT.md. The cwd's own fallback context dirs (.agents/context, docs)
+// hold the root project's context, not a nested product, so they never count.
+// Returns null when nothing nested is found, keeping the cwd default.
+function nearestTargetContextRoot(absCwd, targetDir) {
+  if (!isPathInside(targetDir, absCwd)) return null;
+  const rootFallbackDirs = FALLBACK_DIRS.map((rel) => path.resolve(absCwd, rel));
+  let dir = path.resolve(targetDir);
+  while (dir && dir !== absCwd) {
+    if (!rootFallbackDirs.includes(dir) && firstExisting(dir, [...PRODUCT_NAMES, ...DESIGN_NAMES])) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
 }
 
 function nearestProjectLikeRoot(repoRoot, targetDir) {

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -481,18 +481,19 @@ function isExcludedByWorkspacePattern(relSegments, patterns) {
 // An explicit --target in an ordinary (non-monorepo) repository must still
 // select a nested product's own context (issue #376). Walk from the target up
 // to — but not including — the invocation root and return the nearest
-// directory carrying canonical context files. Context files only, not
-// package.json: without the monorepo root-context fallback, a package.json
-// marker would strand targets inside plain subpackages away from the root
-// PRODUCT.md. The cwd's own fallback context dirs (.agents/context, docs)
-// hold the root project's context, not a nested product, so they never count.
+// directory carrying context files, in the canonical spot or a fallback dir
+// (resolveLocalContextDir covers both). Context files only, not package.json:
+// without the monorepo root-context fallback, a package.json marker would
+// strand targets inside plain subpackages away from the root PRODUCT.md. The
+// cwd's own fallback context dirs (.agents/context, docs) hold the root
+// project's context, not a nested product, so they never count.
 // Returns null when nothing nested is found, keeping the cwd default.
 function nearestTargetContextRoot(absCwd, targetDir) {
   if (!isPathInside(targetDir, absCwd)) return null;
   const rootFallbackDirs = FALLBACK_DIRS.map((rel) => path.resolve(absCwd, rel));
   let dir = path.resolve(targetDir);
   while (dir && dir !== absCwd) {
-    if (!rootFallbackDirs.includes(dir) && firstExisting(dir, [...PRODUCT_NAMES, ...DESIGN_NAMES])) {
+    if (!rootFallbackDirs.includes(dir) && resolveLocalContextDir(dir)) {
       return dir;
     }
     const parent = path.dirname(dir);

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -312,6 +312,37 @@ describe('loadContext (monorepo project context)', () => {
     assert.equal(ctx.designPath, path.join('nested', 'product', 'DESIGN.md'));
   });
 
+  it('resolves a nested target whose context lives in .agents/context/', () => {
+    write('nested/product/.agents/context/PRODUCT.md', '# Nested product\n');
+    write('nested/product/file.ts', 'export const x = 1;\n');
+
+    const ctx = loadContext(scratch, { targetPath: 'nested/product/file.ts' });
+    assert.equal(ctx.isMonorepo, false);
+    assert.equal(ctx.projectRoot, path.join(scratch, 'nested', 'product'));
+    assert.match(ctx.product, /Nested product/);
+    assert.equal(ctx.productPath, path.join('nested', 'product', '.agents', 'context', 'PRODUCT.md'));
+  });
+
+  it('resolves a nested target whose context lives in docs/', () => {
+    write('nested/product/docs/DESIGN.md', '# Nested design\n');
+    write('nested/product/file.ts', 'export const x = 1;\n');
+
+    const ctx = loadContext(scratch, { targetPath: 'nested/product/file.ts' });
+    assert.equal(ctx.isMonorepo, false);
+    assert.equal(ctx.projectRoot, path.join(scratch, 'nested', 'product'));
+    assert.match(ctx.design, /Nested design/);
+    assert.equal(ctx.designPath, path.join('nested', 'product', 'docs', 'DESIGN.md'));
+  });
+
+  it('does not treat the root fallback context dirs as a nested product', () => {
+    write('.agents/context/PRODUCT.md', '# Root product\n');
+    write('.agents/context/notes/file.md', '# Notes\n');
+
+    const ctx = loadContext(scratch, { targetPath: '.agents/context/notes/file.md' });
+    assert.equal(ctx.projectRoot, scratch);
+    assert.match(ctx.product, /Root product/);
+  });
+
   it('inherits missing root context per-file for a nested target in a non-monorepo repo', () => {
     write('DESIGN.md', '# Root design\n');
     write('nested/product/PRODUCT.md', '# Nested product\n');

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -278,11 +278,12 @@ describe('loadContext (monorepo project context)', () => {
 
   it('does not reuse stale project resolution after workspace markers change', () => {
     write('PRODUCT.md', '# Root product\n');
-    write('apps/dashboard/PRODUCT.md', '# Dashboard product\n');
+    write('apps/dashboard/package.json', JSON.stringify({ name: 'dashboard' }, null, 2));
     write('apps/dashboard/src/App.jsx', 'export default null;\n');
 
     const before = loadContext(scratch, { targetPath: 'apps/dashboard/src/App.jsx' });
     assert.equal(before.projectRoot, scratch);
+    assert.equal(before.isMonorepo, false);
     assert.match(before.product, /Root product/);
 
     write('package.json', JSON.stringify({
@@ -292,7 +293,46 @@ describe('loadContext (monorepo project context)', () => {
 
     const after = loadContext(scratch, { targetPath: 'apps/dashboard/src/App.jsx' });
     assert.equal(after.projectRoot, path.join(scratch, 'apps', 'dashboard'));
-    assert.match(after.product, /Dashboard product/);
+    assert.equal(after.isMonorepo, true);
+    assert.match(after.product, /Root product/);
+  });
+
+  it('resolves an explicit target onto a nested product context in a non-monorepo repo', () => {
+    write('nested/product/PRODUCT.md', '# Nested product\n');
+    write('nested/product/DESIGN.md', '# Nested design\n');
+    write('nested/product/file.ts', 'export const x = 1;\n');
+
+    const ctx = loadContext(scratch, { targetPath: 'nested/product/file.ts' });
+    assert.equal(ctx.isMonorepo, false);
+    assert.equal(ctx.projectRoot, path.join(scratch, 'nested', 'product'));
+    assert.equal(ctx.repoRoot, scratch);
+    assert.match(ctx.product, /Nested product/);
+    assert.match(ctx.design, /Nested design/);
+    assert.equal(ctx.productPath, path.join('nested', 'product', 'PRODUCT.md'));
+    assert.equal(ctx.designPath, path.join('nested', 'product', 'DESIGN.md'));
+  });
+
+  it('inherits missing root context per-file for a nested target in a non-monorepo repo', () => {
+    write('DESIGN.md', '# Root design\n');
+    write('nested/product/PRODUCT.md', '# Nested product\n');
+    write('nested/product/file.ts', 'export const x = 1;\n');
+
+    const ctx = loadContext(scratch, { targetPath: 'nested/product/file.ts' });
+    assert.equal(ctx.projectRoot, path.join(scratch, 'nested', 'product'));
+    assert.match(ctx.product, /Nested product/);
+    assert.match(ctx.design, /Root design/);
+    assert.equal(ctx.designPath, 'DESIGN.md');
+  });
+
+  it('keeps the repo root project for targets without nearby context files', () => {
+    write('PRODUCT.md', '# Root product\n');
+    write('src/App.jsx', 'export default null;\n');
+
+    const ctx = loadContext(scratch, { targetPath: 'src/App.jsx' });
+    assert.equal(ctx.isMonorepo, false);
+    assert.equal(ctx.projectRoot, scratch);
+    assert.match(ctx.product, /Root product/);
+    assert.equal(ctx.productPath, 'PRODUCT.md');
   });
 
   it('does not escape a nested git repo to an ancestor workspace', () => {


### PR DESCRIPTION
Fixes #376.

## The Bug
Issue was that on monorepo, impeccable was not about to resolve the `PRODUCT.md` / `DESIGN.md`

<img width="757" height="1022" alt="Screenshot 2026-07-17 at 23 14 44" src="https://github.com/user-attachments/assets/ff19db58-d15e-43c5-8696-203432b2c04c" />


## After the fix


<img width="638" height="446" alt="Screenshot 2026-07-17 at 23 09 55" src="https://github.com/user-attachments/assets/7a04aa47-b4be-4c93-86c5-a023ea3d888f" />



### Summary 
`context.mjs --target` now resolves nested `PRODUCT.md` / `DESIGN.md` in ordinary Git repos (not just recognized monorepos).

## Test plan
Tested manually as well as with agents on my local test repos and test monorepos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core context path resolution used by the skill boot path; wrong roots would load the wrong product/design guidance, though behavior is heavily covered by new tests.
> 
> **Overview**
> **`context.mjs --target`** now picks the right **`PRODUCT.md` / `DESIGN.md`** when you point at a file inside a nested product in an ordinary repo (not only recognized monorepos), fixing #376.
> 
> For non-monorepos, **`projectRoot`** is set by walking from the target up toward the invocation cwd and taking the nearest directory that has context files (root, **`.agents/context/`**, or **`docs/`**). Root **`.agents/context`** and **`docs`** are not treated as nested products. **Repo-root context** is merged per file whenever the active project sits below the repo root—the same inheritance monorepo workspace children already had.
> 
> Tests cover nested canonical and fallback paths, root inheritance for missing nested files, targets with no nearby context, and adjusted expectations when workspace markers appear after the fact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3fedb816b6f6e5c9fe170df54f71c64a584762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->