### PR TITLE
Retry the doctor-test scratch cleanup to kill a Node 22 CI flake

### DIFF
--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -39,7 +39,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(scratch, { recursive: true, force: true });
+  // These tests run real git subprocesses in the scratch dir; on Node 22 a
+  // recursive delete can race git's object writes and fail the whole test
+  // with ENOTEMPTY (seen in CI). maxRetries/retryDelay make rmSync retry
+  // exactly those transient errors.
+  fs.rmSync(scratch, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 function write(rel, body) {


### PR DESCRIPTION
Kills a CI flake observed on PR #418's rebase run: `tests/doctor.test.mjs`'s `afterEach` recursive delete raced git's object writes on Node 22 and failed the suite with `ENOTEMPTY: directory not empty, rmdir '.../.git/objects'` (a `hookFailed` on an otherwise-passing test; Node 24 was green on the same commit).

The suite is the only one whose scratch cleanup follows real git subprocesses, which is why it alone flakes. `fs.rmSync`'s `maxRetries`/`retryDelay` options exist precisely for these transient `ENOTEMPTY`/`EBUSY` errors; the cleanup now retries up to 5 times at 100ms.

One-line behavior change, no product code touched. `node --test tests/doctor.test.mjs` and the full suite green locally.

## AI disclosure

Prepared with AI assistance (Claude Code), directed by @pbakaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only teardown change with no product or runtime behavior impact.
> 
> **Overview**
> Fixes intermittent CI failures in `tests/doctor.test.mjs` where `afterEach` teardown could hit `ENOTEMPTY` while removing the temp repo after real `git` subprocesses finish writing under `.git/objects` (seen on Node 22).
> 
> Teardown now passes **`maxRetries: 5`** and **`retryDelay: 100`** to `fs.rmSync` so transient `ENOTEMPTY`/`EBUSY` errors are retried instead of failing an otherwise passing test. A short comment documents why this suite needs it versus other tests that only delete files without git activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a6bb5a384c65a9b039280a8dc17a4d965112d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->