### PR TITLE
Fix wrapped Key Characteristics parsing

### DIFF
--- a/skill/scripts/lib/design-parser.mjs
+++ b/skill/scripts/lib/design-parser.mjs
@@ -330,17 +330,16 @@ function extractOverview(section) {
   if (!section) return null;
   const text = section.lines.join('\n');
   const northStar = text.match(/\*\*Creative North Star:\s*"([^"]+)"\*\*/);
-  const keyChars = [];
   const keyCharMatch = text.match(/\*\*Key Characteristics:\*\*\s*\n([\s\S]+?)(?:\n##|\n###|$)/);
-  if (keyCharMatch) {
-    for (const line of keyCharMatch[1].split('\n')) {
-      const m = line.match(/^\s*[-*]\s+(.+)$/);
-      if (m) keyChars.push(stripBold(m[1].trim()));
-    }
-  }
+  const keyChars = keyCharMatch
+    ? collectBullets(keyCharMatch[1].split('\n')).map((bullet) => stripBold(bullet.trim()))
+    : [];
+  const prose = keyCharMatch
+    ? text.slice(0, keyCharMatch.index) + text.slice(keyCharMatch.index + keyCharMatch[0].length)
+    : text;
 
   // Philosophy paragraphs: everything that isn't a rule header or key-char block
-  const paragraphs = collectParagraphs(section.lines).filter(
+  const paragraphs = collectParagraphs(prose.split('\n')).filter(
     (p) =>
       !p.startsWith('**Creative North Star') &&
       !p.startsWith('**Key Characteristics')

--- a/tests/design-parser.test.mjs
+++ b/tests/design-parser.test.mjs
@@ -143,3 +143,28 @@ Prose.
     assert.equal(model.frontmatter.rounded['"2xl"'], undefined);
   });
 });
+
+describe('parseDesignMd overview branch', () => {
+  it('joins wrapped Key Characteristics bullets without leaking continuations into philosophy', () => {
+    const md = `# Design System: Example
+
+## Overview
+
+**Creative North Star: "Structured clarity"**
+
+**Key Characteristics:**
+
+- Status remains understandable without relying on color
+  alone.
+- Navigation controls remain visible when the viewport becomes
+  narrow.
+`;
+    const overview = parseDesignMd(md).overview;
+
+    assert.deepEqual(overview.keyCharacteristics, [
+      'Status remains understandable without relying on color alone.',
+      'Navigation controls remain visible when the viewport becomes narrow.',
+    ]);
+    assert.deepEqual(overview.philosophy, []);
+  });
+});


### PR DESCRIPTION
Closes #463.

## Summary

- join indented Markdown continuation lines in `Key Characteristics` bullets
- keep the complete Key Characteristics block out of Overview philosophy text
- add focused regression coverage for wrapped bullets

## Validation

- `node --test tests/design-parser.test.mjs` — 7/7 passed
- `bun run build` — passed
- `bun run test` — passed, including browser 27/27 and framework 216/216
- `git diff --check` — passed

Generated provider/root harness output was intentionally omitted; this is a source-first fix and `bun run build` validated the generated distribution under `dist/`.

AI assistance disclosure: Codex reproduced the report, implemented the fix, wrote the regression test, and ran validation under explicit maintainer authorization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to DESIGN.md overview parsing with regression tests; no auth, security, or runtime API surface impact.
> 
> **Overview**
> Fixes **Overview** parsing in `design-parser.mjs` when **Key Characteristics** bullets span multiple lines (Markdown continuation indentation).
> 
> `extractOverview` now builds `keyCharacteristics` via **`collectBullets`**, so wrapped lines become single bullet strings instead of truncated first lines. The full Key Characteristics block is removed from the section text before **`collectParagraphs`** runs, so continuation lines no longer appear in **`philosophy`**.
> 
> Adds a regression test in `design-parser.test.mjs` for wrapped bullets and empty philosophy when only North Star + Key Characteristics are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5eb38a381fce2ac64576aba44c90b2cc34d5e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->