### PR TITLE
fix(live-server): restrict CORS to loopback origins so /live.js no longer leaks the session token (#304)

### DIFF
--- a/.agents/skills/impeccable/scripts/live-server.mjs
+++ b/.agents/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.agents/skills/impeccable/scripts/live-server.mjs
+++ b/.agents/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.claude/skills/impeccable/scripts/live-server.mjs
+++ b/.claude/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.claude/skills/impeccable/scripts/live-server.mjs
+++ b/.claude/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.cursor/skills/impeccable/scripts/live-server.mjs
+++ b/.cursor/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.cursor/skills/impeccable/scripts/live-server.mjs
+++ b/.cursor/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.gemini/skills/impeccable/scripts/live-server.mjs
+++ b/.gemini/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.gemini/skills/impeccable/scripts/live-server.mjs
+++ b/.gemini/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.github/skills/impeccable/scripts/live-server.mjs
+++ b/.github/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.github/skills/impeccable/scripts/live-server.mjs
+++ b/.github/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.kiro/skills/impeccable/scripts/live-server.mjs
+++ b/.kiro/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.kiro/skills/impeccable/scripts/live-server.mjs
+++ b/.kiro/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.opencode/skills/impeccable/scripts/live-server.mjs
+++ b/.opencode/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.opencode/skills/impeccable/scripts/live-server.mjs
+++ b/.opencode/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.pi/skills/impeccable/scripts/live-server.mjs
+++ b/.pi/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.pi/skills/impeccable/scripts/live-server.mjs
+++ b/.pi/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.qoder/skills/impeccable/scripts/live-server.mjs
+++ b/.qoder/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.qoder/skills/impeccable/scripts/live-server.mjs
+++ b/.qoder/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.rovodev/skills/impeccable/scripts/live-server.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.rovodev/skills/impeccable/scripts/live-server.mjs
+++ b/.rovodev/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.trae-cn/skills/impeccable/scripts/live-server.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.trae-cn/skills/impeccable/scripts/live-server.mjs
+++ b/.trae-cn/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.trae/skills/impeccable/scripts/live-server.mjs
+++ b/.trae/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.trae/skills/impeccable/scripts/live-server.mjs
+++ b/.trae/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/.vibe/skills/impeccable/scripts/live-server.mjs
+++ b/.vibe/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/.vibe/skills/impeccable/scripts/live-server.mjs
+++ b/.vibe/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/plugin/skills/impeccable/scripts/live-server.mjs
+++ b/plugin/skills/impeccable/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/plugin/skills/impeccable/scripts/live-server.mjs
+++ b/plugin/skills/impeccable/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -85,6 +85,12 @@ async function findOpenPort(start = 8400) {
   });
 }
 
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+function isLoopbackOrigin(origin) {
+  return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -630,7 +636,16 @@ function statOrNull(filePath) {
 function createRequestHandler({ detectScript, liveScriptParts }) {
   return (req, res) => {
     const url = new URL(req.url, `http://localhost:${state.port}`);
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // Reflect only loopback origins. This server always binds 127.0.0.1, so
+    // the dev-server tab (a different loopback port) is the only legitimate
+    // cross-origin caller. A wildcard here let any page open in the same
+    // browser — including a malicious one probing local ports — fetch
+    // /live.js and read the bearer token embedded in its body.
+    const requestOrigin = req.headers.origin;
+    if (isLoopbackOrigin(requestOrigin)) {
+      res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }

--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -85,7 +85,10 @@ async function findOpenPort(start = 8400) {
   });
 }
 
-const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+// Loopback origins only. The whole 127.0.0.0/8 block is loopback (not just
+// 127.0.0.1), so a dev page on e.g. 127.0.0.2 is still same-machine and must
+// be allowed; localhost and the IPv6 loopback [::1] round out the set.
+const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(:\d+)?$/i;
 
 function isLoopbackOrigin(origin) {
   return typeof origin === 'string' && LOOPBACK_ORIGIN_RE.test(origin);

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -302,6 +302,29 @@ describe('live-server integration', () => {
     );
   });
 
+  it('/live.js does not reflect a wildcard or non-loopback CORS origin (regression for #304 token leak)', async () => {
+    const evil = await fetch(`http://localhost:${server.port}/live.js`, {
+      headers: { Origin: 'https://evil.example.com' },
+    });
+    assert.equal(evil.status, 200);
+    assert.equal(
+      evil.headers.get('access-control-allow-origin'),
+      null,
+      'a non-loopback Origin must not be granted read access to the token-bearing response',
+    );
+
+    const loopback = await fetch(`http://localhost:${server.port}/live.js`, {
+      headers: { Origin: 'http://localhost:5173' },
+    });
+    assert.equal(evil.status, 200);
+    assert.equal(
+      loopback.headers.get('access-control-allow-origin'),
+      'http://localhost:5173',
+      'a loopback dev-server origin should be reflected exactly, never as a wildcard',
+    );
+    assert.equal(loopback.headers.get('vary'), 'Origin');
+  });
+
   it('/design-system.json reads DESIGN.md plus .impeccable/design.json', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'impeccable-design-system-'));
     let designServer;

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -316,13 +316,24 @@ describe('live-server integration', () => {
     const loopback = await fetch(`http://localhost:${server.port}/live.js`, {
       headers: { Origin: 'http://localhost:5173' },
     });
-    assert.equal(evil.status, 200);
+    assert.equal(loopback.status, 200);
     assert.equal(
       loopback.headers.get('access-control-allow-origin'),
       'http://localhost:5173',
       'a loopback dev-server origin should be reflected exactly, never as a wildcard',
     );
     assert.equal(loopback.headers.get('vary'), 'Origin');
+
+    // The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1.
+    const altLoopback = await fetch(`http://localhost:${server.port}/live.js`, {
+      headers: { Origin: 'http://127.0.0.2:5173' },
+    });
+    assert.equal(altLoopback.status, 200);
+    assert.equal(
+      altLoopback.headers.get('access-control-allow-origin'),
+      'http://127.0.0.2:5173',
+      'any 127.0.0.0/8 loopback origin should be reflected, not only 127.0.0.1',
+    );
   });
 
   it('/design-system.json reads DESIGN.md plus .impeccable/design.json', async () => {


### PR DESCRIPTION
Fixes #304.

## Problem

`live-server.mjs` embeds the session bearer token in the body of `/live.js`, but served every response with `Access-Control-Allow-Origin: *`. During an active live session, any page open in the same browser could `fetch('http://localhost:<port>/live.js')` cross-origin, read the token out of the response, and then drive the token-protected endpoints (`/events`, `/poll`, `/source`, `/annotation`, `/status`, ...).

As @abdulwahabone noted on the issue, the blast radius is bounded — it only bites during a live session and only if a malicious tab is open in the same browser and probes the port — so this is more P3 than P1. It's still a real token disclosure with a small, self-contained fix.

## Fix

Reflect the request `Origin` **only when it is loopback** (`localhost` / `127.0.0.1` / `[::1]`, any port) and add `Vary: Origin`. The server always binds `127.0.0.1`, so the dev-server tab on another loopback port is the only legitimate cross-origin caller; it keeps working. A non-loopback page now receives no `Access-Control-Allow-Origin` header at all, so the browser blocks it from reading the token-bearing response.

```js
const requestOrigin = req.headers.origin;
if (isLoopbackOrigin(requestOrigin)) {
  res.setHeader('Access-Control-Allow-Origin', requestOrigin);
  res.setHeader('Vary', 'Origin');
}
```

This is a deliberately minimal change (no handshake/bootstrap rework) — it maps to fix option 3 in the issue.

## Tests

Adds a regression test in `tests/live-server.test.mjs`:
- a non-loopback `Origin` (`https://evil.example.com`) receives **no** `Access-Control-Allow-Origin` header;
- a loopback origin (`http://localhost:5173`) is reflected **exactly** (never `*`) with `Vary: Origin`.

## Notes for reviewers

The edit was made to the canonical source `skill/scripts/live-server.mjs` and propagated to all 14 generated per-provider copies so the tree stays consistent — hence the wide-but-identical diff. Happy to adjust the loopback matcher or split the generated-copy sync if you'd prefer it handled by the build step instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix on local auth token exposure; behavior change may break non-loopback cross-origin dev setups, but intended scope is loopback-only callers.
> 
> **Overview**
> **Tightens CORS on the live dev server** so cross-origin pages in the same browser can no longer read `/live.js`, which embeds the session bearer token.
> 
> Instead of `Access-Control-Allow-Origin: *`, responses now set `Access-Control-Allow-Origin` only when the request `Origin` matches loopback (`localhost`, any `127.*` address, or `[::1]`), with `Vary: Origin`. Legitimate dev-server tabs on another local port keep working; remote or arbitrary origins get no CORS header and cannot read the script body.
> 
> The same change is applied across all mirrored `live-server.mjs` skill bundles. **`tests/live-server.test.mjs`** adds a regression test for evil vs loopback origins (including `127.0.0.2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0814df7a94d5927ed15d32884ac309fdbda0d608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->