### PR TITLE
Live mode: clear the durable session checkpoint on a terminal SSE error reply

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6499,6 +6499,19 @@
           if (maybeCompleteSteer(msg)) break;
           console.error('[impeccable] Error:', msg.message);
           showToast('Error: ' + msg.message, 5000);
+          // An agent error reply is terminal for the session it names: tear
+          // it down exactly like 'discarded' (cleanup includes clearSession),
+          // or the durable localStorage checkpoint survives and every reload
+          // resurrects a GENERATING bar for a session the server no longer
+          // knows about (issue #362).
+          if (msg.id && msg.id === currentSessionId) {
+            markSessionHandled();
+            cleanup();
+            break;
+          }
+          // A stored-but-not-current checkpoint naming the errored session
+          // (the error raced a reload) must not resurrect either.
+          if (msg.id && loadSession()?.id === msg.id) clearSession();
           hideBar();
           renderEditBadge('hidden');
           setLiveState('PICKING');

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -273,6 +273,31 @@ describe('live-browser.js regression guards', () => {
     );
   });
 
+  it('SSE error reply clears the durable session checkpoint like discarded', () => {
+    // Issue #362: `live-poll.mjs --reply <id> error "..."` is the documented
+    // abort flow in reference/live.md, and an agent error reply is terminal
+    // for the session it names. The 'error' case used to reset only the UI
+    // (hideBar + PICKING) while the localStorage checkpoint written for the
+    // GENERATING phase survived — so every reload resurrected a dead session
+    // the server no longer knew about, until the user hand-cleared the
+    // impeccable-live* keys in the console. The error path must tear down the
+    // named session exactly like 'discarded' does (markSessionHandled +
+    // cleanup, which includes clearSession), and drop a stored-but-not-
+    // current checkpoint that matches the errored id.
+    const errorCase = SOURCE.match(/case 'error':[\s\S]{0,2500}?setLiveState\('PICKING'\);\s*break;/);
+    assert.ok(errorCase, 'expected an SSE case \'error\' handler in live-browser.js');
+    assert.match(
+      errorCase[0],
+      /if \(msg\.id && msg\.id === currentSessionId\) \{[\s\S]{0,160}?markSessionHandled\(\);[\s\S]{0,80}?cleanup\(\);[\s\S]{0,80}?break;/,
+      'an error reply naming the current session must run the same markSessionHandled + cleanup teardown as \'discarded\' so the durable checkpoint is cleared',
+    );
+    assert.match(
+      errorCase[0],
+      /if \(msg\.id && loadSession\(\)\?\.id === msg\.id\) clearSession\(\);/,
+      'an error reply naming a stored-but-not-current session must drop that checkpoint so a reload cannot resurrect it',
+    );
+  });
+
   it('handleServerLost preserves the current recoverable phase', () => {
     assert.doesNotMatch(
       SOURCE,


### PR DESCRIPTION
Fixes #362 — with credit to @yourcodekitten for the precise diagnosis and proposed patch in the issue.

## The bug

`live-poll.mjs --reply <id> error "..."` — the documented abort flow in `reference/live.md` — reset the live bar to PICKING but never cleared the durable `impeccable-live-session` checkpoint in localStorage. On every reload, `resumeSession` restored a `GENERATING` bar for a session `live-status.mjs` confirmed no longer existed, and the page stayed wedged until the `impeccable-live*` keys were cleared by hand.

## The fix

The `'error'` SSE case now treats an agent error reply as terminal for the session it names, mirroring what `'discarded'` already does:

- `msg.id === currentSessionId` → `markSessionHandled()` + `cleanup()` (which includes `clearSession()`)
- `msg.id` matches a stored-but-not-current checkpoint (the error raced a reload) → `clearSession()`
- errors naming no session keep the existing UI-only reset; the accept-cleanup and steer branches are untouched

This is essentially the patch the reporter validated locally over a day of heavy live-mode use, with the same shape.

## Tests

New guard in `tests/live-browser-regression.test.mjs` (the established test style for the self-contained IIFE): extracts the `case 'error':` block and asserts both the current-session teardown and the stored-checkpoint drop. Written failing-first on main. `bun run test` and `bun run build` fully green.

## AI disclosure

Prepared with AI assistance (Claude Code), directed by @pbakaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted live-browser SSE error handling and a source-structure regression test; no auth, data, or server API changes.
> 
> **Overview**
> Fixes **#362**: when live mode receives a terminal agent **error** SSE reply (`live-poll.mjs --reply <id> error`), the UI used to return to PICKING but left the **`impeccable-live-session`** checkpoint in localStorage, so reloads kept restoring a **GENERATING** bar for a session the server had already ended.
> 
> The **`case 'error':`** handler now treats a named session like **`discarded`**: if **`msg.id === currentSessionId`**, it runs **`markSessionHandled()`** and **`cleanup()`** (including **`clearSession()`**); if the id only matches a stored checkpoint (error raced a reload), it calls **`clearSession()`**. Unscoped errors still only reset the bar; accept-cleanup and steer paths are unchanged.
> 
> A regression test in **`tests/live-browser-regression.test.mjs`** locks in both teardown branches on the extracted error handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d058e744dd38ef029ed65b2f074401fa65b94d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->