### PR TITLE
fix(live): scan JSX comment variant markers; never whole-file-inject raw JSX (#454)

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6210,14 +6210,34 @@
         const parser = new DOMParser();
         let srcWrapper = null;
 
-        // Full-file parse works for HTML/JSX; Astro/Vue sources need marker extraction.
-        const startMark = '<!-- impeccable-variants-start ' + sessionId + ' -->';
-        const endMark = '<!-- impeccable-variants-end ' + sessionId + ' -->';
-        const startIdx = html.indexOf(startMark);
-        const endIdx = html.indexOf(endMark);
-        const block = startIdx !== -1 && endIdx !== -1 && endIdx > startIdx
-          ? html.slice(startIdx + startMark.length, endIdx).trim()
-          : html;
+        // Marker comments differ by source syntax: HTML/Astro/Vue wrappers use
+        // <!-- ... -->, while JSX/TSX wrappers must use {/* ... */} (an HTML
+        // comment is invalid inside a JSX element tree), so scan for both.
+        // Never fall back to whole-file injection for JSX: raw JSX renders
+        // {expressions} and marker text as literal page content (#454).
+        const markerPairs = [
+          { open: '<!--', close: '-->' },
+          { open: '{/*', close: '*/}' },
+        ];
+        let block = null;
+        for (const pair of markerPairs) {
+          const startMark = pair.open + ' impeccable-variants-start ' + sessionId + ' ' + pair.close;
+          const endMark = pair.open + ' impeccable-variants-end ' + sessionId + ' ' + pair.close;
+          const startIdx = html.indexOf(startMark);
+          const endIdx = html.indexOf(endMark);
+          if (startIdx !== -1 && endIdx > startIdx) {
+            block = html.slice(startIdx + startMark.length, endIdx).trim();
+            break;
+          }
+        }
+        if (block == null) {
+          if (/\.[cm]?[jt]sx$/i.test(String(filePath || ''))) {
+            console.warn('[impeccable] JSX source has no variant markers; skipping raw-source injection (#454).');
+            block = '';
+          } else {
+            block = html;
+          }
+        }
         const doc = parser.parseFromString(normalizeSourceFallbackBlock(block, filePath), 'text/html');
         srcWrapper = doc.querySelector('[data-impeccable-variants="' + sessionId + '"]');
         if (!srcWrapper) {
@@ -6341,6 +6361,9 @@
   function normalizeSourceFallbackBlock(block, filePath) {
     if (!/\.[cm]?[jt]sx$/i.test(String(filePath || ''))) return block;
     return String(block)
+      // JSX comments ({/* ... */}) are not HTML comments; strip them so they
+      // don't render as literal text in the DOMParser preview (#454).
+      .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, '')
       .replace(
         /<style\b([^>]*)>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style>/g,
         (_match, attrs, css) => '<style' + attrs + '>' + css + '</style>',

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6203,6 +6203,47 @@
       return;
     }
     rememberSessionFileMeta({ file: filePath });
+    // JSX sources: if the framework already re-rendered the wrapper (Vite full
+    // reload / Fast Refresh), adopt the live DOM tree instead of replacing it
+    // with a DOMParser clone — a clone renders JSX {expressions} as literal
+    // text and detaches React from its own nodes (#454).
+    const jsxDomWrapper = /\.[cm]?[jt]sx$/i.test(String(filePath || ''))
+      ? document.querySelector('[data-impeccable-variants="' + sessionId + '"]')
+      : null;
+    if (jsxDomWrapper) {
+      const wrapper = jsxDomWrapper;
+      recoveryWaitingForAnchor = false;
+      if (pendingVariantAnchorRetryObserver) {
+        pendingVariantAnchorRetryObserver.disconnect();
+        pendingVariantAnchorRetryObserver = null;
+      }
+      const variants = wrapper.querySelectorAll('[data-impeccable-variant]:not([data-impeccable-variant="original"])');
+      arrivedVariants = variants.length;
+      expectedVariants = parseInt(wrapper.dataset.impeccableVariantCount || arrivedVariants);
+      if (arrivedVariants <= 0) {
+        if (state === 'GENERATING' && !opts.generationCompleted) return;
+        recoverEmptyCycling('jsx-dom-adopt-empty');
+        return;
+      }
+      const previousVisibleVariant = currentSessionId === sessionId ? visibleVariant : 0;
+      const saved = loadSession();
+      const savedVisibleVariant = saved && saved.id === sessionId ? saved.visible : 0;
+      visibleVariant = previousVisibleVariant > 0 && previousVisibleVariant <= arrivedVariants
+        ? previousVisibleVariant
+        : (savedVisibleVariant > 0 && savedVisibleVariant <= arrivedVariants ? savedVisibleVariant : 1);
+      showVariantInDOM(sessionId, visibleVariant);
+      selectedElement = pickVariantContent(wrapper, visibleVariant) || wrapper.parentElement;
+      setLiveState('CYCLING');
+      hideShaderOverlay();
+      showOrUpdateCyclingBar();
+      disableInlineEdit();
+      refreshParamsPanel();
+      positionBar();
+      saveSession();
+      if (parameterGenerationState === 'loading') completeParameterPublication();
+      console.log('[impeccable] Adopted ' + arrivedVariants + ' variants from live DOM (JSX).');
+      return;
+    }
     const url = 'http://localhost:' + PORT + '/source?token=' + TOKEN + '&path=' + encodeURIComponent(filePath);
     fetch(url)
       .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })
@@ -6220,6 +6261,7 @@
           { open: '{/*', close: '*/}' },
         ];
         let block = null;
+        let jsxPairMatched = false;
         for (const pair of markerPairs) {
           const startMark = pair.open + ' impeccable-variants-start ' + sessionId + ' ' + pair.close;
           const endMark = pair.open + ' impeccable-variants-end ' + sessionId + ' ' + pair.close;
@@ -6227,8 +6269,14 @@
           const endIdx = html.indexOf(endMark);
           if (startIdx !== -1 && endIdx > startIdx) {
             block = html.slice(startIdx + startMark.length, endIdx).trim();
+            jsxPairMatched = pair.open === '{/*';
             break;
           }
+        }
+        if (jsxPairMatched && block) {
+          // JSX wrappers carry their markers INSIDE the wrapper div, so the
+          // extracted block lacks the wrapper element; synthesize it (#454).
+          block = '<div data-impeccable-variants="' + sessionId + '" style="display: contents">' + block + '</div>';
         }
         if (block == null) {
           if (/\.[cm]?[jt]sx$/i.test(String(filePath || ''))) {


### PR DESCRIPTION
Fixes #454.

## Problem

`injectVariantsFromSource()` scans only for HTML comment markers, but `live-wrap.mjs` necessarily emits **JSX comment markers** (`{/* impeccable-variants-start ID */}`) inside JSX/TSX wrappers (line ~322; an HTML comment is invalid in a JSX element tree). On React targets the scan always misses, so the no-HMR fallback injects the **entire raw source file**, rendering `{expressions}` and marker text as literal page content.

## Fix (kept minimal)

1. Scan both marker syntaxes (`<!-- -->` and `{/* */}`) before falling back.
2. For `.jsx/.tsx` sources with no markers, treat it like a missing wrapper (existing recovery/orphan path) instead of whole-file injection — raw JSX can never render correctly, so recovery is strictly better than showing source text. HTML behavior is unchanged.
3. `normalizeSourceFallbackBlock`: strip JSX comments so `{/* Original */}` etc. don't render as text in the DOMParser preview.

## Testing

- `node --check` passes.
- Marker-scan logic unit-tested standalone: HTML markers (unchanged), JSX markers (now found), JSX-no-marker (empty block → recovery), HTML-no-marker (whole file, unchanged), `.tsx` covered.
- Reproduced the original symptom on a Vite 6 + React 18 app (raw `{liste.length}` on screen) before the patch; described in #454.

Not run: `bun run build` / live-e2e (no bun locally) — happy to iterate if CI flags the generated outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live cycling injection path for JSX/React, but behavior is narrowly scoped to marker parsing and adoption with existing recovery retries preserved.
> 
> **Overview**
> Fixes **React/JSX live variant injection** when the no-HMR source fallback runs: the browser no longer treats raw `.jsx`/`.tsx` as injectable HTML or misses JSX-only variant markers.
> 
> For JSX/TSX, **`injectVariantsFromSource`** now **adopts an existing live DOM wrapper** (after Vite reload / Fast Refresh) instead of cloning a `DOMParser` preview, which previously showed `{expressions}` as literal text and broke React’s tree (#454).
> 
> When fetching source, variant blocks are found via **both** `<!-- ... -->` and `{/* ... */}` markers; JSX blocks get a **synthesized wrapper** when markers sit inside the element tree. **Unmarked JSX** skips whole-file injection and uses the existing empty/orphan recovery path; HTML unmarked behavior is unchanged. **`normalizeSourceFallbackBlock`** also strips JSX comments from DOMParser previews so comment markers do not render as visible text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d501c644ea799083c8a95894f1f356e8694d35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->