### PR TITLE
Simplify curated pattern loading

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -362,22 +362,9 @@ export function writeFile(filePath, content) {
   fs.writeFileSync(filePath, content, 'utf-8');
 }
 
-/**
- * Extract DO/DON'T patterns from a skill markdown file, grouped by section
- * (h3 `### ` headings). Recognizes both formats:
- *   - Markdown bullet form:  `**DO**: …`  /  `**DON'T**: …`
- *   - Prose form:            `DO …`       /  `DO NOT …`
- *
- * Defaults to the main impeccable SKILL.md but accepts any relative path so
- * rules in `cli/engine/detect-antipatterns.mjs` can anchor to register-specific
- * reference files (e.g. `reference/editorial.md`) via an optional `skillFile`
- * field. Callers that don't pass `relativePath` get the legacy behavior.
- *
- * Returns { patterns: [...], antipatterns: [...] }
- */
-// Curated short-list for the homepage Antidote section. Intentionally
-// hand-written (not auto-extracted) so the copy stays tight and
-// editorial. The long-form catalog lives on /slop — this is the teaser.
+// Curated short-list for the homepage Antidote section. This intentionally
+// stays independent of repository content so the copy remains tight and
+// editorial.
 const CURATED_CATEGORIES = [
   {
     name: 'Typography',
@@ -459,103 +446,10 @@ const CURATED_CATEGORIES = [
 ];
 
 export function readPatterns(_rootDir, _relativePath) {
-  // Hand-curated list — see CURATED_CATEGORIES above. The homepage
-  // Antidote teaser uses this; the full catalog lives on /slop.
   return {
     patterns: CURATED_CATEGORIES.map((c) => ({ name: c.name, items: c.do })),
     antipatterns: CURATED_CATEGORIES.map((c) => ({ name: c.name, items: c.dont })),
   };
-}
-
-// Previous SKILL.md parser retained below but disabled; kept as a
-// reference for how prefix-style extraction used to work.
-function _legacyReadPatterns(rootDir, relativePath = 'skill/SKILL.src.md') {
-  const skillPath = path.join(rootDir, relativePath);
-
-  if (!fs.existsSync(skillPath)) {
-    return { patterns: [], antipatterns: [] };
-  }
-
-  const content = fs.readFileSync(skillPath, 'utf-8');
-  const lines = content.split('\n');
-
-  const patternsMap = {};  // category -> items[]
-  const antipatternsMap = {};  // category -> items[]
-  let currentSection = null;
-
-  const pushPattern = (item) => {
-    if (!currentSection) return;
-    if (!patternsMap[currentSection]) patternsMap[currentSection] = [];
-    patternsMap[currentSection].push(item);
-  };
-  const pushAntipattern = (item) => {
-    if (!currentSection) return;
-    if (!antipatternsMap[currentSection]) antipatternsMap[currentSection] = [];
-    antipatternsMap[currentSection].push(item);
-  };
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    // Track section headings (### Typography, ### Color & Theme, etc.)
-    if (trimmed.startsWith('### ')) {
-      currentSection = trimmed.slice(4).trim();
-      // Normalize "Color & Theme" to "Color & Contrast" for consistency
-      if (currentSection === 'Color & Theme') {
-        currentSection = 'Color & Contrast';
-      }
-      continue;
-    }
-
-    // Markdown bullet form (legacy): **DO**: ... and **DON'T**: ...
-    if (trimmed.startsWith('**DO**:')) {
-      pushPattern(trimmed.slice(7).trim());
-      continue;
-    }
-    if (trimmed.startsWith("**DON'T**:")) {
-      pushAntipattern(trimmed.slice(10).trim());
-      continue;
-    }
-
-    // XML-block prose form (current). Both space and colon variants:
-    //   "DO NOT use ..."  /  "DO NOT: Use ..."
-    //   "DO use ..."      /  "DO: Use ..."
-    // IMPORTANT: check `DO NOT` BEFORE `DO` so the prefix doesn't get
-    // gobbled by the wrong matcher.
-    if (trimmed.startsWith('DO NOT: ')) {
-      pushAntipattern(trimmed.slice('DO NOT: '.length).trim());
-      continue;
-    }
-    if (trimmed.startsWith('DO NOT ')) {
-      pushAntipattern(trimmed.slice('DO NOT '.length).trim());
-      continue;
-    }
-    if (trimmed.startsWith('DO: ')) {
-      pushPattern(trimmed.slice('DO: '.length).trim());
-      continue;
-    }
-    if (trimmed.startsWith('DO ')) {
-      pushPattern(trimmed.slice('DO '.length).trim());
-      continue;
-    }
-  }
-
-  // Convert maps to arrays in consistent order
-  const sectionOrder = ['Typography', 'Color & Contrast', 'Layout & Space', 'Visual Details', 'Motion', 'Interaction', 'Responsive', 'UX Writing'];
-
-  const patterns = [];
-  const antipatterns = [];
-
-  for (const section of sectionOrder) {
-    if (patternsMap[section] && patternsMap[section].length > 0) {
-      patterns.push({ name: section, items: patternsMap[section] });
-    }
-    if (antipatternsMap[section] && antipatternsMap[section].length > 0) {
-      antipatterns.push({ name: section, items: antipatternsMap[section] });
-    }
-  }
-
-  return { patterns, antipatterns };
 }
 
 /**

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -363,7 +363,7 @@ export function writeFile(filePath, content) {
 }
 
 // Curated short-list for the homepage Antidote section. This intentionally
-// stays independent of repository content so the copy remains tight and
+// stays independent of SKILL.md extraction so the copy remains tight and
 // editorial.
 const CURATED_CATEGORIES = [
   {


### PR DESCRIPTION
## Summary

- remove the unreachable legacy SKILL.md pattern parser from `scripts/lib/utils.js`
- keep the curated `readPatterns()` data path and public export unchanged
- replace obsolete parser documentation with an accurate concise invariant

## Hindsight review

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No. Once the homepage switched to an intentionally curated pattern catalog, retaining a disabled, unexported, uncalled 100-line markdown parser in production source added a second obsolete mental model without preserving behavior. The leanest architecture is the existing curated catalog alone.

## Before / after

- Primary file: `scripts/lib/utils.js`
- Lines: **886 → 780** (net **-106**, about 12%)
- Diff: 3 insertions, 109 deletions
- Before: curated catalog plus an unreachable legacy parsing mechanism and stale documentation
- After: one curated data mechanism, one public `readPatterns()` entry point, and accurate documentation
- Public exports, call signatures, output shape, ordering, errors, and user-facing behavior are unchanged

## Validation

- `bun test tests/lib/utils.test.js tests/build.test.js` — 74 pass, 0 fail
- `bun run build` — pass
- `bun run test` — pass, including browser detector and framework fixtures

Generated provider/root-harness output was intentionally omitted; `bun run build` was used for source-first validation and this change does not alter generated behavior.

## Risk

Low. The deleted function was internal, unexported, and had no callers. The active curated implementation and its tests are unchanged.

## Authorization and disclosure

This PR was prepared with Codex assistance under maintainer **pbakaus's explicit scheduled architecture-cleanup authorization**. It is ready for regular CI and review-bot evaluation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead code removal with no callers on the deleted parser; active curated path and tests are unchanged.
> 
> **Overview**
> Removes ~100 lines of **unused** legacy logic from `scripts/lib/utils.js` that once parsed DO/DON'T rules out of `SKILL.src.md`. The homepage Antidote path already relied on the hand-curated `CURATED_CATEGORIES` list inside `readPatterns()`.
> 
> **`readPatterns()`** is unchanged for callers: same signature, return shape, and curated copy. Comments now state that the teaser catalog is intentionally independent of SKILL extraction.
> 
> This is source cleanup only—no build output or public behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f824b5b5ec5092d7b966b4b58009ba08fcc667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->