### PR TITLE
Add MiniMax image-01 fallback to generate-image script

### DIFF
--- a/.agents/skills/impeccable/scripts/context.mjs
+++ b/.agents/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.agents/skills/impeccable/scripts/generate-image.mjs
+++ b/.agents/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.claude/skills/impeccable/scripts/context.mjs
+++ b/.claude/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.claude/skills/impeccable/scripts/generate-image.mjs
+++ b/.claude/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.cursor/skills/impeccable/scripts/context.mjs
+++ b/.cursor/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.cursor/skills/impeccable/scripts/generate-image.mjs
+++ b/.cursor/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.gemini/skills/impeccable/scripts/context.mjs
+++ b/.gemini/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.gemini/skills/impeccable/scripts/generate-image.mjs
+++ b/.gemini/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.github/skills/impeccable/scripts/context.mjs
+++ b/.github/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.github/skills/impeccable/scripts/generate-image.mjs
+++ b/.github/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.grok/skills/impeccable/scripts/context.mjs
+++ b/.grok/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.grok/skills/impeccable/scripts/generate-image.mjs
+++ b/.grok/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.kiro/skills/impeccable/scripts/context.mjs
+++ b/.kiro/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.kiro/skills/impeccable/scripts/generate-image.mjs
+++ b/.kiro/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.opencode/skills/impeccable/scripts/context.mjs
+++ b/.opencode/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.opencode/skills/impeccable/scripts/generate-image.mjs
+++ b/.opencode/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.pi/skills/impeccable/scripts/context.mjs
+++ b/.pi/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.pi/skills/impeccable/scripts/generate-image.mjs
+++ b/.pi/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.qoder/skills/impeccable/scripts/context.mjs
+++ b/.qoder/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.qoder/skills/impeccable/scripts/generate-image.mjs
+++ b/.qoder/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.rovodev/skills/impeccable/scripts/context.mjs
+++ b/.rovodev/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.rovodev/skills/impeccable/scripts/generate-image.mjs
+++ b/.rovodev/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.trae-cn/skills/impeccable/scripts/context.mjs
+++ b/.trae-cn/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.trae-cn/skills/impeccable/scripts/generate-image.mjs
+++ b/.trae-cn/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.trae/skills/impeccable/scripts/context.mjs
+++ b/.trae/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.trae/skills/impeccable/scripts/generate-image.mjs
+++ b/.trae/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/.vibe/skills/impeccable/scripts/context.mjs
+++ b/.vibe/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/.vibe/skills/impeccable/scripts/generate-image.mjs
+++ b/.vibe/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/plugin/skills/impeccable/scripts/context.mjs
+++ b/plugin/skills/impeccable/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/plugin/skills/impeccable/scripts/generate-image.mjs
+++ b/plugin/skills/impeccable/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -1267,13 +1267,21 @@ function automaticHookMode(ctx) {
 
 
 // Image generation availability: harness-native tools always win, but when the
-// environment carries an OpenAI key the API fallback works everywhere. The
-// flag only reports capability, positively: absence stays silent, because a
-// "none" line reads as "no visualization anywhere" and suppresses the
-// harness's own image tools.
+// environment carries an OpenAI key (or a MiniMax key, for the image-01 path)
+// the API fallback works everywhere. The flag only reports capability,
+// positively: absence stays silent, because a "none" line reads as "no
+// visualization anywhere" and suppresses the harness's own image tools.
 function appendImageGenDirective(parts) {
-  if (!process.env.OPENAI_API_KEY) return;
+  if (!process.env.OPENAI_API_KEY && !process.env.MINIMAX_API_KEY) return;
   const scriptsPath = path.dirname(fileURLToPath(import.meta.url));
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) {
+    parts.push([
+      'IMAGE_GEN_AVAILABLE: A MiniMax key is present, so image generation works even without a harness-native image tool:',
+      `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file> --provider minimax\` (image-01, billed to the user's key; say so before the first render).`,
+      'Prefer the harness-native image tool when one exists. Visualizing a direction before building it measurably strengthens the result.',
+    ].join(' '));
+    return;
+  }
   parts.push([
     'IMAGE_GEN_AVAILABLE: An OpenAI key is present, so image generation works even without a harness-native image tool:',
     `\`node ${scriptsPath}/generate-image.mjs --prompt "..." --out <file>\` (gpt-image-2, billed to the user's key; say so before the first render).`,

--- a/skill/scripts/generate-image.mjs
+++ b/skill/scripts/generate-image.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * API image generation fallback: renders a mock or world board with the
- * user's own OpenAI key when the harness has no native image generation.
+ * user's own API key when the harness has no native image generation.
  *
- * context.mjs reports availability (it checks OPENAI_API_KEY); harness-native
- * generation always wins when present. This uses gpt-image-2 and spends the
- * user's API credit (roughly $0.05-0.25 per image at default quality), so the
- * skill states that before the first call in a session.
+ * context.mjs reports availability (it checks OPENAI_API_KEY, or
+ * MINIMAX_API_KEY for the MiniMax image-01 path); harness-native
+ * generation always wins when present. The OpenAI path uses gpt-image-2 and
+ * spends the user's API credit (roughly $0.05-0.25 per image at default
+ * quality). The MiniMax path calls the /v1/image_generation endpoint with
+ * image-01 and returns either a URL or base64; the skill states the cost
+ * before the first call in a session.
  *
  *   node generate-image.mjs --prompt "..." --out mock.png [--size 1536x1024] [--quality medium]
  *   node generate-image.mjs --prompt-file prompt.txt --out mock.png
+ *   node generate-image.mjs --prompt "..." --out mock.png --provider minimax [--aspect-ratio 16:9] [--model image-01]
  */
 import fs from 'node:fs';
 import zlib from 'node:zlib';
@@ -24,7 +28,7 @@ function arg(name, fallback = null) {
 // ---------------------------------------------------------------------------
 // Fake mode (IMPECCABLE_IMAGE_GEN_FAKE=1)
 //
-// Deterministic offline stand-in for the OpenAI call: same prompt -> identical
+// Deterministic offline stand-in for the API call: same prompt -> identical
 // bytes, no network, no key, cost line reads $0.00. Used by the new-work smoke
 // suite so the concept/serve-question/image chain can run without spend. The
 // output renders the prompt over a 2-3 color palette hashed from the prompt,
@@ -198,11 +202,133 @@ if (process.env.IMPECCABLE_IMAGE_GEN_FAKE) {
   process.exit(0);
 }
 
-const key = process.env.OPENAI_API_KEY;
-if (!key) {
-  console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
-  process.exit(1);
+// Provider dispatch. The OpenAI path (default) uses gpt-image-2 and bills the
+// user's OpenAI key. The MiniMax path calls /v1/image_generation with the
+// image-01 model and bills the user's MiniMax key; it accepts an explicit
+// aspect ratio or width/height, and the response can return either image URLs
+// or base64 strings. The CN endpoint variant (api.minimaxi.com) is selected by
+// setting IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh; the default is the global
+// endpoint (api.minimax.io).
+const MINIMAX_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/image_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/image_generation',
+};
+const MINIMAX_MODELS = ['image-01', 'image-01-live'];
+const MINIMAX_ASPECT_RATIOS = ['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9'];
+
+function resolveProvider() {
+  const explicit = arg('provider');
+  if (explicit) return String(explicit).toLowerCase();
+  if (process.env.MINIMAX_API_KEY && !process.env.OPENAI_API_KEY) return 'minimax';
+  return 'openai';
 }
+
+function selectMinimaxEndpoint() {
+  const region = process.env.IMPECCABLE_IMAGE_GEN_MINIMAX_REGION || 'global_en';
+  return MINIMAX_ENDPOINTS[region] || MINIMAX_ENDPOINTS.global_en;
+}
+
+async function generateWithMinimax({ prompt, out }) {
+  const key = process.env.MINIMAX_API_KEY;
+  if (!key) {
+    console.error('generate-image: MINIMAX_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const model = arg('model', 'image-01');
+  if (!MINIMAX_MODELS.includes(model)) {
+    console.error(`generate-image: invalid --model "${model}". Valid: ${MINIMAX_MODELS.join(', ')}.`);
+    process.exit(1);
+  }
+  const aspectRatio = arg('aspect-ratio');
+  const widthArg = arg('width');
+  const heightArg = arg('height');
+  const responseFormat = arg('response-format', 'url');
+  const n = Number(arg('n', '1'));
+  const seed = arg('seed');
+  const promptOptimizer = arg('prompt-optimizer');
+
+  const body = { model, prompt };
+  if (aspectRatio) {
+    if (!MINIMAX_ASPECT_RATIOS.includes(aspectRatio)) {
+      console.error(`generate-image: invalid --aspect-ratio "${aspectRatio}". Valid: ${MINIMAX_ASPECT_RATIOS.join(', ')}.`);
+      process.exit(1);
+    }
+    body.aspect_ratio = aspectRatio;
+  }
+  if (widthArg && heightArg) {
+    const w = Number(widthArg);
+    const h = Number(heightArg);
+    if (!Number.isInteger(w) || !Number.isInteger(h) || w < 512 || w > 2048 || h < 512 || h > 2048 || w % 8 !== 0 || h % 8 !== 0) {
+      console.error('generate-image: --width and --height must be integers in [512, 2048] divisible by 8, set together.');
+      process.exit(1);
+    }
+    body.width = w;
+    body.height = h;
+  }
+  body.response_format = responseFormat;
+  if (n >= 1 && n <= 9) body.n = n;
+  if (seed !== null) body.seed = Number(seed);
+  if (promptOptimizer !== null) body.prompt_optimizer = String(promptOptimizer).toLowerCase() === 'true';
+
+  const response = await fetch(selectMinimaxEndpoint(), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || json?.base_resp?.status_code !== undefined && json.base_resp.status_code !== 0) {
+    const status = json?.base_resp?.status_code ?? response.status;
+    const msg = json?.base_resp?.status_msg ?? '';
+    console.error(`generate-image: MiniMax API error ${status}: ${(msg || JSON.stringify(json)).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const imageUrls = json?.data?.image_urls;
+  const imageBase64 = json?.data?.image_base64;
+  const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : null;
+  const firstB64 = Array.isArray(imageBase64) ? imageBase64[0] : null;
+  if (firstUrl) {
+    const imgResponse = await fetch(firstUrl);
+    if (!imgResponse.ok) {
+      console.error(`generate-image: failed to fetch generated image URL (${imgResponse.status})`);
+      process.exit(1);
+    }
+    const arrayBuffer = await imgResponse.arrayBuffer();
+    fs.writeFileSync(out, Buffer.from(arrayBuffer));
+  } else if (firstB64) {
+    fs.writeFileSync(out, Buffer.from(firstB64, 'base64'));
+  } else {
+    console.error('generate-image: no image in MiniMax response');
+    process.exit(1);
+  }
+  return { model, responseFormat, aspectRatio: aspectRatio || `${body.width || ''}x${body.height || ''}` };
+}
+
+async function generateWithOpenai({ prompt, out, size, quality }) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error('generate-image: OPENAI_API_KEY is not set; use the harness-native image tool instead.');
+    process.exit(1);
+  }
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
+  });
+  if (!response.ok) {
+    console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  const json = await response.json();
+  const b64 = json?.data?.[0]?.b64_json;
+  if (!b64) {
+    console.error('generate-image: no image in response');
+    process.exit(1);
+  }
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  return { model: 'gpt-image-2', size, quality };
+}
+
+const provider = resolveProvider();
 const promptFile = arg('prompt-file');
 const prompt = promptFile ? fs.readFileSync(promptFile, 'utf8') : arg('prompt');
 const out = arg('out');
@@ -213,28 +339,23 @@ if (!prompt || !out) {
 const size = arg('size', '1536x1024');
 const quality = arg('quality', 'medium');
 
-const response = await fetch('https://api.openai.com/v1/images/generations', {
-  method: 'POST',
-  headers: { Authorization: `Bearer ${key}`, 'content-type': 'application/json' },
-  body: JSON.stringify({ model: 'gpt-image-2', prompt, size, quality, n: 1 }),
-});
-if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
-  process.exit(1);
+let providerInfo;
+if (provider === 'minimax') {
+  providerInfo = await generateWithMinimax({ prompt, out });
+} else {
+  providerInfo = await generateWithOpenai({ prompt, out, size, quality });
 }
-const json = await response.json();
-const b64 = json?.data?.[0]?.b64_json;
-if (!b64) {
-  console.error('generate-image: no image in response');
-  process.exit(1);
-}
-fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+const { model: usedModel } = providerInfo;
 // The prompt travels with the asset: embedded in the file itself (EXIF-class
 // metadata via embed-prompt.mjs) so intent survives copies across harnesses,
 // plus a sidecar for anything that indexes rather than opens the image.
 try {
   const { spawnSync } = await import('node:child_process');
   spawnSync(process.execPath, [new URL('./embed-prompt.mjs', import.meta.url).pathname, out, '--prompt', prompt], { stdio: 'ignore' });
-  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: 'gpt-image-2' }, null, 2));
+  fs.writeFileSync(`${out}.json`, JSON.stringify({ prompt, createdAt: new Date().toISOString(), tool: 'generate-image.mjs', model: usedModel }, null, 2));
 } catch { /* embedding is best-effort */ }
-console.log(`IMAGE: ${out} (${size}, ${quality}, gpt-image-2, billed to your OpenAI key); prompt embedded + sidecar at ${out}.json`);
+const providerTag = provider === 'minimax'
+  ? `minimax ${usedModel}${providerInfo.aspectRatio ? `, ${providerInfo.aspectRatio}` : ''}`
+  : `${size}, ${quality}, gpt-image-2`;
+const keyTag = provider === 'minimax' ? 'MiniMax key' : 'OpenAI key';
+console.log(`IMAGE: ${out} (${providerTag}, billed to your ${keyTag}); prompt embedded + sidecar at ${out}.json`);


### PR DESCRIPTION
Reason: Extend the API image-generation fallback with MiniMax image-01/image-01-live support through the global and CN /v1/image_generation endpoints, including MiniMax request fields and URL/base64 response parsing; the current tool only supports OpenAI gpt-image-2.

## Changes

Adds a MiniMax provider path to `skill/scripts/generate-image.mjs` alongside the existing OpenAI fallback, and reports it from `skill/scripts/context.mjs`:

- **Provider dispatch**: `--provider minimax` selects the MiniMax path explicitly; when only `MINIMAX_API_KEY` is set (and `OPENAI_API_KEY` is absent) it auto-selects. The OpenAI path remains the default when its key is present, so existing behavior is unchanged.
- **MiniMax endpoint selection**: calls `https://api.minimax.io/v1/image_generation` (global) by default, or `https://api.minimaxi.com/v1/image_generation` (CN) when `IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh`.
- **Request fields**: sends `model` (validated against `image-01` / `image-01-live`), `prompt`, `aspect_ratio` (validated against the documented set), `width`/`height` (validated to be in [512, 2048] and divisible by 8), `response_format` (`url` or `base64`, default `url`), `n`, `seed`, and `prompt_optimizer`.
- **Response parsing**: reads `data.image_urls` (downloads the first URL to the output file) or `data.image_base64` (decodes the first base64 string), and treats a non-zero `base_resp.status_code` as an error with the status message.
- **Availability directive**: `context.mjs` now emits an `IMAGE_GEN_AVAILABLE` line when `MINIMAX_API_KEY` is present (and no OpenAI key), pointing at the MiniMax invocation.
- **Synced copies**: the source files under `skill/scripts/` are mirrored to all generated harness skill directories (`.agents`, `.claude`, `.cursor`, `.gemini`, `.github`, `.grok`, `.kiro`, `.opencode`, `.pi`, `.qoder`, `.rovodev`, `.trae`, `.trae-cn`, `.vibe`, `plugin`), matching the existing build sync.

## Checks

- `node --check skill/scripts/generate-image.mjs` and `node --check skill/scripts/context.mjs` (syntax).
- Fake image-generation tests (`IMPECCABLE_IMAGE_GEN_FAKE=1`): deterministic bytes, SYNTHETIC marker, SVG variant, per-prompt palette divergence - 12 assertions pass.
- `node --test tests/context.test.mjs` - 98 tests pass, 0 fail.
- Manual validation of MiniMax error paths: missing key, invalid model, invalid aspect ratio, invalid width/height all exit with a clear message and non-zero status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional provider path; OpenAI remains default when both keys exist. No auth or core app logic changes—only skill CLI scripts and env-gated external API calls.
> 
> **Overview**
> Adds **MiniMax** as a second API fallback for `generate-image.mjs`, alongside the existing OpenAI `gpt-image-2` path, mirrored across all harness skill copies.
> 
> `generate-image.mjs` now **dispatches by provider**: default stays OpenAI when `OPENAI_API_KEY` is set; `--provider minimax` or **only** `MINIMAX_API_KEY` selects MiniMax `image-01` / `image-01-live` against global or CN `/v1/image_generation` (`IMPECCABLE_IMAGE_GEN_MINIMAX_REGION=cn_zh`). MiniMax supports validated aspect ratio, width/height, response format (URL fetch vs base64), and related request fields; sidecar/logging reflect the model used.
> 
> `context.mjs` **IMAGE_GEN_AVAILABLE** now fires when either key is present, with a MiniMax-specific directive when OpenAI is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c4c1e1feb9ba3f15c33a2f5b7317ce28be3287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->