### PR TITLE
Refresh stale metric and library references in command docs

### DIFF
--- a/skill/reference/audit.md
+++ b/skill/reference/audit.md
@@ -27,7 +27,7 @@ Run comprehensive checks across 5 dimensions. Score each dimension 0-4 using the
 - **Layout thrashing**: Reading/writing layout properties in loops
 - **Expensive animations**: Casual layout-property animation, unbounded blur/filter/shadow effects, or effects that visibly drop frames
 - **Missing optimization**: Images without lazy loading, unoptimized assets
-- **will-change overuse**: `will-change` applied broadly or left on at rest (it is a targeted hint for known expensive animations, not a baseline requirement; see optimize.md)
+- **will-change overuse**: `will-change` applied broadly or left on at rest (it is a targeted hint for known expensive animations, not a baseline requirement)
 - **Bundle size**: Unnecessary imports, unused dependencies
 - **Render performance**: Unnecessary re-renders, missing memoization
 

--- a/skill/reference/audit.md
+++ b/skill/reference/audit.md
@@ -26,7 +26,8 @@ Run comprehensive checks across 5 dimensions. Score each dimension 0-4 using the
 **Check for**:
 - **Layout thrashing**: Reading/writing layout properties in loops
 - **Expensive animations**: Casual layout-property animation, unbounded blur/filter/shadow effects, or effects that visibly drop frames
-- **Missing optimization**: Images without lazy loading, unoptimized assets, missing will-change
+- **Missing optimization**: Images without lazy loading, unoptimized assets
+- **will-change overuse**: `will-change` applied broadly or left on at rest (it is a targeted hint for known expensive animations, not a baseline requirement; see optimize.md)
 - **Bundle size**: Unnecessary imports, unused dependencies
 - **Render performance**: Unnecessary re-renders, missing memoization
 

--- a/skill/reference/harden.md
+++ b/skill/reference/harden.md
@@ -78,7 +78,7 @@ Systematically improve resilience:
 
 **Responsive text sizing**:
 - Use `clamp()` for fluid typography
-- Set minimum readable sizes (14px on mobile)
+- Set minimum readable sizes (16px body on mobile, matching typeset.md's floor; 14px only for genuinely secondary text. iOS Safari force-zooms focused inputs under 16px, which breaks form layouts)
 - Test text scaling (zoom to 200%)
 - Ensure containers expand with text
 

--- a/skill/reference/harden.md
+++ b/skill/reference/harden.md
@@ -78,7 +78,7 @@ Systematically improve resilience:
 
 **Responsive text sizing**:
 - Use `clamp()` for fluid typography
-- Set minimum readable sizes (16px body on mobile, matching typeset.md's floor; 14px only for genuinely secondary text. iOS Safari force-zooms focused inputs under 16px, which breaks form layouts)
+- Set minimum readable sizes (16px body on mobile, the same floor the typography guidance sets; 14px only for genuinely secondary text. iOS Safari force-zooms focused inputs under 16px, which breaks form layouts)
 - Test text scaling (zoom to 200%)
 - Ensure containers expand with text
 

--- a/skill/reference/optimize.md
+++ b/skill/reference/optimize.md
@@ -5,7 +5,7 @@ Performance is a feature. Identify the actual bottleneck for THIS interface, fix
 Understand current performance and identify problems:
 
 1. **Measure current state**:
-   - **Core Web Vitals**: LCP, FID/INP, CLS scores
+   - **Core Web Vitals**: LCP, INP, CLS scores
    - **Load time**: Time to interactive, first contentful paint
    - **Bundle size**: JavaScript, CSS, image sizes
    - **Runtime performance**: Frame rate, memory usage, CPU usage
@@ -106,7 +106,7 @@ elements.forEach((el, i) => {
 - Minimize DOM depth (flatter is faster)
 - Reduce DOM size (fewer elements)
 - Use `content-visibility: auto` for long lists
-- Virtual scrolling for very long lists (react-window, react-virtualized)
+- Virtual scrolling for very long lists (react-window, TanStack Virtual)
 
 **Reduce Paint & Composite**:
 - Use `transform` and `opacity` for reliable movement, but allow blur, filters, masks, clip paths, shadows, and color shifts when they create meaningful polish
@@ -196,7 +196,7 @@ const observer = new IntersectionObserver((entries) => {
 - Use CDN
 - Server-side rendering
 
-### First Input Delay (FID < 100ms) / INP (< 200ms)
+### Interaction to Next Paint (INP < 200ms)
 - Break up long tasks
 - Defer non-critical JavaScript
 - Use web workers for heavy computation
@@ -226,7 +226,7 @@ const observer = new IntersectionObserver((entries) => {
 - Performance monitoring (Sentry, DataDog, New Relic)
 
 **Key metrics**:
-- LCP, FID/INP, CLS (Core Web Vitals)
+- LCP, INP, CLS (Core Web Vitals; INP replaced FID in March 2024)
 - Time to Interactive (TTI)
 - First Contentful Paint (FCP)
 - Total Blocking Time (TBT)

--- a/skill/reference/overdrive.md
+++ b/skill/reference/overdrive.md
@@ -57,7 +57,7 @@ Organized by what you're trying to achieve, not by technology name.
 
 ### Render beyond CSS
 - **WebGL** (all browsers): shader effects, post-processing, particle systems. Libraries: Three.js, OGL (lightweight), regl. Use for effects CSS can't express.
-- **WebGPU** (Chrome/Edge; Safari partial; Firefox: flag only): next-gen GPU compute. More powerful than WebGL but limited browser support. Always fall back to WebGL2.
+- **WebGPU** (Chrome/Edge; Safari 26+; Firefox on Windows/macOS; flag only on Firefox Linux/Android): next-gen GPU compute, more powerful than WebGL. Always fall back to WebGL2.
 - **Canvas 2D / OffscreenCanvas**: custom rendering, pixel manipulation, or moving heavy rendering off the main thread entirely via Web Workers + OffscreenCanvas.
 - **SVG filter chains**: displacement maps, turbulence, morphology for organic distortion effects. CSS-animatable.
 


### PR DESCRIPTION
Addresses what remains of #395 on current main.

## Still stale, now fixed

| Where | Was | Now |
|---|---|---|
| `optimize.md` section heading + both metric lists | Led with FID, retired as a Core Web Vital 2024-03-12 | INP leads; one list notes the replacement date |
| `optimize.md` virtual scrolling | `react-window, react-virtualized` (superseded) | `react-window, TanStack Virtual` (agrees with overdrive.md) |
| `overdrive.md` WebGPU matrix | "Safari partial; Firefox: flag only" | Safari 26+, Firefox on Windows/macOS; flag only on Firefox Linux/Android |
| `audit.md` performance checklist | "missing will-change" as a defect, while animate.md and optimize.md both say apply it sparingly and never preemptively | Flags will-change **overuse** instead of absence |
| `harden.md` readable sizes | 14px mobile floor, contradicting typeset.md's 16px ordinary floor | 16px floor matching typeset.md, 14px reserved for secondary text, with the iOS Safari input-zoom rationale |

## Already resolved before this PR

The issue's items 2 (Framer Motion naming), 4 (Popmotion), 6-partial (polish.md's 14px line), 8 (humor in errors), 9 (quieter's HSL saturation phrasing), and 10 (polish duration cap) no longer exist on main; the v4 reference consolidation removed or rewrote those passages. Item 5's neighboring scroll-driven-animation line is still accurate and was left alone, as the issue itself suggested.

No behavior change and no test surface; validation is the build's two prose gates plus the count validators, all green (`bun run build && bun run test`).

## AI disclosure

Prepared with AI assistance (Claude Code), directed by @pbakaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only edits to reference markdown; no application code, APIs, or security-sensitive paths.
> 
> **Overview**
> Updates **skill reference docs** so performance and platform guidance matches current web standards and stays consistent across commands—no runtime or test behavior changes.
> 
> **`optimize.md`** now treats **INP** (not retired **FID**) as the interaction Core Web Vital in measurement lists, section headings, and monitoring notes; virtual scrolling examples point to **TanStack Virtual** alongside `react-window`.
> 
> **`audit.md`** no longer flags missing `will-change` as a defect; it instead calls out **`will-change` overuse**, aligning with sparing-use guidance in `animate.md` / `optimize.md`.
> 
> **`harden.md`** raises the mobile readable text floor to **16px** for body copy (14px only for secondary text) and documents the **iOS Safari input zoom** issue under 16px.
> 
> **`overdrive.md`** refreshes the **WebGPU** browser support matrix (Safari 26+, Firefox on Windows/macOS, flags on Firefox Linux/Android).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d2ffe9007733b1c3854780bc2f262014568d2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->