### PR TITLE
Warn when static HTML parser dependencies are unavailable

### DIFF
--- a/cli/engine/engines/static-html/detect-html.mjs
+++ b/cli/engine/engines/static-html/detect-html.mjs
@@ -138,9 +138,20 @@ async function detectHtml(filePath, options = {}) {
         domutils,
       };
     });
-  } catch {
-    return detectText(html, filePath, options);
+  } catch (err) {
+  if (!globalThis.__impeccableStaticHtmlWarned) {
+    globalThis.__impeccableStaticHtmlWarned = true;
+
+    process.stderr.write(
+  'impeccable detect: DEGRADED - HTML parser modules unavailable ' +
+  '(htmlparser2, css-select, css-tree, domutils).\n' +
+  'Falling back to regex matching. Custom properties, selector matching and computed ' +
+  'contrast are NOT evaluated; findings are an undercount, not a clean bill of health.\n'
+);
   }
+
+  return detectText(html, filePath, options);
+}
 
   const resolvedPath = path.resolve(filePath);
   const fileDir = path.dirname(resolvedPath);


### PR DESCRIPTION
## Summary

This PR adds a warning when the static HTML parser dependencies (`htmlparser2`, `css-select`, `css-tree`, and `domutils`) cannot be loaded.

Previously, the detector silently fell back to regex-based detection, which could make users believe a full HTML scan had completed successfully. With this change, the detector clearly warns that it is running in a degraded mode before falling back to `detectText()`.

## Changes

* Added a one-time warning when the static HTML parser modules cannot be imported.
* Preserved the existing fallback to `detectText()`.
* The warning explains that regex-based detection is being used and that the results may be incomplete.

## Verification

* Reproduced the skill-install scenario without `package.json` and `node_modules`.
* Confirmed the warning is printed when the parser modules are unavailable.
* Verified that the detector still falls back to `detectText()` without crashing.
* Successfully built the project using `npm run build:skills`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to stderr messaging on an already-existing fallback path; no change to full-parser success behavior.
> 
> **Overview**
> When `htmlperrser2`, `css-select`, `css-tree`, or `domutils` cannot be imported, **`detectHtml` no longer fails silently** into regex mode. It writes a **one-time** message to stderr (`impeccable detect: DEGRADED - …`) that names the missing stack, states that results are an undercount, and notes that custom properties, selector matching, and computed contrast are skipped.
> 
> The existing **`detectText()` fallback is unchanged**; only visibility for users (e.g. skill installs without `node_modules`) is improved via `globalThis.__impeccableStaticHtmlWarned`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dcf6db5d042ce15a2629817e240401fec145cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->