### PR TITLE
Sync workflow: retry the generated-output push when main advances mid-sync

### DIFF
--- a/.github/workflows/sync-generated-output.yml
+++ b/.github/workflows/sync-generated-output.yml
@@ -78,6 +78,7 @@ jobs:
           fi
 
       - name: Commit generated output
+        id: commit
         if: steps.drift.outputs.changed == 'true'
         run: |
           set -euo pipefail
@@ -97,6 +98,7 @@ jobs:
               # The race that beat us was another sync (or the rebuilt output
               # matches the new main); nothing left to push.
               echo "No generated output drift after rebuild (attempt $attempt); nothing to push."
+              echo "pushed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             git commit -m "Sync generated provider output"
@@ -104,6 +106,7 @@ jobs:
             git fetch origin main
             if git merge-base --is-ancestor origin/main HEAD && git push origin HEAD:main; then
               echo "Pushed generated output on attempt $attempt."
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -125,4 +128,8 @@ jobs:
       - name: Summarize generated output commit
         if: steps.drift.outputs.changed == 'true'
         run: |
-          echo "Committed generated provider output directly to main." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.commit.outputs.pushed }}" = "true" ]; then
+            echo "Committed generated provider output directly to main." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Generated output drift resolved itself after a mid-run rebuild; nothing was pushed." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/sync-generated-output.yml
+++ b/.github/workflows/sync-generated-output.yml
@@ -107,14 +107,19 @@ jobs:
               exit 0
             fi
 
-            echo "main advanced during attempt $attempt; re-syncing and rebuilding."
+            # The recovery work is pointless on the final attempt: nothing
+            # would consume the rebuild, and the backoff would only delay
+            # the failure.
+            if [ "$attempt" = 5 ]; then break; fi
+
+            echo "Push did not land on attempt $attempt (main advanced, or the push itself failed); re-syncing and rebuilding."
             git reset --hard origin/main
             bun install --frozen-lockfile
             bun run build:release
             sleep $((attempt * 5))
           done
 
-          echo "::error::main kept advancing through 5 sync attempts; rerun this workflow on the latest main."
+          echo "::error::Could not push generated output after 5 attempts (main kept advancing, or pushes kept failing); rerun this workflow on the latest main."
           exit 1
 
       - name: Summarize generated output commit

--- a/.github/workflows/sync-generated-output.yml
+++ b/.github/workflows/sync-generated-output.yml
@@ -80,18 +80,42 @@ jobs:
       - name: Commit generated output
         if: steps.drift.outputs.changed == 'true'
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add $GENERATED_PATHS
-          git commit -m "Sync generated provider output"
 
-          git fetch origin main
-          if ! git merge-base --is-ancestor origin/main HEAD; then
-            echo "::error::main advanced while generated output was building; rerun this workflow on the latest main."
-            exit 1
-          fi
+          # A push can lose the race against a human commit landing on main
+          # during the ~30s build window (issue #388: ~10% of runs). Instead
+          # of aborting and waiting for an unrelated push to re-trigger the
+          # sync, re-sync to the latest main, rebuild against the current
+          # source, and push again, with backoff. Every attempt builds from
+          # a fresh origin/main, so pushed output always matches the source
+          # state it lands on.
+          for attempt in 1 2 3 4 5; do
+            git add $GENERATED_PATHS
+            if git diff --cached --quiet; then
+              # The race that beat us was another sync (or the rebuilt output
+              # matches the new main); nothing left to push.
+              echo "No generated output drift after rebuild (attempt $attempt); nothing to push."
+              exit 0
+            fi
+            git commit -m "Sync generated provider output"
 
-          git push origin HEAD:main
+            git fetch origin main
+            if git merge-base --is-ancestor origin/main HEAD && git push origin HEAD:main; then
+              echo "Pushed generated output on attempt $attempt."
+              exit 0
+            fi
+
+            echo "main advanced during attempt $attempt; re-syncing and rebuilding."
+            git reset --hard origin/main
+            bun install --frozen-lockfile
+            bun run build:release
+            sleep $((attempt * 5))
+          done
+
+          echo "::error::main kept advancing through 5 sync attempts; rerun this workflow on the latest main."
+          exit 1
 
       - name: Summarize generated output commit
         if: steps.drift.outputs.changed == 'true'


### PR DESCRIPTION
Fixes #388. Retry design proposed by @mktdgtbrz in the issue; implemented from the description rather than applying the attached patch, with one addition (the no-drift early exit).

## The problem

The sync job fetches main once, builds ~30s, then pushes. If a commit lands on main in that window, the `merge-base --is-ancestor` guard correctly aborts (pushing would attach stale output to a main it wasn't built from), but nothing retries — generated output lags until the next unrelated push self-heals it. Evidence in the issue: 3 of 30 runs.

## The change

The commit step becomes a bounded retry loop (5 attempts, linear backoff 5/10/15/20s):

1. Stage + commit the drift; if staging shows **no drift after a rebuild**, exit 0 — the racing commit was another sync run, or the new source builds identical output, and an empty "Sync" commit would be noise.
2. Fetch main; keep the original `merge-base --is-ancestor` check **inside the loop** as the pre-push verification, then push.
3. On a lost race: `git reset --hard origin/main` (source included, discarding our commit), `bun install --frozen-lockfile` (the racing commit may have touched the lockfile), `bun run build:release`, back off, go again.

The invariant the old abort protected — *pushed output always matches the source state it lands on* — is preserved by rebuilding from the fresh main on every attempt, not bypassed. After five lost races the job fails with the same rerun guidance as before. The workflow's `concurrency` group already serializes sync runs, so races are only against human pushes.

## Validation

CI workflows can't test themselves, so three layers:
- `yaml-lint` on the workflow, `bash -n` on the extracted script
- A local three-repo simulation (bare origin + sync worker + racing clone): worker loses attempt 1, resets onto the racer's source commit, rebuilds, and attempt 2 lands output built from the racer's source (verified by content)
- The no-drift exit path exercised in the same harness

**Requesting closer-than-usual review** since this touches the release-sync path — particularly whether you want `--frozen-lockfile` failures (a racing commit with a bad lockfile) to fail the job, which this preserves.

## AI disclosure

Prepared with AI assistance (Claude Code), directed by @pbakaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release sync path that commits directly to main; logic is careful but mis-handling could still push wrong output or mask persistent push failures until the fifth attempt.
> 
> **Overview**
> When **main moves during the ~30s build**, the sync workflow no longer fails once and leaves generated output stale until another push. The **Commit generated output** step is now a **bounded retry loop** (up to 5 attempts, linear backoff) that still only pushes output built from the **current** `origin/main`.
> 
> Each attempt stages generated paths, **exits successfully without pushing** if there is nothing left to commit (another sync or a rebuild already matches main), then fetches main, runs the existing **`merge-base --is-ancestor` check**, and pushes. On a lost race or failed push it **hard-resets to `origin/main`**, runs **`bun install --frozen-lockfile`** and **`bun run build:release`**, then retries. After five failures the job errors with the same rerun guidance as before.
> 
> The step summary now distinguishes a successful push from the case where drift cleared after a mid-run rebuild and **nothing was pushed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166ec9a51e8ed7e52a532b17a7429db3531d507d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->