### PR TITLE
Fix rounded-none border accent false positive

### DIFF
--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -12,7 +12,8 @@ import { profileFindings, profileStep } from '../../profile/profiler.mjs';
 // Regex fallback (non-HTML files: CSS, JSX, TSX, etc.)
 // ---------------------------------------------------------------------------
 
-const hasRounded = (line) => /\brounded(?:-\w+)?\b/.test(line);
+const hasRounded = (line) =>
+  /\brounded(?:-\w+)?\b/.test(line.replace(/\brounded-none\b/g, ''));
 const hasBorderRadius = (line) => /border-radius/i.test(line);
 const isSafeElement = (line) => /<(?:blockquote|nav[\s>]|pre[\s>]|code[\s>]|a\s|input[\s>]|span[\s>])/i.test(line);
 

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -199,6 +199,22 @@ describe('detectText — Tailwind side-tab', () => {
     const f = detectText('<div class="border-t-4 border-b-4">', 'test.html');
     expect(f.filter(r => r.antipattern === 'border-accent-on-rounded')).toHaveLength(0);
   });
+
+  test('ignores border accent paired with rounded-none', () => {
+    const f = detectText(
+      '<TabsTrigger className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary" />',
+      'test.tsx',
+    );
+    expect(f.filter(r => r.antipattern === 'border-accent-on-rounded')).toHaveLength(0);
+  });
+
+  test('still detects a real rounded token alongside rounded-none', () => {
+    const f = detectText(
+      '<div className="rounded-none md:rounded-lg border-b-2 border-primary" />',
+      'test.tsx',
+    );
+    expect(f.some(r => r.antipattern === 'border-accent-on-rounded')).toBe(true);
+  });
 });
 
 describe('detectText — CSS borders', () => {


### PR DESCRIPTION
## Summary

- Exclude Tailwind’s `rounded-none` utility when the regex detector decides whether an element is rounded.
- Preserve detection when a genuine rounded utility is also present, including responsive variants.

Fixes #424.

## Root cause

The broad `rounded(?:-\w+)?` matcher treated `rounded-none` as evidence of rounded corners, so ordinary underline tabs were reported as rounded-card border accents.

## Validation

- `bun run build:browser`
- `bun run build:extension`
- `bun run build`
- `bun run test` — full core, detector/browser, live-mode, and framework fixture suites passed.

Generated root harness output was intentionally omitted per repository policy; the required browser and extension rebuilds produced no tracked generated diff.

## AI assistance

Implemented and validated with Codex under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small heuristic change in regex fallback detection with targeted tests; no auth, data, or API surface.
> 
> **Overview**
> Fixes **false positives** on `border-accent-on-rounded` (and related **side-tab** thresholds) when Tailwind classes include **`rounded-none`** alongside top/bottom border accents—common on underline tab triggers.
> 
> The regex engine’s **`hasRounded`** helper now **strips `rounded-none`** from the line before matching `rounded*` utilities, so square tabs are no longer treated as rounded cards. **Real rounded classes** (e.g. responsive `md:rounded-lg`) still count when present on the same line.
> 
> Tests cover tab-style `rounded-none` + `border-b-*` (no flag) and mixed `rounded-none` + `md:rounded-lg` (still flagged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872c032582ea6474bb3467c99bf83bd0512086e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->