### PR TITLE
Bump web-ext lint to v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         # Pinned for reproducible CI. Fails on AMO errors; innerHTML style
         # warnings in the panel renderer are non-blocking and not promoted to
         # errors here.
-        run: npx --yes web-ext@8 lint --source-dir dist/extension-firefox
+        run: npx --yes web-ext@10 lint --source-dir dist/extension-firefox
 
       - name: Verify generated tracked outputs
         run: git diff --exit-code -- .agents .claude .cursor .gemini .github/skills plugin cli/engine/detect-antipatterns-browser.js extension/detector


### PR DESCRIPTION
## Summary

Update the Firefox extension lint step from the `web-ext` v8 release line to v10.

- Current effective version: `web-ext` 8.10.0 (`web-ext@8`)
- Proposed effective version: `web-ext` 10.5.0 (`web-ext@10`)
- Keeps the existing major-line pin style while picking up current Firefox schemas and `addons-linter` updates.

## Risk and migration

This crosses two major versions. The v9 breaking change removes `.js` config-file support, but this repository has no `web-ext` config file, so no migration is required. v10 uses Node 22 by default and supports Node >=20; the repository tests Node 22.12 and 24.

The newer linter adds one advisory warning for the Firefox Android minimum-version metadata. It remains non-blocking alongside the five existing dynamic `innerHTML` warnings; lint reports zero errors.

## Validation

- `bun install --frozen-lockfile`
- `bun run build:browser`
- `bun run build:extension`
- `bun run test:detector`
- `npx --yes web-ext@10 lint --source-dir dist/extension-firefox` (0 errors, 6 warnings)
- Ruby YAML parse of `.github/workflows/ci.yml`
- `git diff --check`

Browser and extension builds produced no tracked generated-output drift.

## AI disclosure

Prepared with AI assistance from OpenAI Codex under maintainer automation instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin with no application code changes; main risk is stricter or different linter output on future extension changes.
> 
> **Overview**
> Updates the **Lint Firefox extension (web-ext)** CI step to run **`web-ext@10`** instead of **`web-ext@8`**, keeping the same pinned `npx` pattern and `dist/extension-firefox` source dir.
> 
> Behavior is unchanged: the job still runs only when detector tests run, still fails on AMO **errors**, and still treats existing `innerHTML`-related warnings as non-blocking per the step comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e43ecd3fbd5cf05859976e7db9231ade486e59d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->