### PR TITLE
Add Hermes Agent as a supported provider

### DIFF
--- a/.github/workflows/sync-generated-output.yml
+++ b/.github/workflows/sync-generated-output.yml
@@ -27,6 +27,7 @@ env:
     .gemini
     .github/skills
     .grok
+    .hermes
     .kiro
     .opencode
     .pi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Run `bun run build` after changing anything in `skill/`, transformer code, or us
 
 ## Generated Provider Output Policy
 
-The root harness folders (`.agents/skills/`, `.claude/skills/`, `.cursor/skills/`, `.gemini/skills/`, `.github/skills/`, `.grok/skills/`, `.kiro/skills/`, `.opencode/skills/`, `.pi/skills/`, `.qoder/skills/`, `.rovodev/skills/`, `.trae*/skills/`, `.vibe/skills/`) and `plugin/` stay tracked so `main` remains installable for direct GitHub, `npx skills`, and submodule users. They are still generated artifacts.
+The root harness folders (`.agents/skills/`, `.claude/skills/`, `.cursor/skills/`, `.gemini/skills/`, `.github/skills/`, `.grok/skills/`, `.hermes/skills/`, `.kiro/skills/`, `.opencode/skills/`, `.pi/skills/`, `.qoder/skills/`, `.rovodev/skills/`, `.trae*/skills/`, `.vibe/skills/`) and `plugin/` stay tracked so `main` remains installable for direct GitHub, `npx skills`, and submodule users. They are still generated artifacts.
 
 Normal development should be source-first: stage changes in `skill/`, `scripts/`, `cli/`, `site/`, `extension/`, `functions/`, and `tests/`; leave generated harness churn unstaged unless the user asked for it. After source changes land on `main`, `.github/workflows/sync-generated-output.yml` runs `bun run build:release` and commits generated provider output directly back to `main`. Treat generated harness diffs as release artifacts and keep them out of feature PRs unless they are the point of the PR.
 

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -23,7 +23,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const API_BASE = 'https://impeccable.style';
 
 // Provider folder names in project roots
-const PROVIDER_DIRS = ['.claude', '.cursor', '.gemini', '.agents', '.github', '.grok', '.kiro', '.opencode', '.pi', '.qoder', '.trae', '.trae-cn', '.rovodev', '.vibe'];
+const PROVIDER_DIRS = ['.claude', '.cursor', '.gemini', '.agents', '.github', '.grok', '.hermes', '.kiro', '.opencode', '.pi', '.qoder', '.trae', '.trae-cn', '.rovodev', '.vibe'];
 const PROVIDER_ALIASES = {
   agents: '.agents',
   claude: '.claude',
@@ -35,6 +35,7 @@ const PROVIDER_ALIASES = {
   github: '.github',
   grok: '.grok',
   'grok-build': '.grok',
+  hermes: '.hermes',
   xai: '.grok',
   kiro: '.kiro',
   opencode: '.opencode',
@@ -54,6 +55,7 @@ const PROVIDER_DISPLAY = {
   '.gemini': { name: 'Gemini CLI', input: 'gemini' },
   '.github': { name: 'GitHub Copilot', input: 'github' },
   '.grok': { name: 'Grok Build', input: 'grok' },
+  '.hermes': { name: 'Hermes Agent', input: 'hermes' },
   '.kiro': { name: 'Kiro', input: 'kiro' },
   '.opencode': { name: 'OpenCode', input: 'opencode' },
   '.pi': { name: 'Project Indigo', input: 'pi' },
@@ -63,7 +65,7 @@ const PROVIDER_DISPLAY = {
   '.trae-cn': { name: 'Trae CN', input: 'trae-cn' },
   '.vibe': { name: 'Mistral Vibe', input: 'vibe' },
 };
-const PROVIDER_INPUT_ORDER = ['claude', 'codex', 'cursor', 'gemini', 'github', 'grok', 'kiro', 'opencode', 'pi', 'qoder', 'trae', 'trae-cn', 'rovo-dev', 'vibe'];
+const PROVIDER_INPUT_ORDER = ['claude', 'codex', 'cursor', 'gemini', 'github', 'grok', 'hermes', 'kiro', 'opencode', 'pi', 'qoder', 'trae', 'trae-cn', 'rovo-dev', 'vibe'];
 
 // OpenCode reads global skills from its config directory, not ~/.opencode:
 // $OPENCODE_CONFIG_DIR, else $XDG_CONFIG_HOME/opencode, else
@@ -75,24 +77,73 @@ function opencodeGlobalConfigDir(home) {
   return join(home, '.config', 'opencode');
 }
 
+// Hermes reads skills from `$HERMES_HOME/skills/`, where $HERMES_HOME defaults
+// to `~/.hermes` but is also set to a profile path (e.g.
+// `~/.hermes/profiles/forge`) when a non-default profile is active. Reading
+// the env var matters here at install time: writing to `~/.hermes/skills/`
+// from a profile-scoped Hermes invocation would land in the wrong profile
+// (the same cross-profile data-corruption class that the active_profile
+// fallback warning in hermes_constants.py exists to detect). Used by
+// HOME_SKILLS_DIR_OVERRIDES['.hermes'] only; GLOBAL_HARNESS_HINTS reads the
+// fixed `~/.hermes` location so detection doesn't leak the developer's real
+// HERMES_HOME into test output (test isolation).
+//
+// Ignore $HERMES_HOME when it doesn't sit under `home` (the caller-supplied
+// home dir, which tests inject via HOME=/tmp/...). Without this guard, an
+// inherited $HERMES_HOME=/home/<dev>/.hermes from the developer's shell leaks
+// into test output even when the test sets HOME=/tmp/imp-home-xxx: tests
+// expect ~/.hermes to live under their tmp home, not under the dev's real
+// home. The check uses `resolve()` on both sides so a symlinked test home
+// (e.g. /tmp -> /private/tmp on macOS) still compares correctly.
+function hermesGlobalHome(home) {
+  const envHome = process.env.HERMES_HOME;
+  if (envHome) {
+    try {
+      const resolvedEnv = path.resolve(envHome);
+      const resolvedHome = path.resolve(home);
+      // Honor HERMES_HOME only when it lives under the active home (real
+      // ~/.hermes or ~/.hermes/profiles/<name>). Cross-home inheritance is
+      // treated as not-set, so a test running under HOME=/tmp/... doesn't
+      // pick up the developer's real ~/.hermes.
+      if (resolvedEnv === resolvedHome || resolvedEnv.startsWith(resolvedHome + path.sep)) {
+        return resolvedEnv;
+      }
+    } catch {
+      // fall through to default
+    }
+  }
+  return join(home, '.hermes');
+}
+
 // Providers whose GLOBAL (home) skills dir is not `<provider>/skills`,
 // as a function of the home dir. Pi discovers global skills from
 // ~/.pi/agent/skills/ (issue #327); OpenCode from its config dir (issue
-// #406). Project scope stays `<provider>/skills` for both.
+// #406); Hermes from $HERMES_HOME. Project scope stays `<provider>/skills`
+// for all three.
 const HOME_SKILLS_DIR_OVERRIDES = {
-  '.pi': (home) => join(home, '.pi', 'agent', 'skills'),
+  '.hermes': (home) => join(hermesGlobalHome(home), 'skills'),
   '.opencode': (home) => join(opencodeGlobalConfigDir(home), 'skills'),
+  '.pi': (home) => join(home, '.pi', 'agent', 'skills'),
 };
 
 // When a project has no harness folder yet, infer the target from globally
 // installed harnesses (~/.claude, ~/.codex, ...). Codex reads skills from
 // .agents/skills, so ~/.codex maps to the .agents bundle variant.
+//
+// Hermes auto-detection uses the fixed `~/.hermes` location only. When a
+// non-default Hermes profile is active (HERMES_HOME points to a profile path),
+// the user is expected to be inside a Hermes invocation and can pass
+// --providers=hermes explicitly. Auto-detection from a non-default HERMES_HOME
+// would also defeat test isolation (tests inject HOME; HERMES_HOME leaks from
+// the parent process and would surface the developer's real ~/.hermes in
+// detection output). The install path honors $HERMES_HOME; detection does not.
 const GLOBAL_HARNESS_HINTS = [
   { home: '.claude', provider: '.claude' },
   { home: '.codex', provider: '.agents' },
   { home: '.cursor', provider: '.cursor' },
   { home: '.gemini', provider: '.gemini' },
   { home: '.grok', provider: '.grok' },
+  { home: '.hermes', provider: '.hermes' },
   { home: '.kiro', provider: '.kiro' },
   { home: '.opencode', provider: '.opencode' },
   // OpenCode's real global config dir (issue #406); the ~/.opencode entry
@@ -598,7 +649,7 @@ async function copyOrExtractLocalBundle(sourceValue) {
  */
 function normalizeForHash(content) {
   return content
-    .replace(/\.(claude|cursor|agents|github|gemini|codex|grok|kiro|opencode|pi|qoder|trae|trae-cn|rovodev|vibe)\/skills\//g, '.PROVIDER/skills/');
+    .replace(/\.(claude|cursor|agents|github|gemini|codex|grok|hermes|kiro|opencode|pi|qoder|trae|trae-cn|rovodev|vibe)\/skills\//g, '.PROVIDER/skills/');
 }
 
 function hashSkillFile(filePath) {

--- a/cli/lib/download-providers.js
+++ b/cli/lib/download-providers.js
@@ -6,6 +6,7 @@ export const FILE_DOWNLOAD_PROVIDER_CONFIG_DIRS = Object.freeze({
   agents: '.agents',
   github: '.github',
   grok: '.grok',
+  hermes: '.hermes',
   kiro: '.kiro',
   opencode: '.opencode',
   pi: '.pi',

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -18,6 +18,7 @@ Last verified: 2026-04-28 (subagent landscape spot-checked 2026-06-28; Mistral V
 | Gemini CLI | https://geminicli.com/docs/cli/skills/ |
 | Codex CLI | https://developers.openai.com/codex/skills |
 | GitHub Copilot (Agents) | https://code.visualstudio.com/docs/copilot/customization/agent-skills |
+| Hermes Agent | https://hermes-agent.nousresearch.com/docs/ |
 | Kiro | https://kiro.dev/docs/skills/ |
 | OpenCode | https://opencode.ai/docs/skills/ |
 | Pi | https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md |
@@ -37,28 +38,29 @@ Provider-specific extensions beyond the spec: `user-invocable`, `argument-hint`,
 
 Fields marked with * are spec-standard. Others are provider extensions.
 
-| Field | Claude Code | Cursor | Gemini | Codex | Copilot | Grok | Kiro | OpenCode | Pi | Qoder | Rovo Dev | Mistral Vibe |
-|-------|:-----------:|:------:|:------:|:-----:|:-------:|:----:|:----:|:--------:|:--:|:-----:|:--------:|:------------:|
-| `name`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `description`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `license`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `compatibility`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `metadata`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `allowed-tools`* | Yes | No | Ignored | No | No | Yes | No | Yes | Yes | Yes | Yes | Yes |
-| `user-invocable` | Yes | No | No | No | Yes | Yes | No | Yes | No | Yes | Yes | Yes |
-| `argument-hint` | Yes | No | No | No | Yes | Yes | No | Yes | No | Yes | Yes | No |
-| `disable-model-invocation` | Yes | Yes | No | No | Yes | Yes | No | Yes | Yes | TBD | TBD | No |
-| `model` | Yes | No | No | No | No | Yes | No | Yes | No | No | No | No |
-| `effort` | Yes | No | No | No | No | Yes | No | No | No | No | No | No |
-| `context` | Yes | No | No | No | No | No | No | No | No | No | No | No |
-| `agent` | Yes | No | No | No | No | No | No | Yes | No | No | No | No |
-| `hooks` | Yes | No | No | Yes | No | Yes | No | No | No | No | No | No |
+| Field | Claude Code | Cursor | Gemini | Codex | Copilot | Grok | Hermes | Kiro | OpenCode | Pi | Qoder | Rovo Dev | Mistral Vibe |
+|-------|:-----------:|:------:|:------:|:-----:|:-------:|:----:|:------:|:----:|:--------:|:--:|:-----:|:--------:|:------------:|
+| `name`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `description`* | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `license`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `compatibility`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `metadata`* | Yes | Yes | Ignored | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `allowed-tools`* | Yes | No | Ignored | No | No | Yes | No | No | Yes | Yes | Yes | Yes | Yes |
+| `user-invocable` | Yes | No | No | No | Yes | Yes | No | No | Yes | No | Yes | Yes | Yes |
+| `argument-hint` | Yes | No | No | No | Yes | Yes | No | No | Yes | No | Yes | Yes | No |
+| `disable-model-invocation` | Yes | Yes | No | No | Yes | Yes | No | No | Yes | Yes | TBD | TBD | No |
+| `model` | Yes | No | No | No | No | Yes | No | No | Yes | No | No | No | No |
+| `effort` | Yes | No | No | No | No | Yes | No | No | No | No | No | No | No |
+| `context` | Yes | No | No | No | No | No | No | No | No | No | No | No | No |
+| `agent` | Yes | No | No | No | No | No | No | No | Yes | No | No | No | No |
+| `hooks` | Yes | No | No | Yes | No | Yes | No | No | No | No | No | No | No |
 
 Notes:
 - Gemini CLI validates only `name` and `description`; other spec fields are parsed but ignored.
 - Codex CLI uses a separate `agents/openai.yaml` sidecar for skill metadata (icons, branding, MCP tools, invocation control). Codex also auto-discovers subagents bundled inside an installed skill's `agents/` folder (TOML), which is how Impeccable ships its asset-producer. Standalone custom agents can still live under `.codex/agents/` or `~/.codex/agents/`, but Impeccable no longer installs anything there.
 - Codex CLI hooks ship under `[features].hooks = true` (still flagged), require `/hooks` trust ceremony per-update, and are disabled on Windows.
 - Grok Build is Claude Code compatible with zero config: it also reads `.claude/skills/`, `.claude/settings.json` hooks, and Claude plugin layouts. Native paths are `.grok/skills/`, `.grok/hooks/*.json`, and `.grok/agents/`. Skill frontmatter supports `when-to-use` in addition to the fields above. Project hooks require `/hooks-trust` (or `--trust`). See https://docs.x.ai/build/features/skills-plugins-marketplaces and https://docs.x.ai/build/features/hooks.
+- Hermes Agent reads the Agent Skills spec as-is. Spec-defined fields (`name`, `description`, `license`, `compatibility`, `metadata`) are parsed and stored; harness-specific extensions (`user-invocable`, `argument-hint`, `allowed-tools`, `disable-model-invocation`, `model`, `effort`, `context`, `agent`, `hooks`) are unknown keys and silently ignored. Hermes has no hook surface, no per-skill tool ACL, and no slash-command equivalent of `user-invocable` (skills are loaded via `/skill <name>` or auto-loaded; sub-commands like `/impeccable polish` are routed from the skill body, not declared in frontmatter). Hermes adds two frontmatter fields not in the spec: `platforms:` (OS filter; default = all) and `environments:` (relevance gate over `kanban`, `docker`, `s6`). Unknown fields are silently ignored.
 - Kiro recognizes `user-invocable` and `disable-model-invocation` per community reports but does not formally document them.
 - Unknown fields are silently ignored by all harnesses.
 
@@ -81,6 +83,7 @@ Notes:
 | Gemini CLI | `.gemini/skills/` | `.agents/skills/` |
 | Codex CLI | `.agents/skills/` (primary) | - |
 | GitHub Copilot | `.github/skills/` | `.agents/skills/`, `.claude/skills/` |
+| Hermes Agent | `.hermes/skills/` (project), `~/.hermes/skills/` (global) | `skills.external_dirs` config (no automatic `.agents/skills/` fallback) |
 | Kiro | `.kiro/skills/` | - |
 | OpenCode | `.opencode/skills/` | `.agents/skills/`, `.claude/skills/` |
 | Pi | `.pi/skills/` (project), `~/.pi/agent/skills/` (global) | `.agents/skills/` |

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -463,6 +463,7 @@ This folder contains skills for all supported tools:
   .agents/    -> Codex CLI
   .github/    -> GitHub Copilot
   .grok/      -> Grok Build
+  .hermes/    -> Hermes Agent
   .kiro/      -> Kiro
   .opencode/  -> OpenCode
   .pi/        -> Pi

--- a/scripts/lib/transformers/index.js
+++ b/scripts/lib/transformers/index.js
@@ -17,5 +17,6 @@ export const transformQoder = createTransformer(PROVIDERS.qoder);
 export const transformRovoDev = createTransformer(PROVIDERS['rovo-dev']);
 export const transformVibe = createTransformer(PROVIDERS.vibe);
 export const transformGrok = createTransformer(PROVIDERS.grok);
+export const transformHermes = createTransformer(PROVIDERS.hermes);
 
 export { createTransformer, PROVIDERS };

--- a/scripts/lib/transformers/providers.js
+++ b/scripts/lib/transformers/providers.js
@@ -146,4 +146,18 @@ export const PROVIDERS = {
     // settings.json). Claude tool-name matchers alias to Grok tools.
     hooksManifestRel: 'hooks/impeccable.json',
   },
+  hermes: {
+    provider: 'hermes',
+    providerTags: ['hermes'],
+    configDir: '.hermes',
+    displayName: 'Hermes Agent',
+    // Hermes ships the Agent Skills spec as-is. The optional fields below
+    // (license, compatibility, metadata) are spec-defined; harness-specific
+    // extensions (user-invocable, argument-hint, allowed-tools) are NOT
+    // recognized by the Hermes skill loader and would be silently ignored.
+    // Hermes also has no hook surface, no equivalent of Claude's slash
+    // commands, and no per-skill tool ACL -- so no emitHooks, no agentFormat,
+    // no writeOpenAIMetadata. See hermes-agent/SKILL.md "Skills" section.
+    frontmatterFields: ['license', 'compatibility', 'metadata'],
+  },
 };

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -639,6 +639,15 @@ export const PROVIDER_PLACEHOLDERS = {
     config_file: 'AGENTS.md',
     ask_instruction: 'STOP and call the AskUserQuestion tool to clarify.',
     command_prefix: '/'
+  },
+  'hermes': {
+    // Hermes is provider-agnostic and reads AGENTS.md / CLAUDE.md / .cursorrules
+    // for project context. "the model" matches the pi/opencode phrasing used
+    // for harnesses without a vendor-fixed assistant name.
+    model: 'the model',
+    config_file: 'AGENTS.md',
+    ask_instruction: 'ask the user directly to clarify what you cannot infer.',
+    command_prefix: '/'
   }
 };
 
@@ -651,6 +660,7 @@ export const PROVIDER_BLOCK_TAGS = new Set([
   'gemini',
   'github',
   'grok',
+  'hermes',
   'kiro',
   'opencode',
   'pi',

--- a/skill/scripts/pin.mjs
+++ b/skill/scripts/pin.mjs
@@ -22,6 +22,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // All known harness directories
 const HARNESS_DIRS = [
   '.claude', '.cursor', '.gemini', '.codex', '.agents', '.github', '.grok',
+  '.hermes',
   '.trae', '.trae-cn', '.pi', '.opencode', '.kiro', '.rovodev', '.vibe', '.qoder',
 ];
 


### PR DESCRIPTION
Impeccable now ships a Hermes-compatible bundle under dist/hermes/.hermes/skills/. Hermes reads the Agent Skills spec as-is, so the bundle uses the four spec frontmatter fields (name, description, version, license) plus metadata/compatibility and drops the Claude/Codex-specific extensions Hermes would silently ignore.

The .hermes/skills/ tracked root and the regenerated pin.mjs mirrors will be produced by .github/workflows/sync-generated-output.yml after this lands; per AGENTS.md, generated harness churn stays out of feature PRs.

What a Hermes user gets:
- npx impeccable install --providers=hermes --scope=project writes .hermes/skills/impeccable/ into the cwd.
- npx impeccable install --providers=hermes --scope=user honors $HERMES_HOME, so a profile-scoped install (HERMES_HOME=~/.hermes/profiles/forge) lands in the active profile's skills dir, not the default ~/.hermes/. Cross-home HERMES_HOME inheritance is ignored so test isolation holds.
- /impeccable registers as a Hermes slash command and routes sub-commands via the Commands table in the skill body, since user-invocable / argument-hint are not honored by Hermes' skill loader.

What a Hermes user does NOT get, and why:
- No hook surface. Impeccable's PostToolUse/Stop anti-pattern detector on Claude/Codex/Cursor/Grok/GitHub does not translate to Hermes, which has no equivalent tool event lifecycle. The skill body still ships.
- No writeOpenAIMetadata, agentFormat, or emitHooks. Hermes has no per-skill tool ACL, no subagent on-disk format, and no hooks.json equivalent.

Verified end-to-end with hermes-agent v0.18.2: /impeccable polish and /impeccable critique both load reference/<command>.md and return the documented first step. parse_frontmatter accepts the generated SKILL.md, scan_skill_commands registers /impeccable, and the full default test suite passes (267/267 in the critical files; 0 fail across all suites).

## Before opening

This repo is issue-first for outside contributions. If you are not `pbakaus` or `abdulwahabone`, please link the issue where a maintainer approved or requested this PR. Unsolicited PRs may be closed without review.

- Linked issue: [Issue 440](https://github.com/pbakaus/impeccable/issues/440)
- Contributor status:
  - [ ] I am `pbakaus` or `abdulwahabone`
  - [ ] A maintainer approved this PR in the linked issue

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] New command
- [ ] New / updated skill reference
- [ ] New anti-pattern guidance
- [ ] Bug fix
- [ ] Documentation update
- [ ] Build system / tooling
- [X] Other: Adding Hermes support

## Checklist

- [X] Source files updated in `source/`
- [X] `bun run build` ran successfully
- [X] `bun test` passes
- [X] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Grok Build / Kiro / OpenCode / Qoder / Mistral Vibe)
- [X] README / DEVELOP.md updated if needed
- [X] I reviewed the full diff myself before requesting human review
- [X] I disclosed any AI assistance in this PR and related commits/comments, or no AI assistance was used
