### PR TITLE
Fix Pi provider display name

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -56,7 +56,7 @@ const PROVIDER_DISPLAY = {
   '.grok': { name: 'Grok Build', input: 'grok' },
   '.kiro': { name: 'Kiro', input: 'kiro' },
   '.opencode': { name: 'OpenCode', input: 'opencode' },
-  '.pi': { name: 'Project Indigo', input: 'pi' },
+  '.pi': { name: 'Pi Coding Agent', input: 'pi' },
   '.qoder': { name: 'Qoder', input: 'qoder' },
   '.rovodev': { name: 'Rovo Dev', input: 'rovo-dev' },
   '.trae': { name: 'Trae', input: 'trae' },

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -737,13 +737,21 @@ describe('skills install/update: local universal bundle e2e', () => {
         installRoot: home,
         installPath: join(home, '.agents', 'skills'),
       },
+      {
+        provider: '.pi',
+        scope: 'user',
+        foundPath: join(home, '.pi'),
+        installRoot: home,
+        installPath: join(home, '.pi', 'agent', 'skills'),
+      },
     ];
 
     const lines = formatInstallDetectionLines(tmp, detections, home);
     expect(lines).toEqual([
       'Detected harnesses:',
-      '  Claude Code  ~/.claude',
-      '  Codex CLI    ~/.codex',
+      '  Claude Code      ~/.claude',
+      '  Codex CLI        ~/.codex',
+      '  Pi Coding Agent  ~/.pi',
     ]);
 
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Rename the `.pi` provider display label from the obsolete “Project Indigo” name to “Pi Coding Agent”.
- Cover Pi in the detected-harness formatting test so the user-facing label cannot regress.

Fixes #442.

## Validation

- `bun test tests/skills-cli.test.js` — 67 passed, 8 skipped, 0 failed.

Generated provider output was not refreshed; this is a CLI display-name change only.

## AI assistance

Implemented and validated with Codex under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI label and test expectations only; no install logic or paths change.
> 
> **Overview**
> **Renames the `.pi` harness label** shown during `impeccable skills install` from “Project Indigo” to **“Pi Coding Agent”** in `PROVIDER_DISPLAY` (install prompts, harness lists, and related CLI copy). Install paths and behavior are unchanged.
> 
> **Extends the `formatInstallDetectionLines` test** to include a user-level `.pi` detection and locks in the aligned column layout (`Claude Code`, `Codex CLI`, `Pi Coding Agent` with padded names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1132e7fff0b08c29be984055d32d086f83fad38f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->