### PR TITLE
feat: add Oh My Pi (omp) provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ git add .gitmodules .impeccable .claude .cursor
 git commit -m "Add Impeccable skills"
 ```
 
-Use the providers your project needs, for example `claude`, `cursor`, `gemini`, `codex`, `github`, `grok`, `opencode`, `pi`, `qoder`, `trae`, `trae-cn`, `rovo-dev`, or `vibe`. The command links individual skill folders from `.impeccable/dist/universal/` and leaves existing real skill directories untouched unless you pass `--force`.
+Use the providers your project needs, for example `claude`, `cursor`, `gemini`, `codex`, `github`, `grok`, `opencode`, `omp`, `pi`, `qoder`, `trae`, `trae-cn`, `rovo-dev`, or `vibe`. The command links individual skill folders from `.impeccable/dist/universal/` and leaves existing real skill directories untouched unless you pass `--force`.
 
 To update later:
 

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -603,7 +603,7 @@ async function copyOrExtractLocalBundle(sourceValue) {
  */
 function normalizeForHash(content) {
   return content
-    .replace(/\.(claude|cursor|agents|github|gemini|codex|grok|kiro|opencode|pi|qoder|trae|trae-cn|rovodev|vibe)\/skills\//g, '.PROVIDER/skills/');
+    .replace(/\.(claude|cursor|agents|github|gemini|codex|grok|kiro|opencode|omp|pi|qoder|trae|trae-cn|rovodev|vibe)\/skills\//g, '.PROVIDER/skills/');
 }
 
 function hashSkillFile(filePath) {

--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -23,7 +23,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const API_BASE = 'https://impeccable.style';
 
 // Provider folder names in project roots
-const PROVIDER_DIRS = ['.claude', '.cursor', '.gemini', '.agents', '.github', '.grok', '.kiro', '.opencode', '.pi', '.qoder', '.trae', '.trae-cn', '.rovodev', '.vibe'];
+const PROVIDER_DIRS = ['.claude', '.cursor', '.gemini', '.agents', '.github', '.grok', '.kiro', '.omp', '.opencode', '.pi', '.qoder', '.trae', '.trae-cn', '.rovodev', '.vibe'];
 const PROVIDER_ALIASES = {
   agents: '.agents',
   claude: '.claude',
@@ -38,6 +38,8 @@ const PROVIDER_ALIASES = {
   xai: '.grok',
   kiro: '.kiro',
   opencode: '.opencode',
+  omp: '.omp',
+  'oh-my-pi': '.omp',
   pi: '.pi',
   qoder: '.qoder',
   'rovo-dev': '.rovodev',
@@ -55,6 +57,7 @@ const PROVIDER_DISPLAY = {
   '.github': { name: 'GitHub Copilot', input: 'github' },
   '.grok': { name: 'Grok Build', input: 'grok' },
   '.kiro': { name: 'Kiro', input: 'kiro' },
+  '.omp': { name: 'Oh My Pi', input: 'omp' },
   '.opencode': { name: 'OpenCode', input: 'opencode' },
   '.pi': { name: 'Pi Coding Agent', input: 'pi' },
   '.qoder': { name: 'Qoder', input: 'qoder' },
@@ -63,7 +66,7 @@ const PROVIDER_DISPLAY = {
   '.trae-cn': { name: 'Trae CN', input: 'trae-cn' },
   '.vibe': { name: 'Mistral Vibe', input: 'vibe' },
 };
-const PROVIDER_INPUT_ORDER = ['claude', 'codex', 'cursor', 'gemini', 'github', 'grok', 'kiro', 'opencode', 'pi', 'qoder', 'trae', 'trae-cn', 'rovo-dev', 'vibe'];
+const PROVIDER_INPUT_ORDER = ['claude', 'codex', 'cursor', 'gemini', 'github', 'grok', 'kiro', 'omp', 'opencode', 'pi', 'qoder', 'trae', 'trae-cn', 'rovo-dev', 'vibe'];
 
 // OpenCode reads global skills from its config directory, not ~/.opencode:
 // $OPENCODE_CONFIG_DIR, else $XDG_CONFIG_HOME/opencode, else
@@ -80,6 +83,7 @@ function opencodeGlobalConfigDir(home) {
 // ~/.pi/agent/skills/ (issue #327); OpenCode from its config dir (issue
 // #406). Project scope stays `<provider>/skills` for both.
 const HOME_SKILLS_DIR_OVERRIDES = {
+  '.omp': (home) => join(home, '.omp', 'agent', 'skills'),
   '.pi': (home) => join(home, '.pi', 'agent', 'skills'),
   '.opencode': (home) => join(opencodeGlobalConfigDir(home), 'skills'),
 };
@@ -95,6 +99,7 @@ const GLOBAL_HARNESS_HINTS = [
   { home: '.grok', provider: '.grok' },
   { home: '.kiro', provider: '.kiro' },
   { home: '.opencode', provider: '.opencode' },
+  { home: '.omp', provider: '.omp' },
   // OpenCode's real global config dir (issue #406); the ~/.opencode entry
   // above keeps recognizing machines that only have the legacy dir.
   { resolve: opencodeGlobalConfigDir, provider: '.opencode' },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -470,6 +470,7 @@ This folder contains skills for all supported tools:
   .grok/      -> Grok Build
   .kiro/      -> Kiro
   .opencode/  -> OpenCode
+  .omp/       -> Oh My Pi (omp)
   .pi/        -> Pi
   .trae-cn/   -> Trae China
   .trae/      -> Trae International

--- a/scripts/lib/transformers/index.js
+++ b/scripts/lib/transformers/index.js
@@ -13,6 +13,7 @@ export const transformGitHub = createTransformer(PROVIDERS.github);
 export const transformKiro = createTransformer(PROVIDERS.kiro);
 export const transformOpenCode = createTransformer(PROVIDERS.opencode);
 export const transformPi = createTransformer(PROVIDERS.pi);
+export const transformOmp = createTransformer(PROVIDERS.omp);
 export const transformQoder = createTransformer(PROVIDERS.qoder);
 export const transformRovoDev = createTransformer(PROVIDERS['rovo-dev']);
 export const transformVibe = createTransformer(PROVIDERS.vibe);

--- a/scripts/lib/transformers/providers.js
+++ b/scripts/lib/transformers/providers.js
@@ -102,6 +102,13 @@ export const PROVIDERS = {
     displayName: 'Pi',
     frontmatterFields: ['license', 'compatibility', 'metadata', 'allowed-tools'],
   },
+  omp: {
+    provider: 'omp',
+    providerTags: ['omp'],
+    configDir: '.omp',
+    displayName: 'Oh My Pi',
+    frontmatterFields: ['license', 'compatibility', 'metadata', 'allowed-tools'],
+  },
   qoder: {
     provider: 'qoder',
     providerTags: ['qoder'],

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -610,6 +610,12 @@ export const PROVIDER_PLACEHOLDERS = {
     ask_instruction: 'ask the user directly to clarify what you cannot infer.',
     command_prefix: '/'
   },
+  'omp': {
+    model: 'the model',
+    config_file: 'AGENTS.md',
+    ask_instruction: 'ask the user directly to clarify what you cannot infer.',
+    command_prefix: '/'
+  },
   'qoder': {
     model: 'the model',
     config_file: 'AGENTS.md',
@@ -653,6 +659,7 @@ export const PROVIDER_BLOCK_TAGS = new Set([
   'grok',
   'kiro',
   'opencode',
+  'omp',
   'pi',
   'qoder',
   'rovo-dev',

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -65,6 +65,7 @@ describe('build orchestration', () => {
     const transformClaudeCodeSpy = spyOn(transformers, 'transformClaudeCode').mockImplementation(() => {});
     const transformGeminiSpy = spyOn(transformers, 'transformGemini').mockImplementation(() => {});
     const transformCodexSpy = spyOn(transformers, 'transformCodex').mockImplementation(() => {});
+    const transformOmpSpy = spyOn(transformers, 'transformOmp').mockImplementation(() => {});
 
     const ROOT_DIR = TEST_DIR;
     const DIST_DIR = path.join(ROOT_DIR, 'dist');
@@ -75,11 +76,13 @@ describe('build orchestration', () => {
     transformers.transformClaudeCode(sourceFiles.skills, DIST_DIR, patternData);
     transformers.transformGemini(sourceFiles.skills, DIST_DIR, patternData);
     transformers.transformCodex(sourceFiles.skills, DIST_DIR, patternData);
+    transformers.transformOmp(sourceFiles.skills, DIST_DIR, patternData);
 
     expect(transformCursorSpy).toHaveBeenCalledWith(skills, DIST_DIR, patterns);
     expect(transformClaudeCodeSpy).toHaveBeenCalledWith(skills, DIST_DIR, patterns);
     expect(transformGeminiSpy).toHaveBeenCalledWith(skills, DIST_DIR, patterns);
     expect(transformCodexSpy).toHaveBeenCalledWith(skills, DIST_DIR, patterns);
+    expect(transformOmpSpy).toHaveBeenCalledWith(skills, DIST_DIR, patterns);
 
     readSourceFilesSpy.mockRestore();
     readPatternsSpy.mockRestore();
@@ -87,6 +90,7 @@ describe('build orchestration', () => {
     transformClaudeCodeSpy.mockRestore();
     transformGeminiSpy.mockRestore();
     transformCodexSpy.mockRestore();
+    transformOmpSpy.mockRestore();
   });
 
   test('should handle empty source files', () => {
@@ -101,6 +105,7 @@ describe('build orchestration', () => {
     const transformClaudeCodeSpy = spyOn(transformers, 'transformClaudeCode').mockImplementation(() => {});
     const transformGeminiSpy = spyOn(transformers, 'transformGemini').mockImplementation(() => {});
     const transformCodexSpy = spyOn(transformers, 'transformCodex').mockImplementation(() => {});
+    const transformOmpSpy = spyOn(transformers, 'transformOmp').mockImplementation(() => {});
 
     const ROOT_DIR = TEST_DIR;
     const DIST_DIR = path.join(ROOT_DIR, 'dist');
@@ -111,11 +116,13 @@ describe('build orchestration', () => {
     transformers.transformClaudeCode(skills, DIST_DIR, patternData);
     transformers.transformGemini(skills, DIST_DIR, patternData);
     transformers.transformCodex(skills, DIST_DIR, patternData);
+    transformers.transformOmp(skills, DIST_DIR, patternData);
 
     expect(transformCursorSpy).toHaveBeenCalledWith([], DIST_DIR, patterns);
     expect(transformClaudeCodeSpy).toHaveBeenCalledWith([], DIST_DIR, patterns);
     expect(transformGeminiSpy).toHaveBeenCalledWith([], DIST_DIR, patterns);
     expect(transformCodexSpy).toHaveBeenCalledWith([], DIST_DIR, patterns);
+    expect(transformOmpSpy).toHaveBeenCalledWith([], DIST_DIR, patterns);
 
     readSourceFilesSpy.mockRestore();
     readPatternsSpy.mockRestore();
@@ -123,6 +130,7 @@ describe('build orchestration', () => {
     transformClaudeCodeSpy.mockRestore();
     transformGeminiSpy.mockRestore();
     transformCodexSpy.mockRestore();
+    transformOmpSpy.mockRestore();
   });
 
   test('integration: full build creates all expected outputs', () => {


### PR DESCRIPTION
## Summary

Add Oh My Pi (omp) as a supported provider in both the CLI install/update workflow and the build system transformer pipeline.

## Motivation

omp already inherits skills from `.claude`, `.cursor`, `.codex`, etc. on first run, but adding direct support makes the Impeccable skill available to anyone with omp installed, regardless of other providers.

## Changes

- **CLI (`skills.mjs`)**: Register `.omp` in provider directories, aliases, display names, input order, global skills path (`~/.omp/agent/skills/`), and harness detection.
- **Build system**: Add `omp` provider config, `transformOmp` export, universal ZIP README entry, and `PROVIDER_BLOCK_TAGS` registration for future `<omp>` conditional blocks.
- **Placeholders**: Map omp to `AGENTS.md` config file with standard ask/command behavior matching `.pi`.
- **Tests**: Add `transformOmp` spy to build test assertions.

## Notes

omp's skill layout mirrors Pi's (`~/.omp/agent/skills/` for global, `.omp/skills/` for project). No hook artifacts or agent files are needed — omp has no native hook lifecycle or sub-agent markdown format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Provider-registry and build-pipeline additions only; no auth, hooks, or runtime behavior changes outside new omp install paths.
> 
> **Overview**
> Adds **Oh My Pi (`omp`)** as a full provider alongside Pi-style skill layouts: project skills under `.omp/skills/`, global skills under `~/.omp/agent/skills/`.
> 
> **CLI (`skills.mjs`)** registers `.omp` in provider lists, aliases (`omp`, `oh-my-pi`), display name, install order, global skills path override, and harness auto-detection. Skill hash normalization now treats `.omp/skills/` paths like other providers.
> 
> **Build pipeline** adds an `omp` provider config (`.omp` config dir, `omp` conditional blocks), `transformOmp`, placeholder mapping (`AGENTS.md`, same ask/command behavior as Pi), and lists `.omp` in the universal bundle README.
> 
> **Docs** mention `omp` in the submodule `link` provider example.
> 
> No hook manifests or sub-agent formats are added for omp in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd17e749f4f0678e3ef9f99638c8cffc1e7d5fa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->