### PR TITLE
Fix Google Fonts ignore-value suppression

### DIFF
--- a/cli/lib/impeccable-config.mjs
+++ b/cli/lib/impeccable-config.mjs
@@ -529,6 +529,9 @@ function extractFindingIgnoreValueRaw(finding, rule = normalizeIgnoreRule(findin
     const primary = text.match(/Primary font:\s*([^()\n;]+)/i);
     if (primary) return cleanIgnoreValueDisplay(primary[1]);
 
+    const googleLabel = text.match(/Google Fonts:\s*([^()\n;]+)/i);
+    if (googleLabel) return cleanIgnoreValueDisplay(googleLabel[1]);
+
     const family = text.match(/font-family\s*:\s*["']?([^'",;\n]+)/i);
     if (family) return cleanIgnoreValueDisplay(family[1]);
 

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -880,6 +880,9 @@ function extractFindingIgnoreValueRaw(finding, rule = normalizeIgnoreRule(findin
     const primary = text.match(/Primary font:\s*([^()\n;]+)/i);
     if (primary) return cleanIgnoreValueDisplay(primary[1]);
 
+    const googleLabel = text.match(/Google Fonts:\s*([^()\n;]+)/i);
+    if (googleLabel) return cleanIgnoreValueDisplay(googleLabel[1]);
+
     const family = text.match(/font-family\s*:\s*["']?([^'",;\n]+)/i);
     if (family) return cleanIgnoreValueDisplay(family[1]);
 

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -470,6 +470,7 @@ describe('filterFindings()', () => {
     const findings = [
       finding('overused-font', 1, { snippet: 'Primary font: Inter (86% of text)' }),
       finding('overused-font', 2, { snippet: 'Primary font: Roboto' }),
+      finding('overused-font', 5, { snippet: 'Google Fonts: space grotesk' }),
       finding('bounce-easing', 3, { snippet: 'animation: bounce-ball' }),
       finding('bounce-easing', 4, { snippet: 'animation: wobble-card' }),
       finding('side-tab', 3),
@@ -478,6 +479,7 @@ describe('filterFindings()', () => {
       ignoreRules: [],
       ignoreValues: [
         { rule: 'overused-font', value: 'inter' },
+        { rule: 'overused-font', value: 'space grotesk' },
         { rule: 'bounce-easing', value: 'bounce-ball' },
       ],
       minSeverity: 'warning',
@@ -573,6 +575,10 @@ describe('filterFindings()', () => {
     assert.equal(
       extractFindingIgnoreValue(finding('overused-font', 1, { snippet: 'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400' })),
       'plus jakarta sans',
+    );
+    assert.equal(
+      extractFindingIgnoreValue(finding('overused-font', 1, { snippet: 'Google Fonts: space grotesk' })),
+      'space grotesk',
     );
     assert.equal(extractFindingIgnoreValue(finding('side-tab', 1)), '');
   });

--- a/tests/lib/impeccable-config.test.js
+++ b/tests/lib/impeccable-config.test.js
@@ -182,6 +182,7 @@ describe('cli/lib/impeccable-config', () => {
       { antipattern: 'design-system-color', file: join(root, 'src', 'demo.css'), line: 3, ignoreValue: '#8b5cf6' },
       { antipattern: 'design-system-color', file: join(root, 'src', 'real.css'), line: 4, ignoreValue: '#8b5cf6' },
       { antipattern: 'design-system-font', file: join(root, 'src', 'demo.css'), line: 5, ignoreValue: 'Avenir Next' },
+      { antipattern: 'overused-font', file: join(root, 'src', 'fonts.css'), line: 6, snippet: 'Google Fonts: space grotesk' },
     ];
     const filtered = filterDetectionFindings(findings, {
       ignoreRules: [],
@@ -189,6 +190,7 @@ describe('cli/lib/impeccable-config', () => {
         { rule: 'overused-font', value: 'avenir next' },
         { rule: 'design-system-color', value: '*', files: ['src/demo.css'] },
         { rule: 'design-system-font', value: '*' },
+        { rule: 'overused-font', value: 'space grotesk' },
       ],
     });
 
@@ -236,6 +238,7 @@ describe('cli/lib/impeccable-config', () => {
   test('extractFindingIgnoreValue handles fonts, Google font URLs, and motion snippets', () => {
     expect(extractFindingIgnoreValue({ antipattern: 'overused-font', snippet: 'Primary font: Avenir Next (80% of text)' })).toBe('avenir next');
     expect(extractFindingIgnoreValue({ antipattern: 'overused-font', snippet: 'https://fonts.googleapis.com/css2?family=Alumni+Sans:wght@700' })).toBe('alumni sans');
+    expect(extractFindingIgnoreValue({ antipattern: 'overused-font', snippet: 'Google Fonts: space grotesk' })).toBe('space grotesk');
     expect(extractFindingIgnoreValue({ antipattern: 'bounce-easing', snippet: 'animation: bounce-ball 1s infinite' })).toBe('bounce-ball');
   });
 


### PR DESCRIPTION
## Summary

- Extract values from the normalized `Google Fonts: <family>` finding shape in both the CLI and hook config paths.
- Verify that one `ignoreValues` entry suppresses the Google Fonts import finding as well as the CSS `font-family` finding.

Fixes #443.

## Root cause

The detector had already reduced the Google Fonts URL to a label, but the ignore-value extractor only understood raw `family=` URLs, `Primary font:`, and `font-family:` snippets. The label therefore produced an empty value and could never match configuration.

## Validation

- `bun run build`
- `bun test tests/hook.test.mjs tests/lib/impeccable-config.test.js` — 218 passed, 0 failed.

Generated root harness output was intentionally omitted per repository policy.

## AI assistance

Implemented and validated with Codex under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mirrored change to ignore-value parsing plus tests; no auth, security, or data-path changes.
> 
> **Overview**
> **`ignoreValues` for `overused-font` now works when findings use the normalized `Google Fonts: <family>` snippet**, not only `Primary font:`, `font-family:`, or raw `family=` URLs.
> 
> The ignore-value extractor gains a **`Google Fonts:`** regex branch in **`cli/lib/impeccable-config.mjs`** and **`skill/scripts/hook-lib.mjs`** (kept in sync), so configured waivers like `space grotesk` match and filter those findings in CLI detect and the design hook alike.
> 
> Tests cover extraction and **`ignoreValues`** filtering for the new shape in **`tests/hook.test.mjs`** and **`tests/lib/impeccable-config.test.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c418978840de8fedaa114387111686344210b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->