### PR TITLE
Fix critique ignore file tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ src/__impeccable_provider_smoke_*.html
 # Per-run critique snapshots are local artifacts. ignore.md (also under
 # this dir) carries deferrals the user may want to share, so it's
 # explicitly re-included below.
-.impeccable/critique/
+.impeccable/critique/*
 !.impeccable/critique/ignore.md
 
 # Legacy live mode session file + annotation screenshots


### PR DESCRIPTION
## Summary

- Ignore the contents of `.impeccable/critique/` instead of excluding the directory itself.
- Keep `.impeccable/critique/ignore.md` reachable by Git’s negation rule while per-run critique snapshots remain ignored.

Fixes #437.

## Validation

- `git check-ignore --no-index --quiet .impeccable/critique/ignore.md` returns not ignored.
- A timestamped critique snapshot remains ignored.
- `git diff --check` passes.

Generated provider output was not refreshed; this changes only repository hygiene.

## AI assistance

Implemented and validated with Codex under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `.gitignore` hygiene change with no runtime or application code impact.
> 
> **Overview**
> **Fixes critique ignore-file tracking** by changing `.gitignore` from `.impeccable/critique/` to `.impeccable/critique/*`.
> 
> Ignoring the directory itself prevented Git from applying the existing `!.impeccable/critique/ignore.md` exception, so shared deferral lists could not be tracked. Per-run snapshot files under that folder remain ignored; only `ignore.md` is meant to be committable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d95cddc54c4f99e09614333b57c320ecd5008b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->