### PR TITLE
fix(detect): add --url for Windows cmd ampersand-safe scans (#403)

### DIFF
--- a/cli/bin/cli.js
+++ b/cli/bin/cli.js
@@ -37,6 +37,7 @@ async function main() {
 
 Commands:
   detect [file-or-dir-or-url...]   Scan for UI anti-patterns and design quality issues
+                                  On Windows cmd.exe prefer: detect --url "https://...?a=1&b=2"
   ignores                          Manage detector ignore rules, files, and values
   help                             List all available skills and commands
   install                          Install impeccable skills into your project or global harness

--- a/cli/engine/cli/main.mjs
+++ b/cli/engine/cli/main.mjs
@@ -186,8 +186,14 @@ Examples:
   impeccable detect src/
   impeccable detect index.html
   impeccable detect https://example.com
+  impeccable detect --url "https://example.com?foo=1&bar=2"
   impeccable detect --json .
-  impeccable detect --no-config src/`);
+  impeccable detect --no-config src/
+
+Windows cmd.exe note:
+  Bare URLs with & are command separators. Prefer --url with quotes, or use
+  PowerShell / Git Bash. Example:
+    impeccable detect --url "https://example.com?foo=1&bar=2"`);
 }
 
 async function detectCli() {
@@ -214,6 +220,23 @@ async function detectCli() {
     process.stderr.write(
       'Note: --gpt and --gemini are deprecated and ignored. Generated-UI tells now run by default.\n',
     );
+  }
+  // --url <url> keeps query strings with & out of bare argv. On Windows cmd.exe,
+  // unquoted & is a command separator, so prefer: detect --url "https://...?a=1&b=2"
+  const urlFlagTargets = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== '--url' && !args[i].startsWith('--url=')) continue;
+    const inline = args[i].startsWith('--url=');
+    const value = inline ? args[i].slice('--url='.length) : args[i + 1];
+    if (!value || value.startsWith('--')) {
+      process.stderr.write(
+        'Error: --url requires a URL value. On Windows cmd.exe quote it, e.g. --url "https://example.com?a=1&b=2"\n',
+      );
+      process.exit(1);
+    }
+    urlFlagTargets.push(value);
+    args.splice(i, inline ? 1 : 2);
+    i -= 1;
   }
   const configEnabled = !args.includes('--no-config');
   const detectionConfig = configEnabled
@@ -278,7 +301,7 @@ async function detectCli() {
     const designSystem = loadDesignSystemForTarget(localPath, { cache: designSystemCache });
     return designSystem ? { ...baseScanOptions, designSystem } : baseScanOptions;
   };
-  const targets = args.filter(a => !a.startsWith('--'));
+  const targets = [...urlFlagTargets, ...args.filter(a => !a.startsWith('--'))];
 
   if (helpMode) { printUsage(); process.exit(0); }
 

--- a/cli/engine/cli/main.mjs
+++ b/cli/engine/cli/main.mjs
@@ -227,8 +227,10 @@ async function detectCli() {
   }
   // --url <url> keeps query strings with & out of bare argv. On Windows cmd.exe,
   // unquoted & is a command separator, so prefer: detect --url "https://...?a=1&b=2"
+  // Help mode never reaches the scan, so a bare `--url` must not exit with a
+  // parse error before the usage text gets a chance to print.
   const urlFlagTargets = [];
-  for (let i = 0; i < args.length; i++) {
+  for (let i = 0; !helpMode && i < args.length; i++) {
     if (args[i] !== '--url' && !args[i].startsWith('--url=')) continue;
     const inline = args[i].startsWith('--url=');
     const value = inline ? args[i].slice('--url='.length) : args[i + 1];

--- a/cli/engine/cli/main.mjs
+++ b/cli/engine/cli/main.mjs
@@ -147,6 +147,8 @@ Scan files or URLs for UI anti-patterns and design quality issues.
 Options:
   --json              Output results as JSON
   --quiet             In text mode, only print the final findings count
+  --url <value>       Scan a URL passed as its own argument, keeping query
+                      string & out of bare argv. Also accepts --url=<value>.
   --scope <name>      Only report rules in the given design domain
                       (type, layout). Comma-separated.
   --viewport <WxH>    Browser viewport for URL scans (default 1280x800),
@@ -187,13 +189,15 @@ Examples:
   impeccable detect index.html
   impeccable detect https://example.com
   impeccable detect --url "https://example.com?foo=1&bar=2"
+  impeccable detect --url="https://example.com?foo=1&bar=2"
   impeccable detect --json .
   impeccable detect --no-config src/
 
 Windows cmd.exe note:
   Bare URLs with & are command separators. Prefer --url with quotes, or use
   PowerShell / Git Bash. Example:
-    impeccable detect --url "https://example.com?foo=1&bar=2"`);
+    impeccable detect --url "https://example.com?foo=1&bar=2"
+    impeccable detect --url="https://example.com?foo=1&bar=2"`);
 }
 
 async function detectCli() {

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -1849,8 +1849,27 @@ describe('CLI', () => {
     expect(code).toBe(0);
     expect(stdout).toContain('Usage:');
     expect(stdout).toContain('--quiet');
+    expect(stdout).toContain('--url');
+    expect(stdout).toContain('Windows cmd.exe');
     expect(stdout).not.toContain('--gpt');
     expect(stdout).not.toContain('--gemini');
+  });
+
+  test('--url accepts a URL with query string ampersands', () => {
+    const { stderr, code } = run('--url');
+    expect(code).toBe(1);
+    expect(stderr).toContain('--url requires a URL value');
+  });
+
+  test('--url= form is accepted as a detect target alongside files', () => {
+    const file = path.join(FIXTURES, 'jsx-should-pass.jsx');
+    // --url of a non-http path is still treated as a target string; use a
+    // real local file via --url to prove the flag is consumed (not left in argv).
+    const { code, stderr } = run('--url', file);
+    // Local path via --url still goes through URL regex fail then path resolve.
+    // file path does not match urlRe, so it is scanned as a filesystem target.
+    expect([0, 2]).toContain(code);
+    expect(stderr).not.toContain('--url requires a URL value');
   });
 
   test('generated-UI tells run by default in the CLI', () => {

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -1850,15 +1850,41 @@ describe('CLI', () => {
     expect(stdout).toContain('Usage:');
     expect(stdout).toContain('--quiet');
     expect(stdout).toContain('--url');
+    expect(stdout).toContain('--url=<value>');
     expect(stdout).toContain('Windows cmd.exe');
     expect(stdout).not.toContain('--gpt');
     expect(stdout).not.toContain('--gemini');
   });
 
-  test('--url accepts a URL with query string ampersands', () => {
+  test('--url with no value errors instead of silently scanning cwd', () => {
     const { stderr, code } = run('--url');
     expect(code).toBe(1);
     expect(stderr).toContain('--url requires a URL value');
+  });
+
+  // The next two tests scan an unresolvable host so they fail fast (DNS
+  // rejection, no real navigation) while still exercising the real argv ->
+  // detectUrl() path. The assertion is on the *exact* URL string puppeteer
+  // was asked to navigate to, echoed back in the error message, which is
+  // the only reliable way to prove the value (including the query string's
+  // `&`) survived argument parsing intact rather than being split or
+  // truncated.
+  const UNRESOLVABLE_URL = 'https://impeccable-test-host-does-not-exist-zzz.invalid/x?a=1&b=2';
+
+  test('--url space-separated form preserves a query string with &', () => {
+    const { stdout, stderr, code } = run('--url', UNRESOLVABLE_URL, '--json');
+    expect(code).toBe(0);
+    expect(stderr).not.toContain('--url requires a URL value');
+    expect(stderr).toContain(`Error: net::ERR_NAME_NOT_RESOLVED at ${UNRESOLVABLE_URL}`);
+    expect(JSON.parse(stdout)).toEqual([]);
+  });
+
+  test('--url=<value> inline form preserves a query string with &', () => {
+    const { stdout, stderr, code } = run(`--url=${UNRESOLVABLE_URL}`, '--json');
+    expect(code).toBe(0);
+    expect(stderr).not.toContain('--url requires a URL value');
+    expect(stderr).toContain(`Error: net::ERR_NAME_NOT_RESOLVED at ${UNRESOLVABLE_URL}`);
+    expect(JSON.parse(stdout)).toEqual([]);
   });
 
   test('--url= form is accepted as a detect target alongside files', () => {

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -1862,6 +1862,13 @@ describe('CLI', () => {
     expect(stderr).toContain('--url requires a URL value');
   });
 
+  test('--help still prints usage when a bare --url is also present', () => {
+    const { stdout, stderr, code } = run('--help', '--url');
+    expect(code).toBe(0);
+    expect(stdout).toContain('Usage:');
+    expect(stderr).not.toContain('--url requires a URL value');
+  });
+
   // The next two tests scan an unresolvable host so they fail fast (DNS
   // rejection, no real navigation) while still exercising the real argv ->
   // detectUrl() path. The assertion is on the *exact* URL string puppeteer
@@ -1871,7 +1878,19 @@ describe('CLI', () => {
   // truncated.
   const UNRESOLVABLE_URL = 'https://impeccable-test-host-does-not-exist-zzz.invalid/x?a=1&b=2';
 
-  test('--url space-separated form preserves a query string with &', () => {
+  // Reading the URL back out of the DNS error needs a browser that actually
+  // starts. puppeteer is an optionalDependency, and even when installed the
+  // bundled Chromium refuses to launch as root without --no-sandbox, so both
+  // gaps are ordinary on a contributor machine and in a container. Skip
+  // loudly instead of softening the assertion: these two tests exist to prove
+  // the `&` survived argument parsing, and a variant that quietly stopped
+  // checking that would be a test whose name outruns what it verifies.
+  const browserProbeStderr = run('--url', UNRESOLVABLE_URL, '--json').stderr;
+  const noBrowser = /puppeteer is required for URL scanning|Failed to launch the browser/.test(
+    browserProbeStderr,
+  );
+
+  test.skipIf(noBrowser)('--url space-separated form preserves a query string with &', () => {
     const { stdout, stderr, code } = run('--url', UNRESOLVABLE_URL, '--json');
     expect(code).toBe(0);
     expect(stderr).not.toContain('--url requires a URL value');
@@ -1879,12 +1898,28 @@ describe('CLI', () => {
     expect(JSON.parse(stdout)).toEqual([]);
   });
 
-  test('--url=<value> inline form preserves a query string with &', () => {
+  test.skipIf(noBrowser)('--url=<value> inline form preserves a query string with &', () => {
     const { stdout, stderr, code } = run(`--url=${UNRESOLVABLE_URL}`, '--json');
     expect(code).toBe(0);
     expect(stderr).not.toContain('--url requires a URL value');
     expect(stderr).toContain(`Error: net::ERR_NAME_NOT_RESOLVED at ${UNRESOLVABLE_URL}`);
     expect(JSON.parse(stdout)).toEqual([]);
+  });
+
+  // Browser-free half of the same guarantee, so a machine without Chromium
+  // still catches the parsing regressions this flag was added to prevent:
+  // both the flag and its value must leave argv, or a stray `--url` reaches
+  // the scanner or the URL gets scanned twice.
+  test('--url consumes both the flag and its value in either form', () => {
+    for (const argv of [
+      ['--url', UNRESOLVABLE_URL, '--json'],
+      [`--url=${UNRESOLVABLE_URL}`, '--json'],
+    ]) {
+      const { stdout, stderr, code } = run(...argv);
+      expect(code).toBe(0);
+      expect(stderr).not.toContain('--url requires a URL value');
+      expect(JSON.parse(stdout)).toEqual([]);
+    }
   });
 
   test('--url= form is accepted as a detect target alongside files', () => {


### PR DESCRIPTION
## Before opening

This repo is issue-first for outside contributions. If you are not `pbakaus` or `abdulwahabone`, please link the issue where a maintainer approved or requested this PR. Unsolicited PRs may be closed without review.

- Linked issue: https://github.com/pbakaus/impeccable/issues/403
- Contributor status:
  - [ ] I am `pbakaus` or `abdulwahabone`
  - [ ] A maintainer approved this PR in the linked issue

Note: #403 is a filed Windows bug with a concrete repro and suggested mitigations (`--url` / docs). Happy to close or reshape if you want discussion first.

## Summary

Fixes #403. On Windows `cmd.exe`, bare `&` in a URL is a command separator, and the npm `.cmd` shim does not reliably preserve quoting via `%*`. This adds `detect --url <url>` / `--url=` so query strings can be passed as a flag value, and documents the cmd.exe quoting caveat in `--help`.

## Type of change

- [x] Bug fix

## Checklist

- [ ] Source files updated in `source/` (CLI-only change under `cli/`)
- [ ] `bun run build` ran successfully (not required for this CLI path)
- [x] Targeted tests pass (`bun test tests/detect-antipatterns.test.js -t --help|--url`)
- [ ] Tested with at least one provider
- [ ] README / DEVELOP.md updated if needed (help text covers the caveat)
- [x] I reviewed the full diff myself before requesting human review
- [x] I disclosed any AI assistance in this PR and related commits/comments, or no AI assistance was used

## Evidence

```text
$ bun test tests/detect-antipatterns.test.js -t --help|--url
(pass) CLI > --help exits 0
(pass) CLI > --url accepts a URL with query string ampersands
(pass) CLI > --url= form is accepted as a detect target alongside files
3 pass
0 fail
```

## AI assistance

Assisted by Cursor/Grok. Human author: Stan Shih (@stantheman0128).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only argument parsing and help text; no changes to detection engines or security-sensitive paths.
> 
> **Overview**
> Fixes **Windows `cmd.exe`** breaking bare URLs when query strings contain **`&`**, by letting users pass the scan target via **`detect --url`** / **`--url=`** instead of a positional argument.
> 
> The detect CLI **parses and removes** `--url` values into the scan target list (supports space-separated and inline forms), **errors** if the flag has no value (except when **`--help`** is also present), and **documents** the cmd.exe quoting caveat in top-level help, `detect --help`, and examples.
> 
> **Tests** cover help text, missing-value behavior, argv consumption without a browser, optional Puppeteer checks that the full URL (including `&`) reaches navigation, and local paths passed through `--url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7777b4dc11974c791429cfed7e3f72b919c89b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->