### PR TITLE
Live mode: recognize a late accept failure after the optimistic teardown

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6490,10 +6490,12 @@
           // The deterministic accept has already committed the reviewed DOM
           // and fenced generation. Carbonize may continue in the background;
           // it must not hold the foreground picker hostage.
-          // Any agent_done naming the awaited id post-accept is accept-side
-          // work reporting back (accept ack or carbonize), so the awaited
-          // failure window closes here too.
-          if (awaitingAcceptResult?.id && msg.id === awaitingAcceptResult.id) awaitingAcceptResult = null;
+          // Only a carbonize agent_done is provably accept-side: accept
+          // unlocks at the first variant, so a late generation agent_done
+          // for the same session id can still arrive after Accept and must
+          // not close the awaited failure window early (the SSE broadcast
+          // carries no sourceEventType to tell the two apart).
+          if (msg.data?.carbonize === true && awaitingAcceptResult?.id && msg.id === awaitingAcceptResult.id) awaitingAcceptResult = null;
           if (msg.data?.carbonize === true && maybeCompleteAcceptedSession(msg)) break;
           break;
         case 'discarded':
@@ -6518,7 +6520,12 @@
           if (awaitingAcceptResult?.id && msg.id === awaitingAcceptResult.id) {
             awaitingAcceptResult = null;
             console.error('[impeccable] Accept failed after teardown:', msg.message);
-            showToast('Accept failed: ' + msg.message + ' The variant was not saved; pick the element and generate again.', 8000);
+            // Hedged on purpose: a carbonize-phase failure raises this same
+            // error after the source WAS promoted, so "was not saved" would
+            // overclaim. Normalize the server message's terminal punctuation
+            // so the two sentences don't run together.
+            const acceptFailDetail = String(msg.message || 'unknown error').trim().replace(/[.!?]?$/, '.');
+            showToast('Accept failed: ' + acceptFailDetail + ' The variant may not have been saved. If the change is missing, pick the element and generate again.', 8000);
             break;
           }
           if (maybeCompleteSteer(msg)) break;

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -175,6 +175,14 @@
   let pickedAnchorViewportTop = null;
   let pendingVariantAnchorRetryObserver = null;
   let pendingAcceptedSession = null;
+  // Survives cleanupAcceptedSession on purpose: the id of an accept whose
+  // POST was acknowledged (intent durable, epoch fenced) but whose actual
+  // source promotion hasn't reported back yet. Accept is optimistic, so the
+  // teardown nulls pendingAcceptedSession long before live-accept.mjs runs;
+  // this marker is what lets the SSE 'error' branch still recognize a late
+  // accept failure and say the variant was not saved (issue #384). Released
+  // when the real accept result arrives or a new session starts.
+  let awaitingAcceptResult = null;
   let variantObserver = null;
   let variantSelectionInFlight = false;
   let variantSelectionPromise = null;
@@ -6474,12 +6482,18 @@
           break;
         case 'complete':
         case 'accept':
+          // The real accept result arrived: the awaited failure window closed.
+          if (awaitingAcceptResult?.id && msg.id === awaitingAcceptResult.id) awaitingAcceptResult = null;
           if (maybeCompleteAcceptedSession(msg)) break;
           break;
         case 'agent_done':
           // The deterministic accept has already committed the reviewed DOM
           // and fenced generation. Carbonize may continue in the background;
           // it must not hold the foreground picker hostage.
+          // Any agent_done naming the awaited id post-accept is accept-side
+          // work reporting back (accept ack or carbonize), so the awaited
+          // failure window closes here too.
+          if (awaitingAcceptResult?.id && msg.id === awaitingAcceptResult.id) awaitingAcceptResult = null;
           if (msg.data?.carbonize === true && maybeCompleteAcceptedSession(msg)) break;
           break;
         case 'discarded':
@@ -6491,9 +6505,20 @@
         case 'error':
           if (pendingAcceptedSession?.id && msg.id === pendingAcceptedSession.id) {
             pendingAcceptedSession = null;
+            awaitingAcceptResult = null;
             setLiveState('CYCLING');
             updateBarContent('cycling');
             showToast('Could not complete accept cleanup. Try Accept again.', 5000);
+            break;
+          }
+          // The optimistic teardown already released the session, so the
+          // CYCLING recovery above can no longer match; without this branch
+          // the failure fell through to the generic toast and the user had
+          // no hint their variant was never written (issue #384).
+          if (awaitingAcceptResult?.id && msg.id === awaitingAcceptResult.id) {
+            awaitingAcceptResult = null;
+            console.error('[impeccable] Accept failed after teardown:', msg.message);
+            showToast('Accept failed: ' + msg.message + ' The variant was not saved; pick the element and generate again.', 8000);
             break;
           }
           if (maybeCompleteSteer(msg)) break;
@@ -6958,6 +6983,9 @@
     stripManualEditRuntimeState(selectedElement);
 
     pendingAcceptedSession = null;
+    // A new session supersedes any accept still awaiting its result; a late
+    // failure toast for the previous session would only mislead here.
+    awaitingAcceptResult = null;
     currentSessionId = id8();
     expectedVariants = selectedCount;
     arrivedVariants = 0;
@@ -7037,6 +7065,9 @@
 
     stopVoice({ suppressSubmit: true });
     pendingAcceptedSession = null;
+    // A new session supersedes any accept still awaiting its result; a late
+    // failure toast for the previous session would only mislead here.
+    awaitingAcceptResult = null;
     currentSessionId = id8();
     expectedVariants = selectedCount;
     arrivedVariants = 0;
@@ -7868,6 +7899,7 @@ void main() {
         markSessionHandled();
         setLiveState('CONFIRMED');
         document.documentElement.dataset.impeccableAcceptToPickingMs = String(Date.now() - acceptPayload.clientSentAt);
+        awaitingAcceptResult = { id: acceptedSessionId };
         scheduleAcceptCleanup(pending);
       })
       .catch(() => {

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -298,6 +298,38 @@ describe('live-browser.js regression guards', () => {
     );
   });
 
+  it('a late accept failure is recognized after the optimistic teardown (#384)', () => {
+    // Accept is optimistic: POST /events acknowledging the intent schedules
+    // cleanupAcceptedSession(), which nulls pendingAcceptedSession before
+    // live-accept.mjs has actually run. When the accept later fails (missing
+    // markers, preview error, receipt conflict, source_locked), the SSE
+    // 'error' guard keyed on pendingAcceptedSession could no longer match,
+    // so the user got only the generic error toast with no hint that their
+    // variant was never written. An awaitingAcceptResult id must be set on
+    // the optimistic success path, survive cleanupAcceptedSession, be
+    // matched in the 'error' case with an explicit not-saved message, and
+    // be released when the real accept result arrives.
+    assert.match(
+      SOURCE,
+      /awaitingAcceptResult = \{ id: acceptedSessionId \};[\s\S]{0,400}?scheduleAcceptCleanup\(pending\);/,
+      'the optimistic POST-success path must record awaitingAcceptResult before scheduling the teardown',
+    );
+    const errorCase = SOURCE.match(/case 'error':[\s\S]{0,2600}?setLiveState\('PICKING'\);\s*break;/);
+    assert.ok(errorCase, 'expected an SSE case \'error\' handler in live-browser.js');
+    assert.match(
+      errorCase[0],
+      /if \(awaitingAcceptResult\?\.id && msg\.id === awaitingAcceptResult\.id\) \{[\s\S]{0,400}?awaitingAcceptResult = null;[\s\S]{0,400}?not saved[\s\S]{0,200}?break;/,
+      'an error naming the awaited accept must clear the marker and tell the user the variant was not saved',
+    );
+    const cleanupFn = SOURCE.match(/function cleanupAcceptedSession\(\) \{[\s\S]{0,1200}?\n  \}/);
+    assert.ok(cleanupFn, 'expected cleanupAcceptedSession in live-browser.js');
+    assert.doesNotMatch(
+      cleanupFn[0],
+      /awaitingAcceptResult\s*=/,
+      'cleanupAcceptedSession must not clear awaitingAcceptResult - surviving the teardown is the point',
+    );
+  });
+
   it('handleServerLost preserves the current recoverable phase', () => {
     assert.doesNotMatch(
       SOURCE,

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -318,8 +318,18 @@ describe('live-browser.js regression guards', () => {
     assert.ok(errorCase, 'expected an SSE case \'error\' handler in live-browser.js');
     assert.match(
       errorCase[0],
-      /if \(awaitingAcceptResult\?\.id && msg\.id === awaitingAcceptResult\.id\) \{[\s\S]{0,400}?awaitingAcceptResult = null;[\s\S]{0,400}?not saved[\s\S]{0,200}?break;/,
-      'an error naming the awaited accept must clear the marker and tell the user the variant was not saved',
+      /if \(awaitingAcceptResult\?\.id && msg\.id === awaitingAcceptResult\.id\) \{[\s\S]{0,700}?awaitingAcceptResult = null;[\s\S]{0,700}?may not have been saved[\s\S]{0,300}?break;/,
+      'an error naming the awaited accept must clear the marker and warn that the variant may not have been saved (hedged: a carbonize-phase failure fires this after the source WAS promoted)',
+    );
+    // Accept unlocks at the first variant, so a late generation agent_done
+    // for the same session id can arrive after Accept; only a carbonize
+    // agent_done is provably accept-side and may close the window.
+    const agentDoneCase = SOURCE.match(/case 'agent_done':[\s\S]{0,1200}?break;/);
+    assert.ok(agentDoneCase, 'expected an SSE case \'agent_done\' handler in live-browser.js');
+    assert.match(
+      agentDoneCase[0],
+      /msg\.data\?\.carbonize === true && awaitingAcceptResult\?\.id && msg\.id === awaitingAcceptResult\.id/,
+      'agent_done must only release the awaited accept marker for carbonize completions, or a late generation agent_done reopens the #384 hole',
     );
     const cleanupFn = SOURCE.match(/function cleanupAcceptedSession\(\) \{[\s\S]{0,1200}?\n  \}/);
     assert.ok(cleanupFn, 'expected cleanupAcceptedSession in live-browser.js');

--- a/tests/live-browser-source.test.mjs
+++ b/tests/live-browser-source.test.mjs
@@ -320,7 +320,7 @@ describe('live-browser source contracts', () => {
     );
     assert.match(
       SOURCE,
-      /case 'complete':\s*case 'accept':\s*if \(maybeCompleteAcceptedSession\(msg\)\) break;/,
+      /case 'complete':\s*case 'accept':[\s\S]{0,400}?if \(maybeCompleteAcceptedSession\(msg\)\) break;/,
       'final accepted DOM cleanup should be driven by explicit complete or harness accept replies',
     );
     assert.match(
@@ -340,8 +340,8 @@ describe('live-browser source contracts', () => {
     assert.match(agentDoneSource, /maybeCompleteAcceptedSession\(msg\)/);
     assert.match(
       SOURCE,
-      /function handleGo\(\)[\s\S]{0,900}?pendingAcceptedSession = null;[\s\S]{0,80}?currentSessionId = id8\(\);/,
-      'starting a new generation should clear any stale accepted-session sentinel first',
+      /function handleGo\(\)[\s\S]{0,900}?pendingAcceptedSession = null;[\s\S]{0,400}?awaitingAcceptResult = null;[\s\S]{0,120}?currentSessionId = id8\(\);/,
+      'starting a new generation should clear any stale accepted-session sentinel (and the awaited accept-result marker, #384) first',
     );
     const handleAcceptStart = SOURCE.indexOf('function handleAccept()');
     const maybeCompleteStart = SOURCE.indexOf('function maybeCompleteAcceptedSession', handleAcceptStart);


### PR DESCRIPTION
Fixes #384.

## The bug

`scheduleAcceptCleanup` queues a microtask on the optimistic POST-success path that nulls `pendingAcceptedSession` long before `live-accept.mjs` actually runs. When the accept later fails (missing markers, preview error, receipt conflict, `source_locked`), the SSE `error` guard keyed on `pendingAcceptedSession` can't match, so the tailored recovery never fires: generic toast, session gone, no hint the variant was never written.

## The fix

The issue's own sketch, implemented: an `awaitingAcceptResult` id set on the optimistic success path (right before `scheduleAcceptCleanup`) that **deliberately survives** `cleanupAcceptedSession`. Lifecycle:

- **Set:** POST-success `.then`, alongside the CONFIRMED transition.
- **Matched:** a new branch in the SSE `error` case, after the existing pre-teardown `pendingAcceptedSession` recovery. Post-teardown the wrapper may already be gone (HMR or the 2s manual-swap fallback), so restoring CYCLING isn't honestly possible — the branch instead states plainly that the variant was not saved and to pick + generate again, with the server's failure message.
- **Released:** when the real accept result arrives (`complete` / `accept` / any post-accept `agent_done` naming the id — carbonize included), when the pre-teardown error recovery runs, or when `handleGo`/insert starts a new session (a stale failure toast for a superseded session would only mislead).

Composes with #414: that PR's generic-error checkpoint clearing is a no-op in this scenario (the teardown already cleared the checkpoint), and the two changes touch different spots of the `error` case.

## Tests (failing-first)

New regression guard asserting the set-before-teardown ordering, the error-branch match with the not-saved message, and — the point of the design — that `cleanupAcceptedSession` does **not** touch the marker. The existing `handleGo` source contract is strengthened to require clearing the marker on new sessions. The issue notes no E2E fixture drives a post-teardown accept failure; the deterministic source-shape guards pin the mechanism the same way #362's fix is pinned.

`bun run test` and `bun run build` fully green.

## AI disclosure

Prepared with AI assistance (Claude Code), directed by @pbakaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side live-browser SSE/toast handling only; no auth, persistence, or server contract changes beyond existing accept flow.
> 
> **Overview**
> Fixes **#384**: after Accept, the UI tears down optimistically once `POST /events` succeeds, which clears `pendingAcceptedSession` before the server may still fail the real accept. Late SSE `error` events then missed the tailored handler and only showed a generic toast.
> 
> Adds **`awaitingAcceptResult`** (session id) set on the optimistic success path, intentionally **not** cleared by `cleanupAcceptedSession`. A new SSE `error` branch matches that id and shows an explicit message that the variant **may not have been saved**, with hedged wording for carbonize failures after source promotion. The marker is cleared on `complete`/`accept`, on **`agent_done` only when `carbonize === true`** (so a late generation `agent_done` does not close the window early), on pre-teardown accept errors, and when starting a new generation/insert.
> 
> Regression tests in `live-browser-regression.test.mjs` and updated source-shape contracts in `live-browser-source.test.mjs` lock in the lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c5558960603b6bb1486e37829d7758186a8840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->