### PR TITLE
Fix seed DESIGN.md coverage checks

### DIFF
--- a/skill/scripts/lib/staleness-deep.mjs
+++ b/skill/scripts/lib/staleness-deep.mjs
@@ -129,6 +129,9 @@ function hasCoverageValue(value) {
   return false;
 }
 
+const SEED_DESIGN_MARKER = '<!-- SEED: established with the user before implementation; '
+  + "re-run /impeccable document once there's code to capture the actual tokens and components. -->";
+
 export function checkDesignCoverage({ design, designPath, parseDesignMd }) {
   if (!design || typeof parseDesignMd !== 'function') return [];
   let model;
@@ -137,7 +140,10 @@ export function checkDesignCoverage({ design, designPath, parseDesignMd }) {
   } catch {
     return [];
   }
-  const missing = ['colors', 'typography', 'components']
+  const requiredSections = design.includes(SEED_DESIGN_MARKER)
+    ? ['colors', 'typography']
+    : ['colors', 'typography', 'components'];
+  const missing = requiredSections
     .filter((section) => !model[section] && !hasCoverageValue(model.frontmatter?.[section]));
   if (!missing.length) return [];
   return [finding({

--- a/skill/scripts/lib/staleness-deep.mjs
+++ b/skill/scripts/lib/staleness-deep.mjs
@@ -129,8 +129,10 @@ function hasCoverageValue(value) {
   return false;
 }
 
-const SEED_DESIGN_MARKER = '<!-- SEED: established with the user before implementation; '
-  + "re-run /impeccable document once there's code to capture the actual tokens and components. -->";
+const SEED_DESIGN_MARKERS = ['/', '$'].map((prefix) =>
+  '<!-- SEED: established with the user before implementation; '
+    + `re-run ${prefix}impeccable document once there's code to capture the actual tokens and components. -->`
+);
 
 export function checkDesignCoverage({ design, designPath, parseDesignMd }) {
   if (!design || typeof parseDesignMd !== 'function') return [];
@@ -140,7 +142,8 @@ export function checkDesignCoverage({ design, designPath, parseDesignMd }) {
   } catch {
     return [];
   }
-  const requiredSections = design.includes(SEED_DESIGN_MARKER)
+  const isSeed = SEED_DESIGN_MARKERS.some((marker) => design.includes(marker));
+  const requiredSections = isSeed
     ? ['colors', 'typography']
     : ['colors', 'typography', 'components'];
   const missing = requiredSections

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -173,31 +173,35 @@ describe('checkDesignCoverage', () => {
   });
 
   it('allows Components to be absent from a marked seed document', () => {
-    const design = [
-      '<!-- SEED: established with the user before implementation; re-run /impeccable document once there\'s code to capture the actual tokens and components. -->',
-      '',
-      '# Design System: X',
-      '',
-      '## Colors', '', '### Primary', '- **Ink** (#111): Text.', '',
-      '## Typography', '', '**Body Font:** Inter', '',
-      '### Hierarchy', '- **Body** (400, 16px, 1.5): Paragraphs.', '',
-    ].join('\n');
-    assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
+    for (const command of ['/impeccable', '$impeccable']) {
+      const design = [
+        `<!-- SEED: established with the user before implementation; re-run ${command} document once there's code to capture the actual tokens and components. -->`,
+        '',
+        '# Design System: X',
+        '',
+        '## Colors', '', '### Primary', '- **Ink** (#111): Text.', '',
+        '## Typography', '', '**Body Font:** Inter', '',
+        '### Hierarchy', '- **Body** (400, 16px, 1.5): Paragraphs.', '',
+      ].join('\n');
+      assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
+    }
   });
 
   it('still requires seed documents to cover Colors and Typography', () => {
-    const design = [
-      '<!-- SEED: established with the user before implementation; re-run /impeccable document once there\'s code to capture the actual tokens and components. -->',
-      '',
-      '# Design System: X',
-      '',
-      '## Typography', '', '**Body Font:** Inter', '',
-      '### Hierarchy', '- **Body** (400, 16px, 1.5): Paragraphs.', '',
-    ].join('\n');
-    const findings = checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd });
-    assert.deepEqual(ids(findings), ['design-md-coverage']);
-    assert.match(findings[0].summary, /no colors section/);
-    assert.doesNotMatch(findings[0].summary, /components/);
+    for (const command of ['/impeccable', '$impeccable']) {
+      const design = [
+        `<!-- SEED: established with the user before implementation; re-run ${command} document once there's code to capture the actual tokens and components. -->`,
+        '',
+        '# Design System: X',
+        '',
+        '## Typography', '', '**Body Font:** Inter', '',
+        '### Hierarchy', '- **Body** (400, 16px, 1.5): Paragraphs.', '',
+      ].join('\n');
+      const findings = checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd });
+      assert.deepEqual(ids(findings), ['design-md-coverage']);
+      assert.match(findings[0].summary, /no colors section/);
+      assert.doesNotMatch(findings[0].summary, /components/);
+    }
   });
 
   it('counts machine-readable frontmatter as section coverage', () => {

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -172,6 +172,34 @@ describe('checkDesignCoverage', () => {
     assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
   });
 
+  it('allows Components to be absent from a marked seed document', () => {
+    const design = [
+      '<!-- SEED: established with the user before implementation; re-run /impeccable document once there\'s code to capture the actual tokens and components. -->',
+      '',
+      '# Design System: X',
+      '',
+      '## Colors', '', '### Primary', '- **Ink** (#111): Text.', '',
+      '## Typography', '', '**Body Font:** Inter', '',
+      '### Hierarchy', '- **Body** (400, 16px, 1.5): Paragraphs.', '',
+    ].join('\n');
+    assert.deepEqual(checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd }), []);
+  });
+
+  it('still requires seed documents to cover Colors and Typography', () => {
+    const design = [
+      '<!-- SEED: established with the user before implementation; re-run /impeccable document once there\'s code to capture the actual tokens and components. -->',
+      '',
+      '# Design System: X',
+      '',
+      '## Typography', '', '**Body Font:** Inter', '',
+      '### Hierarchy', '- **Body** (400, 16px, 1.5): Paragraphs.', '',
+    ].join('\n');
+    const findings = checkDesignCoverage({ design, designPath: 'DESIGN.md', parseDesignMd });
+    assert.deepEqual(ids(findings), ['design-md-coverage']);
+    assert.match(findings[0].summary, /no colors section/);
+    assert.doesNotMatch(findings[0].summary, /components/);
+  });
+
   it('counts machine-readable frontmatter as section coverage', () => {
     const design = [
       '---',


### PR DESCRIPTION
Closes #464.

## Summary

- recognize the exact prescribed DESIGN.md seed marker during coverage checks
- make Components optional only for marked seed documents
- retain Colors and Typography coverage requirements in seed mode
- add focused positive and negative regression coverage

## Validation

- `node --test tests/doctor.test.mjs` — 45/45 passed
- `bun run build` — passed
- `bun run test` — passed, including browser 27/27 and framework 216/216
- `git diff --check` — passed

Generated provider/root harness output was intentionally omitted; this is a source-first fix and `bun run build` validated the generated distribution under `dist/`.

AI assistance disclosure: Codex reproduced the report, implemented the fix, wrote the regression tests, and ran validation under explicit maintainer authorization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only adjust staleness/doctor validation rules and tests; no runtime product behavior or data handling.
> 
> **Overview**
> **DESIGN.md coverage checks** now recognize the prescribed `<!-- SEED: ... -->` marker (for both `/impeccable` and `$impeccable` document commands). When that marker is present, **`checkDesignCoverage` only requires Colors and Typography**; the Components section is optional, matching pre-implementation seed docs that intentionally omit component guidance until code exists.
> 
> Non-seed documents still require all three sections. Regression tests cover seed docs without Components (no finding) and seed docs missing Colors (finding mentions colors only, not components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d7b247aabd5c731dc5bd035b0497aa6c967a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->