### PR TITLE
Fix DESIGN.md frontmatter coverage

### DIFF
--- a/skill/scripts/lib/staleness-deep.mjs
+++ b/skill/scripts/lib/staleness-deep.mjs
@@ -117,6 +117,15 @@ export function checkDesignDrift({ designPath, projectRoot, threshold = 25 }) {
  * a section can be absent because it never applied, so this is reported as a
  * documentation gap for a human to judge, never as an error.
  */
+function hasCoverageValue(value) {
+  if (Array.isArray(value)) return value.some(hasCoverageValue);
+  if (value && typeof value === 'object') {
+    return Object.values(value).some(hasCoverageValue);
+  }
+  if (typeof value === 'string') return value.trim().length > 0;
+  return value !== null && value !== undefined;
+}
+
 export function checkDesignCoverage({ design, designPath, parseDesignMd }) {
   if (!design || typeof parseDesignMd !== 'function') return [];
   let model;
@@ -126,7 +135,7 @@ export function checkDesignCoverage({ design, designPath, parseDesignMd }) {
     return [];
   }
   const missing = ['colors', 'typography', 'components']
-    .filter((section) => !model[section] && !model.frontmatter?.[section]);
+    .filter((section) => !model[section] && !hasCoverageValue(model.frontmatter?.[section]));
   if (!missing.length) return [];
   return [finding({
     id: 'design-md-coverage',

--- a/skill/scripts/lib/staleness-deep.mjs
+++ b/skill/scripts/lib/staleness-deep.mjs
@@ -126,7 +126,7 @@ export function checkDesignCoverage({ design, designPath, parseDesignMd }) {
     return [];
   }
   const missing = ['colors', 'typography', 'components']
-    .filter((section) => !model[section]);
+    .filter((section) => !model[section] && !model.frontmatter?.[section]);
   if (!missing.length) return [];
   return [finding({
     id: 'design-md-coverage',

--- a/skill/scripts/lib/staleness-deep.mjs
+++ b/skill/scripts/lib/staleness-deep.mjs
@@ -122,7 +122,10 @@ function hasCoverageValue(value) {
   if (value && typeof value === 'object') {
     return Object.values(value).some(hasCoverageValue);
   }
-  if (typeof value === 'string') return value.trim().length > 0;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 && !/^(?:\[\s*\]|\{\s*\})$/.test(trimmed);
+  }
   return false;
 }
 

--- a/skill/scripts/lib/staleness-deep.mjs
+++ b/skill/scripts/lib/staleness-deep.mjs
@@ -123,7 +123,7 @@ function hasCoverageValue(value) {
     return Object.values(value).some(hasCoverageValue);
   }
   if (typeof value === 'string') return value.trim().length > 0;
-  return value !== null && value !== undefined;
+  return false;
 }
 
 export function checkDesignCoverage({ design, designPath, parseDesignMd }) {

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -216,6 +216,29 @@ describe('checkDesignCoverage', () => {
     assert.doesNotMatch(findings[0].summary, /typography|components/);
   });
 
+  it('does not count boolean or numeric frontmatter scalars as section coverage', () => {
+    for (const colors of ['false', '0']) {
+      const design = [
+        '---',
+        'name: X',
+        `colors: ${colors}`,
+        'typography:',
+        '  body:',
+        '    fontFamily: Inter',
+        'components:',
+        '  button:',
+        '    backgroundColor: "#111111"',
+        '---',
+        '',
+        '# Design System: X',
+        '',
+      ].join('\n');
+      const findings = checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd });
+      assert.deepEqual(ids(findings), ['design-md-coverage']);
+      assert.match(findings[0].summary, /no colors section/);
+    }
+  });
+
   it('reports nothing without a DESIGN.md', () => {
     assert.deepEqual(checkDesignCoverage({ design: null, parseDesignMd }), []);
   });

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -239,6 +239,44 @@ describe('checkDesignCoverage', () => {
     }
   });
 
+  it('does not count empty frontmatter collection literals as section coverage', () => {
+    for (const colors of ['[]', '{}']) {
+      const design = [
+        '---',
+        'name: X',
+        `colors: ${colors}`,
+        'typography:',
+        '  body:',
+        '    fontFamily: Inter',
+        'components:',
+        '  button:',
+        '    backgroundColor: "#111111"',
+        '---',
+        '',
+        '# Design System: X',
+        '',
+      ].join('\n');
+      const findings = checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd });
+      assert.deepEqual(ids(findings), ['design-md-coverage']);
+      assert.match(findings[0].summary, /no colors section/);
+    }
+  });
+
+  it('counts populated frontmatter array literals as section coverage', () => {
+    const design = [
+      '---',
+      'name: X',
+      'colors: ["#111111"]',
+      'typography: [Inter]',
+      'components: [button]',
+      '---',
+      '',
+      '# Design System: X',
+      '',
+    ].join('\n');
+    assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
+  });
+
   it('reports nothing without a DESIGN.md', () => {
     assert.deepEqual(checkDesignCoverage({ design: null, parseDesignMd }), []);
   });

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -194,6 +194,28 @@ describe('checkDesignCoverage', () => {
     assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
   });
 
+  it('does not count empty frontmatter mappings as section coverage', () => {
+    const design = [
+      '---',
+      'name: X',
+      'colors:',
+      'typography:',
+      '  body:',
+      '    fontFamily: Inter',
+      'components:',
+      '  button:',
+      '    backgroundColor: "#111111"',
+      '---',
+      '',
+      '# Design System: X',
+      '',
+    ].join('\n');
+    const findings = checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd });
+    assert.deepEqual(ids(findings), ['design-md-coverage']);
+    assert.match(findings[0].summary, /no colors section/);
+    assert.doesNotMatch(findings[0].summary, /typography|components/);
+  });
+
   it('reports nothing without a DESIGN.md', () => {
     assert.deepEqual(checkDesignCoverage({ design: null, parseDesignMd }), []);
   });

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -172,6 +172,28 @@ describe('checkDesignCoverage', () => {
     assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
   });
 
+  it('counts machine-readable frontmatter as section coverage', () => {
+    const design = [
+      '---',
+      'name: X',
+      'colors:',
+      '  ink: "#111111"',
+      'typography:',
+      '  body:',
+      '    fontFamily: Inter',
+      'components:',
+      '  button:',
+      '    backgroundColor: "{colors.ink}"',
+      '---',
+      '',
+      '# Design System: X',
+      '',
+      'See the canonical source for prose guidance.',
+      '',
+    ].join('\n');
+    assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
+  });
+
   it('reports nothing without a DESIGN.md', () => {
     assert.deepEqual(checkDesignCoverage({ design: null, parseDesignMd }), []);
   });


### PR DESCRIPTION
Closes #436.

## Summary

- Count machine-readable `colors`, `typography`, and `components` frontmatter as valid `DESIGN.md` coverage in `doctor.mjs`.
- Preserve the existing markdown-body section behavior.
- Add a regression test for a frontmatter-only design record.

## User impact

Projects that keep canonical design tokens in `DESIGN.md` frontmatter no longer receive a contradictory `design-md-coverage` warning asking them to duplicate those values in prose sections.

## Reproduction

Before this change, a `DESIGN.md` with populated frontmatter for all three sections still emitted `design-md-coverage` naming `colors`, `typography`, and `components` as absent. The new regression test reproduces that input shape and now stays quiet.

## Validation

- `node --test tests/doctor.test.mjs`
- `bun run build`
- `bun run test`

## Generated output

Generated provider and root harness output was intentionally omitted. The source-first build completed successfully with `--skip-root-sync`, as required for feature PRs.

## AI assistance

AI assistance was used to triage and reproduce the issue, implement the focused fix, add regression coverage, run validation, and prepare this pull request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to doctor staleness heuristics and tests; no auth, data, or runtime hook paths affected.
> 
> **Overview**
> Fixes **false `design-md-coverage` warnings** when canonical design tokens live in `DESIGN.md` YAML frontmatter instead of `## Colors`, `## Typography`, and `## Components` prose.
> 
> `checkDesignCoverage` in `staleness-deep.mjs` now treats a section as covered if either the parsed markdown section exists **or** `model.frontmatter[section]` passes a new `hasCoverageValue` check (non-empty strings, nested objects/arrays with real content; empty mappings, `[]`/`{}` string literals, and boolean/numeric scalars do not count).
> 
> Regression tests in `doctor.test.mjs` cover frontmatter-only records, partial empties, and edge-case scalar/collection literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f274ca2c013a04cdafe8498661f2155ac0d0ed88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->