### PR TITLE
Fix live mode on non-localhost dev hosts (ddev, Valet): authorize CORS by session token

### DIFF
--- a/tests/live-browser-source.test.mjs
+++ b/tests/live-browser-source.test.mjs
@@ -42,7 +42,7 @@ describe('live-browser source contracts', () => {
     );
     assert.match(
       SOURCE,
-      /fetch\('http:\/\/localhost:' \+ PORT \+ '\/manual-edit-stash\?token='[\s\S]{0,300}?pageUrl: location\.pathname[\s\S]{0,80}?element: extractContext\(contextElement\)[\s\S]{0,40}?ops,/,
+      /fetch\('http:\/\/localhost:' \+ PORT \+ '\/manual-edit-stash\?token=' \+ encodeURIComponent\(TOKEN\)[\s\S]{0,300}?pageUrl: location\.pathname[\s\S]{0,80}?element: extractContext\(contextElement\)[\s\S]{0,40}?ops,/,
       'Save should stage edits through /manual-edit-stash with element context and ops',
     );
     assert.match(

--- a/tests/live-browser-source.test.mjs
+++ b/tests/live-browser-source.test.mjs
@@ -42,7 +42,7 @@ describe('live-browser source contracts', () => {
     );
     assert.match(
       SOURCE,
-      /fetch\('http:\/\/localhost:' \+ PORT \+ '\/manual-edit-stash'[\s\S]{0,260}?pageUrl: location\.pathname[\s\S]{0,80}?element: extractContext\(contextElement\)[\s\S]{0,40}?ops,/,
+      /fetch\('http:\/\/localhost:' \+ PORT \+ '\/manual-edit-stash\?token='[\s\S]{0,300}?pageUrl: location\.pathname[\s\S]{0,80}?element: extractContext\(contextElement\)[\s\S]{0,40}?ops,/,
       'Save should stage edits through /manual-edit-stash with element context and ops',
     );
     assert.match(

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -393,22 +393,44 @@ describe('live-server integration', () => {
     assert.ok(body.includes('__IMPECCABLE_LIVE_INIT__'), 'authorized /live.js returns the assembled bundle');
   });
 
-  it('CORS: a remote origin gets no Access-Control-Allow-Origin on any route', async () => {
+  it('CORS: a tokenless remote origin gets no Access-Control-Allow-Origin on any route', async () => {
     const evil = 'https://evil.example';
-    for (const path of ['/health', `/live.js?token=${server.token}`, `/status?token=${server.token}`]) {
+    for (const path of ['/health', '/live.js', '/status', '/status?token=not-the-token']) {
       const res = await fetch(`http://localhost:${server.port}${path}`, { headers: { Origin: evil } });
       assert.equal(
         res.headers.get('access-control-allow-origin'),
         null,
-        `remote origin must not be reflected on ${path}`,
+        `tokenless remote origin must not be reflected on ${path}`,
       );
     }
-    // Preflight from a remote origin is likewise unauthorized to read.
+    // Preflight from a tokenless remote origin is likewise unauthorized to read.
     const preflight = await fetch(`http://localhost:${server.port}/poll`, {
       method: 'OPTIONS',
       headers: { Origin: evil, 'Access-Control-Request-Method': 'POST' },
     });
     assert.equal(preflight.headers.get('access-control-allow-origin'), null);
+  });
+
+  it('CORS: a non-loopback origin with the valid token is reflected (ddev-style dev hosts)', async () => {
+    // A dev server on a loopback alias (https://my-site.ddev.site, *.test)
+    // sends a non-loopback Origin, but its overlay requests carry the session
+    // token — that token, not the origin, is the trust signal.
+    const origin = 'https://my-site.ddev.site';
+    const res = await fetch(`http://localhost:${server.port}/status?token=${server.token}`, {
+      headers: { Origin: origin },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('access-control-allow-origin'), origin);
+    assert.ok(/\bOrigin\b/i.test(res.headers.get('vary') || ''), 'Vary: Origin accompanies the reflected origin');
+
+    // Preflight to the same token-bearing URL is authorized too (OPTIONS hits
+    // the same URL, query string included).
+    const preflight = await fetch(`http://localhost:${server.port}/poll?token=${server.token}`, {
+      method: 'OPTIONS',
+      headers: { Origin: origin, 'Access-Control-Request-Method': 'POST' },
+    });
+    assert.equal(preflight.status, 204);
+    assert.equal(preflight.headers.get('access-control-allow-origin'), origin);
   });
 
   it('CORS: a loopback origin is reflected with Vary: Origin', async () => {

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -431,6 +431,10 @@ describe('live-server integration', () => {
     });
     assert.equal(preflight.status, 204);
     assert.equal(preflight.headers.get('access-control-allow-origin'), origin);
+    assert.ok(
+      /\bOrigin\b/i.test(preflight.headers.get('vary') || ''),
+      'Vary: Origin accompanies the reflected origin on the preflight too',
+    );
   });
 
   it('CORS: a loopback origin is reflected with Vary: Origin', async () => {


### PR DESCRIPTION
## Context

The v4.0.2 security fix for #304 restricted the live server's CORS reflection to literal loopback origins (`localhost` / `127.0.0.1` / `[::1]`). That broke live mode for dev servers on loopback *aliases*, as reported in https://github.com/pbakaus/impeccable/issues/304#issuecomment-5142160513: ddev pages live at `https://my-site.ddev.site`, so their Origin fails the loopback test, the overlay's fetches to `http://localhost:<port>` get no `Access-Control-Allow-Origin`, and the browser blocks every response. Same failure for Laravel Valet (`*.test`) and hosts-file aliases.

## Fix

No config option needed. The session token is already the security boundary (that's the design of the #304 fix itself, which token-gated `/live.js`), and it reaches the page safely on any origin because the injected classic `<script src>` isn't subject to CORS. So the server now reflects the caller's Origin when the request is loopback **or carries the valid session token**:

```js
if (origin && (isLoopbackOrigin(origin) || url.searchParams.get('token') === state.token)) {
```

Two browser-side requests carried the token only in their JSON body (`POST /events`, `POST /manual-edit-stash`); they now also carry it in the query string, which is what authorizes their CORS preflight (an OPTIONS hits the same URL, body excluded). Every other overlay request already had `?token=` in the URL.

Security posture is unchanged: a probing page without the token still gets no ACAO on any route, and a token bearer was already fully authorized everywhere.

## Note on commit split

The source changes to `skill/scripts/live-server.mjs` and `skill/scripts/live-browser.js` were accidentally folded into b1c5707f on main by a concurrent working session in the same checkout, so this PR carries the remaining half of the change: the regression tests written alongside them (tokenless remote origins blocked on all routes; a `https://my-site.ddev.site` origin with the valid token reflected with `Vary: Origin` on both real requests and preflights; the `/manual-edit-stash` source assertion updated for the token-bearing URL).

## Testing

- `bun run build` and the full `bun run test` suite pass
- `bun run test:live-e2e`: one flake in the mount-failure scenario during the full sweep; both fixtures that run it (`vite8-sveltekit`, `vite8-sveltekit-stateful`) pass clean when rerun scoped

Prepared with AI assistance, under maintainer direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is test-only; it documents existing CORS/token behavior without changing server or browser runtime code in this PR.
> 
> **Overview**
> This PR adds **regression tests** for live mode on non-loopback dev hosts (e.g. `https://my-site.ddev.site`). The runtime fix—reflecting CORS when the request is loopback **or** carries a valid session `token` in the query string, and putting `?token=` on overlay fetches that previously relied on the JSON body—is described as already landed on main; **this diff only updates tests**.
> 
> **`live-server.test.mjs`** tightens CORS coverage: tokenless remote origins get no `Access-Control-Allow-Origin` on routes including `/live.js` and bad tokens on `/status`; a ddev-style origin with the valid token is reflected on `/status` and on **OPTIONS** preflights to token-bearing URLs, with `Vary: Origin`.
> 
> **`live-browser-source.test.mjs`** updates the source contract so `/manual-edit-stash` is expected to use `?token=` on the stash URL (so preflights can authorize CORS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60c860f022c4dbc84870e8abc502402b1b81f23f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->