### PR TITLE
Fix: skip POSIX hook guard on Windows installs (#452)

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -1329,25 +1329,38 @@ function hookScriptPathForProvider(skillRoot, provider) {
 // the agent. POSIX-shell form, consistent with the project's other hook
 // commands (e.g. the GitHub manifest's `$(git rev-parse ...)`).
 //
-// On Windows that guard is a hard failure, not a degraded one: Codex runs hook
-// commands through PowerShell, which rejects `[` at parse time ("Missing type
-// name after '['") before node ever starts, so the hook dies even when the
-// file exists (issue #452). No shell-level guard syntax parses in PowerShell,
-// cmd.exe, and sh alike, so a Windows install moves the existence check into
-// node itself: a `node -e` wrapper that exits 0 when the target is missing and
-// otherwise re-spawns node on it with inherited stdio, forwarding the hook's
-// exit code. Project hook manifests (.codex/hooks.json, .cursor/hooks.json)
-// are committable and can be consumed on a teammate's POSIX machine, so the
-// wrapper has to hold there too: it uses only characters that survive
-// PowerShell, cmd.exe (issue #445: shims re-parse through `cmd /C`, which
-// claims < > | & ^ % !), and sh double-quoting alike, with single quotes for
-// the inner string literals. Note PowerShell's `-Command` mode collapses any
-// nonzero native exit code to 1, which equally affects a bare `node "PATH"`;
-// the wrapper preserves exact codes wherever the shell does.
+// On Windows that guard is a hard failure, not a degraded one (issue #452).
+// Codex runs hook commands through COMSPEC (`cmd.exe /C`), where `[` is not a
+// command: the guard errors noisily and `||` then runs node even when the file
+// is missing, trading the silent no-op for a MODULE_NOT_FOUND crash. Two
+// remedies, by provider:
+//
+//   * Codex manifests support a `commandWindows` sibling that Codex 0.146.0+
+//     selects on Windows (`command_windows.unwrap_or(command)` in its hook
+//     discovery). rewriteHookCommandsForSkillRoot adds it with a cmd.exe
+//     `if exist` guard (form contributed and Windows-tested by @PatrickSys in
+//     issue #452; `exit /b` forwards node's errorlevel), so the same
+//     .codex/hooks.json is correct on every OS no matter where it was
+//     written, and `command` stays the plain POSIX guard.
+//   * Claude and Cursor manifests have no per-platform field, so a Windows
+//     install moves the existence check into node itself: a `node -e` wrapper
+//     that exits 0 when the target is missing and otherwise re-spawns node on
+//     it with inherited stdio, forwarding the hook's exit code. Cursor's
+//     hooks.json is committable and can be consumed on a teammate's POSIX
+//     machine, so the wrapper has to hold there too: it uses only characters
+//     that survive PowerShell, cmd.exe (issue #445: shims re-parse through
+//     `cmd /C`, which claims < > | & ^ % !), and sh double-quoting alike,
+//     with single quotes for the inner string literals.
 const WIN32_HOOK_GUARD_SCRIPT = "const p=process.argv[1];const f=require('fs');if(f.existsSync(p)){const r=require('child_process').spawnSync(process.execPath,[p],{stdio:'inherit'});process.exit(r.status===null?1:r.status);}";
 
-function guardHookCommand(quotedPath) {
-  if (process.platform === 'win32') {
+function windowsHookCommand(quotedPath) {
+  return `if exist ${quotedPath} (node ${quotedPath} & exit /b)`;
+}
+
+function guardHookCommand(quotedPath, provider) {
+  // `.agents` (Codex) keeps the POSIX form unconditionally: its Windows
+  // consumers read the commandWindows sibling instead.
+  if (provider !== '.agents' && process.platform === 'win32') {
     return `node -e "${WIN32_HOOK_GUARD_SCRIPT}" ${quotedPath}`;
   }
   return `[ ! -f ${quotedPath} ] || node ${quotedPath}`;
@@ -1362,25 +1375,24 @@ function guardHookCommand(quotedPath) {
 //   * otherwise — keep the bundle's own ${CLAUDE_PROJECT_DIR}-relative path,
 //     which correctly resolves for a project-scoped install.
 // Either way the command goes through guardHookCommand (POSIX shell guard, or
-// the shell-agnostic node -e guard when installing on Windows).
+// the shell-agnostic node -e guard when installing on Windows), and Codex hook
+// entries additionally get a `commandWindows` sibling for cmd.exe.
 function rewriteHookCommandsForSkillRoot(value, provider, { skillRoot, absolute }) {
   const hookScript = hookScriptPathForProvider(skillRoot, provider);
   // Providers we don't own a `node "PATH"` command hook for (.github, .grok)
   // carry their own portable command forms; leave them untouched.
   if (!hookScript) return value;
 
+  // Project-scope installs derive the provider's own project-relative path
+  // rather than trusting the bundle token, which for Codex points at
+  // `.codex/skills/...` while the CLI installs the skill at `.agents/skills/`.
+  const quotedPath = absolute
+    ? JSON.stringify(hookScript)
+    : JSON.stringify(hookScriptRelPathForProvider(provider));
+
   if (typeof value === 'string') {
     if (!valueHasImpeccableHookMarker(value)) return value;
-    let quotedPath;
-    if (absolute) {
-      quotedPath = JSON.stringify(hookScript);
-    } else {
-      // Project-scope install: derive the provider's own project-relative path
-      // rather than trusting the bundle token, which for Codex points at
-      // `.codex/skills/...` while the CLI installs the skill at `.agents/skills/`.
-      quotedPath = JSON.stringify(hookScriptRelPathForProvider(provider));
-    }
-    return guardHookCommand(quotedPath);
+    return guardHookCommand(quotedPath, provider);
   }
   if (Array.isArray(value)) {
     return value.map(item => rewriteHookCommandsForSkillRoot(item, provider, { skillRoot, absolute }));
@@ -1389,6 +1401,9 @@ function rewriteHookCommandsForSkillRoot(value, provider, { skillRoot, absolute 
     const next = {};
     for (const [key, child] of Object.entries(value)) {
       next[key] = rewriteHookCommandsForSkillRoot(child, provider, { skillRoot, absolute });
+    }
+    if (provider === '.agents' && typeof value.command === 'string' && valueHasImpeccableHookMarker(value.command)) {
+      next.commandWindows = windowsHookCommand(quotedPath);
     }
     return next;
   }

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -1332,14 +1332,24 @@ function hookScriptPathForProvider(skillRoot, provider) {
 // On Windows that guard is a hard failure, not a degraded one: Codex runs hook
 // commands through PowerShell, which rejects `[` at parse time ("Missing type
 // name after '['") before node ever starts, so the hook dies even when the
-// file exists (issue #452). No guard syntax parses in PowerShell, cmd.exe, and
-// sh alike, so a Windows install emits the direct `node "PATH"` invocation the
-// bundled plugin manifests already use. Trade-off accepted with the issue: a
-// stale path then surfaces as a node resolution error instead of a silent
-// no-op. The manifest is machine-local (written by this install run on this
-// machine), so selecting the form by the installing platform is sound.
+// file exists (issue #452). No shell-level guard syntax parses in PowerShell,
+// cmd.exe, and sh alike, so a Windows install moves the existence check into
+// node itself: a `node -e` wrapper that exits 0 when the target is missing and
+// otherwise re-spawns node on it with inherited stdio, forwarding the hook's
+// exit code. Project hook manifests (.codex/hooks.json, .cursor/hooks.json)
+// are committable and can be consumed on a teammate's POSIX machine, so the
+// wrapper has to hold there too: it uses only characters that survive
+// PowerShell, cmd.exe (issue #445: shims re-parse through `cmd /C`, which
+// claims < > | & ^ % !), and sh double-quoting alike, with single quotes for
+// the inner string literals. Note PowerShell's `-Command` mode collapses any
+// nonzero native exit code to 1, which equally affects a bare `node "PATH"`;
+// the wrapper preserves exact codes wherever the shell does.
+const WIN32_HOOK_GUARD_SCRIPT = "const p=process.argv[1];const f=require('fs');if(f.existsSync(p)){const r=require('child_process').spawnSync(process.execPath,[p],{stdio:'inherit'});process.exit(r.status===null?1:r.status);}";
+
 function guardHookCommand(quotedPath) {
-  if (process.platform === 'win32') return `node ${quotedPath}`;
+  if (process.platform === 'win32') {
+    return `node -e "${WIN32_HOOK_GUARD_SCRIPT}" ${quotedPath}`;
+  }
   return `[ ! -f ${quotedPath} ] || node ${quotedPath}`;
 }
 
@@ -1351,8 +1361,8 @@ function guardHookCommand(quotedPath) {
 //     when a project hook points at a skill installed elsewhere (--scope=global).
 //   * otherwise — keep the bundle's own ${CLAUDE_PROJECT_DIR}-relative path,
 //     which correctly resolves for a project-scoped install.
-// Either way the command goes through guardHookCommand (missing-file guard on
-// POSIX platforms, direct node invocation on Windows).
+// Either way the command goes through guardHookCommand (POSIX shell guard, or
+// the shell-agnostic node -e guard when installing on Windows).
 function rewriteHookCommandsForSkillRoot(value, provider, { skillRoot, absolute }) {
   const hookScript = hookScriptPathForProvider(skillRoot, provider);
   // Providers we don't own a `node "PATH"` command hook for (.github, .grok)

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -1328,7 +1328,18 @@ function hookScriptPathForProvider(skillRoot, provider) {
 // code when the file exists, so Claude's exit-2 blocking signal still reaches
 // the agent. POSIX-shell form, consistent with the project's other hook
 // commands (e.g. the GitHub manifest's `$(git rev-parse ...)`).
+//
+// On Windows that guard is a hard failure, not a degraded one: Codex runs hook
+// commands through PowerShell, which rejects `[` at parse time ("Missing type
+// name after '['") before node ever starts, so the hook dies even when the
+// file exists (issue #452). No guard syntax parses in PowerShell, cmd.exe, and
+// sh alike, so a Windows install emits the direct `node "PATH"` invocation the
+// bundled plugin manifests already use. Trade-off accepted with the issue: a
+// stale path then surfaces as a node resolution error instead of a silent
+// no-op. The manifest is machine-local (written by this install run on this
+// machine), so selecting the form by the installing platform is sound.
 function guardHookCommand(quotedPath) {
+  if (process.platform === 'win32') return `node ${quotedPath}`;
   return `[ ! -f ${quotedPath} ] || node ${quotedPath}`;
 }
 
@@ -1340,7 +1351,8 @@ function guardHookCommand(quotedPath) {
 //     when a project hook points at a skill installed elsewhere (--scope=global).
 //   * otherwise — keep the bundle's own ${CLAUDE_PROJECT_DIR}-relative path,
 //     which correctly resolves for a project-scoped install.
-// Either way the command is wrapped with the missing-file guard.
+// Either way the command goes through guardHookCommand (missing-file guard on
+// POSIX platforms, direct node invocation on Windows).
 function rewriteHookCommandsForSkillRoot(value, provider, { skillRoot, absolute }) {
   const hookScript = hookScriptPathForProvider(skillRoot, provider);
   // Providers we don't own a `node "PATH"` command hook for (.github, .grok)


### PR DESCRIPTION
Fixes #452.

`npx impeccable install` wrote the POSIX `[ ! -f ... ] ||` guard into hook commands, which breaks under the shells Windows harnesses use (Codex runs hooks through COMSPEC / `cmd.exe /C`). Two changes in `guardHookCommand()` / `rewriteHookCommandsForSkillRoot()`:

- Codex entries always get a `commandWindows` sibling with a cmd.exe `if exist` guard (Codex 0.146.0+ selects it on Windows), while `command` keeps the plain POSIX guard. One `.codex/hooks.json` is correct on every OS regardless of where the install ran. Guard form contributed and Windows-tested by @PatrickSys in #452.
- Claude and Cursor manifests have no per-platform field, so Windows installs emit a shell-agnostic `node -e` existence guard instead of the POSIX form: silent exit 0 when the hook file is missing, exit code forwarded when present, and only characters that survive PowerShell, cmd.exe, and sh alike.

Validated by simulating Windows installs (faked `process.platform`, project and global scope) and running the generated commands in PowerShell 7.6.4 and POSIX sh, with the hook file present and missing. macOS `command` output is byte-identical; `tests/skills-cli.test.js` passes. Generated provider output intentionally untouched.

AI assistance was used for the reproduction and fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only hook command strings written at install/update time; behavior is platform-specific but scoped to manifest generation, with no auth or data-path changes.
> 
> **Overview**
> Fixes **#452**: the POSIX `[ ! -f ... ] || node` hook guard breaks on Windows (Codex via `cmd.exe`, noisy errors and wrong behavior when the hook file is missing).
> 
> **Codex (`.agents`)** — Hook entries now get a **`commandWindows`** sibling with `if exist … (node … & exit /b)` while **`command`** stays POSIX, so one `.codex/hooks.json` works on every OS.
> 
> **Claude and Cursor** — On Windows installs, **`guardHookCommand`** emits a **`node -e`** wrapper that no-ops if the script is missing and forwards the hook exit code when present, using characters safe across PowerShell, cmd, and POSIX shells.
> 
> `rewriteHookCommandsForSkillRoot` centralizes quoted path computation and passes **`provider`** into the guard logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0059804fb81ea737dc22686a8d1858bfcfd5e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->