### PR TITLE
fix: skip design-hook scans for files outside the resolved project root

### DIFF
--- a/skill/scripts/hook-before-edit.mjs
+++ b/skill/scripts/hook-before-edit.mjs
@@ -23,6 +23,7 @@ import {
   designSystemOptions,
   filterFindings,
   isNativePlatform,
+  isScanTargetInsideProject,
   loadDetector,
   matchConfiguredExtension,
   matchesAnyGlob,
@@ -161,7 +162,7 @@ function replaceOnce(original, oldString, newString) {
 }
 
 function readExistingProjectFile(filePath, cwd) {
-  if (!isInsideProject(filePath, cwd)) return null;
+  if (!isScanTargetInsideProject(filePath, cwd)) return null;
   if (SENSITIVE_PATH.test(filePath) || GENERATED_PATH.test(filePath)) return null;
   try {
     const stat = fs.statSync(filePath);
@@ -232,7 +233,7 @@ function shellCopiedFileContent(command, cwd) {
   const source = shellCopyPaths(command)?.source;
   if (!source) return '';
   const sourcePath = path.isAbsolute(source) ? source : path.resolve(cwd, source);
-  if (!isInsideProject(sourcePath, cwd)) return '';
+  if (!isScanTargetInsideProject(sourcePath, cwd)) return '';
   if (SENSITIVE_PATH.test(sourcePath) || GENERATED_PATH.test(sourcePath)) return '';
   try {
     const stat = fs.statSync(sourcePath);
@@ -328,15 +329,6 @@ function relativePath(filePath, cwd) {
   }
 }
 
-function isInsideProject(filePath, cwd) {
-  try {
-    const rel = path.relative(cwd, filePath);
-    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
-  } catch {
-    return false;
-  }
-}
-
 // The static HTML engine reads its input from disk, but preToolUse only has
 // the proposed content. Stage it in a temp file so html-engine targets get the
 // same DOM-structural rules pre-write that runHook applies post-edit.
@@ -414,7 +406,7 @@ async function main() {
   };
 
   if (!filePath) return allow({ ...audit, skipped: 'no-file-path', durationMs: Date.now() - started });
-  if (!isInsideProject(filePath, cwd)) return allow({ ...audit, skipped: 'outside-project', durationMs: Date.now() - started });
+  if (!isScanTargetInsideProject(filePath, cwd)) return allow({ ...audit, skipped: 'outside-project', durationMs: Date.now() - started });
   if (SENSITIVE_PATH.test(filePath)) return allow({ ...audit, skipped: 'sensitive', durationMs: Date.now() - started });
   if (GENERATED_PATH.test(filePath)) return allow({ ...audit, skipped: 'generated', durationMs: Date.now() - started });
 

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -1336,19 +1336,32 @@ function isInsideProject(filePath, projectCwd) {
 // not exist yet — the before-edit hook gates proposed Writes — canonicalize
 // the nearest existing ancestor and re-append the remainder, so a new file
 // under a symlinked root still compares equal to its canonical project.
+// Memoized: the hook runs as a fresh process per tool event, so the cache
+// amounts to once-per-event work — the scan loops re-check the same project
+// root for every target file. The cap only matters to long-lived importers
+// like the test runner.
+const canonicalPathCache = new Map();
+const CANONICAL_PATH_CACHE_MAX = 1024;
+
 function canonicalPath(p) {
   const resolved = path.resolve(p);
+  if (canonicalPathCache.has(resolved)) return canonicalPathCache.get(resolved);
+  let canonical = resolved;
   let dir = resolved;
   const tail = [];
   while (true) {
     try {
-      return tail.length ? path.join(fs.realpathSync(dir), ...tail) : fs.realpathSync(dir);
+      canonical = tail.length ? path.join(fs.realpathSync(dir), ...tail) : fs.realpathSync(dir);
+      break;
     } catch { /* keep climbing */ }
     const parent = path.dirname(dir);
-    if (parent === dir) return resolved;
+    if (parent === dir) break;
     tail.unshift(path.basename(dir));
     dir = parent;
   }
+  if (canonicalPathCache.size >= CANONICAL_PATH_CACHE_MAX) canonicalPathCache.clear();
+  canonicalPathCache.set(resolved, canonical);
+  return canonical;
 }
 
 // Containment gate shared by the before-edit hook and both scan passes. A

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -1332,19 +1332,33 @@ function isInsideProject(filePath, projectCwd) {
   }
 }
 
+// Resolve a path to its canonical (symlink-free) form. When the path does
+// not exist yet — the before-edit hook gates proposed Writes — canonicalize
+// the nearest existing ancestor and re-append the remainder, so a new file
+// under a symlinked root still compares equal to its canonical project.
 function canonicalPath(p) {
-  try { return fs.realpathSync(p); } catch { return path.resolve(p); }
+  const resolved = path.resolve(p);
+  let dir = resolved;
+  const tail = [];
+  while (true) {
+    try {
+      return tail.length ? path.join(fs.realpathSync(dir), ...tail) : fs.realpathSync(dir);
+    } catch { /* keep climbing */ }
+    const parent = path.dirname(dir);
+    if (parent === dir) return resolved;
+    tail.unshift(path.basename(dir));
+    dir = parent;
+  }
 }
 
-// Containment gate for both scan passes. A session routinely touches files
-// that belong to no project or to a different one — harness scratchpad dirs
-// under the system temp root, sibling checkouts, one-off throwaway HTML — and
-// findings against those are judged with THIS project's config and DESIGN.md
-// palette, which is never right. Skip them (audit reason: outside-project).
-// Paths are canonicalized first so a symlinked root (macOS /tmp ->
-// /private/tmp) doesn't split the comparison; the realpath fallback for
-// missing paths is only correct because both scan loops check existence
-// before calling this.
+// Containment gate shared by the before-edit hook and both scan passes. A
+// session routinely touches files that belong to no project or to a
+// different one — harness scratchpad dirs under the system temp root,
+// sibling checkouts, one-off throwaway HTML — and findings against those are
+// judged with THIS project's config and DESIGN.md palette, which is never
+// right. Skip them (audit reason: outside-project). Paths are canonicalized
+// first so a symlinked root (macOS /tmp -> /private/tmp) doesn't split the
+// comparison.
 export function isScanTargetInsideProject(filePath, projectCwd) {
   if (!filePath || !projectCwd) return false;
   return isInsideProject(canonicalPath(filePath), canonicalPath(projectCwd));

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -1332,6 +1332,24 @@ function isInsideProject(filePath, projectCwd) {
   }
 }
 
+function canonicalPath(p) {
+  try { return fs.realpathSync(p); } catch { return path.resolve(p); }
+}
+
+// Containment gate for both scan passes. A session routinely touches files
+// that belong to no project or to a different one — harness scratchpad dirs
+// under the system temp root, sibling checkouts, one-off throwaway HTML — and
+// findings against those are judged with THIS project's config and DESIGN.md
+// palette, which is never right. Skip them (audit reason: outside-project).
+// Paths are canonicalized first so a symlinked root (macOS /tmp ->
+// /private/tmp) doesn't split the comparison; the realpath fallback for
+// missing paths is only correct because both scan loops check existence
+// before calling this.
+export function isScanTargetInsideProject(filePath, projectCwd) {
+  if (!filePath || !projectCwd) return false;
+  return isInsideProject(canonicalPath(filePath), canonicalPath(projectCwd));
+}
+
 export function parseStaticStyleImports(content, fromFile, projectCwd) {
   if (!content || typeof content !== 'string') return [];
   const dir = path.dirname(fromFile);
@@ -1690,6 +1708,10 @@ export async function runHook({ stdinJson, env = {}, cwd = process.cwd(), now = 
         lastSkip = 'file-missing';
         continue;
       }
+      if (!isScanTargetInsideProject(filePath, projectCwd)) {
+        lastSkip = 'outside-project';
+        continue;
+      }
 
       const maxFileBytes = config.limits?.maxFileBytes ?? DEFAULT_CONFIG.limits.maxFileBytes;
       if (maxFileBytes > 0) {
@@ -2020,6 +2042,10 @@ export async function runStopHook({ stdinJson, env = {}, cwd = process.cwd(), no
       const relForMatch = relativize(filePath, projectCwd);
       if (matchesAnyGlob(relForMatch, config.ignoreFiles) || matchesAnyGlob(filePath, config.ignoreFiles)) continue;
       if (!fs.existsSync(filePath)) continue;
+      // Caches written before this gate existed can still hold out-of-project
+      // paths, so the Stop pass re-checks containment rather than trusting
+      // the per-edit pass to have filtered them.
+      if (!isScanTargetInsideProject(filePath, projectCwd)) continue;
 
       scanned += 1;
       let content = '';

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -60,6 +60,7 @@ import {
   resolveProjectPlatform,
   isNativePlatform,
   normalizeIgnoreValueEntries,
+  isScanTargetInsideProject,
 } from '../skill/scripts/hook-lib.mjs';
 import { normalizeIgnoreValueEntries as normalizeIgnoreValueEntriesCli } from '../cli/lib/impeccable-config.mjs';
 import { detectHtml, detectText } from '../cli/engine/detect-antipatterns.mjs';
@@ -155,6 +156,44 @@ describe('SENSITIVE_PATH / GENERATED_PATH', () => {
     ]) {
       assert.ok(!GENERATED_PATH.test(p), `unexpected generated: ${p}`);
     }
+  });
+});
+
+describe('isScanTargetInsideProject()', () => {
+  let root;
+  beforeEach(() => { root = mkTmp(); });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('accepts files under the project root and the root itself', () => {
+    const file = path.join(root, 'src', 'Card.tsx');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, 'noop');
+    assert.equal(isScanTargetInsideProject(file, root), true);
+    assert.equal(isScanTargetInsideProject(root, root), true);
+  });
+
+  it('rejects siblings, temp scratchpads, and empty inputs', () => {
+    const scratch = mkTmp();
+    try {
+      const outside = path.join(scratch, 'landing.html');
+      fs.writeFileSync(outside, '<h1>x</h1>');
+      assert.equal(isScanTargetInsideProject(outside, root), false);
+      assert.equal(isScanTargetInsideProject('', root), false);
+      assert.equal(isScanTargetInsideProject(outside, ''), false);
+    } finally {
+      fs.rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it('treats symlinked and canonical forms of the same tree as one project', () => {
+    const real = path.join(root, 'real');
+    const link = path.join(root, 'link');
+    fs.mkdirSync(path.join(real, 'src'), { recursive: true });
+    fs.symlinkSync(real, link);
+    const file = path.join(real, 'src', 'Card.tsx');
+    fs.writeFileSync(file, 'noop');
+    assert.equal(isScanTargetInsideProject(file, link), true);
+    assert.equal(isScanTargetInsideProject(path.join(link, 'src', 'Card.tsx'), real), true);
   });
 });
 
@@ -1530,6 +1569,49 @@ rounded:
       env: {}, cwd,
     });
     assert.equal(r.audit.skipped, 'sensitive');
+  });
+
+  it('rejects files outside the project, like harness scratchpads', async () => {
+    // Session cwd is a real project; the touched file is a throwaway HTML in
+    // a temp dir elsewhere. Findings against it would be judged with this
+    // project's config and DESIGN.md, so the scan must skip it entirely.
+    fs.writeFileSync(path.join(cwd, 'package.json'), '{"name":"proj"}');
+    const scratch = mkTmp();
+    try {
+      const file = path.join(scratch, 'id-test', 'landing.html');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, '<h1>throwaway</h1>');
+      const det = fakeDetector([finding('side-tab', 1)]);
+      const r = await runHook({ stdinJson: JSON.stringify(eventFor(file)), env: {}, cwd, detector: det });
+      assert.equal(r.stdout, '');
+      assert.equal(r.audit.skipped, 'outside-project');
+      assert.ok(!fs.existsSync(path.join(cwd, '.impeccable')), 'out-of-project edit must not dirty the cache');
+    } finally {
+      fs.rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it('still scans a file whose project root is reached through a symlinked cwd', async () => {
+    // macOS /tmp -> /private/tmp style: the session cwd is a symlink to the
+    // project while the tool reports the canonical file path. Containment
+    // compares canonical paths, so this is inside, not outside.
+    const real = path.join(cwd, 'realproj');
+    const link = path.join(cwd, 'proj-link');
+    fs.mkdirSync(path.join(real, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(real, 'package.json'), '{"name":"proj"}');
+    fs.symlinkSync(real, link);
+    const file = path.join(real, 'src', 'Card.tsx');
+    fs.writeFileSync(file, 'noop');
+    const event = {
+      session_id: 'sym-sid',
+      cwd: link,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: file },
+    };
+    const r = await runHook({ stdinJson: JSON.stringify(event), env: {}, cwd: link, detector: fakeDetector([]) });
+    assert.notEqual(r.audit.skipped, 'outside-project');
+    assert.match(r.stdout, /No deterministic design-quality issues found/);
   });
 
   it('rejects extensions outside the allowlist', async () => {
@@ -3340,6 +3422,29 @@ describe('runStopHook()', () => {
     assert.equal(r.exitCode, 0);
     assert.equal(r.stdout, '');
     assert.equal(r.audit.skipped, 'no-touched-files');
+  });
+
+  it('skips out-of-project files even when an older cache still lists them', async () => {
+    // Caches written before the containment gate can hold scratchpad paths.
+    // The deep pass re-checks containment instead of trusting the per-edit
+    // pass to have filtered them.
+    const sid = 'stop-outside';
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-scratch-'));
+    try {
+      const outside = path.join(scratch, 'landing.html');
+      fs.writeFileSync(outside, '<h1>throwaway</h1>');
+      persistCache(cwd, {
+        version: 1,
+        sessions: { [sid]: { updatedAt: Date.now(), files: { [outside]: { editCount: 1, findings: [] } } } },
+      });
+      const det = fakeDetector([finding('side-tab', 7)]);
+      const stop = await runStopHook({ stdinJson: JSON.stringify(stopEvent(sid)), env: {}, cwd, detector: det });
+      assert.equal(stop.stdout, '');
+      assert.equal(stop.audit.skipped, 'stop-clean');
+      assert.equal(stop.audit.scannedFiles, 0);
+    } finally {
+      fs.rmSync(scratch, { recursive: true, force: true });
+    }
   });
 
   it('a second Stop fire is silent: deep-pass findings are remembered', async () => {

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -195,6 +195,19 @@ describe('isScanTargetInsideProject()', () => {
     assert.equal(isScanTargetInsideProject(file, link), true);
     assert.equal(isScanTargetInsideProject(path.join(link, 'src', 'Card.tsx'), real), true);
   });
+
+  it('classifies not-yet-written files by their nearest existing ancestor', () => {
+    // The before-edit hook gates proposed Writes, so the target often does
+    // not exist. Canonicalization must climb to an existing ancestor rather
+    // than bail, or a new file under a symlinked root would read as outside.
+    const real = path.join(root, 'real');
+    const link = path.join(root, 'link');
+    fs.mkdirSync(real, { recursive: true });
+    fs.symlinkSync(real, link);
+    assert.equal(isScanTargetInsideProject(path.join(link, 'src', 'New.tsx'), real), true);
+    assert.equal(isScanTargetInsideProject(path.join(real, 'deep', 'New.tsx'), link), true);
+    assert.equal(isScanTargetInsideProject(path.join(root, 'elsewhere', 'New.tsx'), real), false);
+  });
 });
 
 describe('readConfig()', () => {


### PR DESCRIPTION
## Problem

The design hook's per-edit pass and Stop deep pass scan every file the session touched that survives the existing gates (sensitive path, generated path, extension, config ignores, size) — but neither pass ever checks that the file is **inside the project**. A session that writes throwaway HTML into the Claude Code scratchpad dir (`/private/tmp/claude-501/...`), or edits a file in a sibling checkout, gets those files scanned and judged against **this** project's config and DESIGN.md palette. The result is a Stop-blocking envelope full of `design-system-color` findings comparing a throwaway file's colors to a design system it was never part of — wrong by construction.

The gap was an oversight, not a decision: `hook-before-edit.mjs` already had exactly this gate (`outside-project` skip reason), and `hook-lib.mjs` even had an `isInsideProject()` helper, applied only to co-scanned style imports.

## Fix

- New exported `isScanTargetInsideProject(filePath, projectCwd)` in `hook-lib.mjs`: containment check on canonicalized paths, so a symlinked root (macOS `/tmp` → `/private/tmp`) doesn't split the comparison. For paths that don't exist yet, canonicalization climbs to the nearest existing ancestor and re-appends the remainder.
- Per-edit pass: skips out-of-project files with audit reason `outside-project`, **before** any cache mutation, so scratchpad files never enter the session cache.
- Stop deep pass: re-checks containment itself, because caches written by older hook versions can still list out-of-project paths.
- `hook-before-edit.mjs` cleanup: its local string-based `isInsideProject` is gone; all three call sites now use the shared helper, so every hook pass applies one containment semantic. The nearest-existing-ancestor canonicalization exists precisely because this hook gates proposed Writes whose target file doesn't exist yet.

Umbrella-dir launches (issue #305) are unaffected: `resolveCacheCwd` resolves `projectCwd` to the edited file's own project root, so containment holds by construction — covered by the existing test.

## Tests

- Per-edit: scratchpad-style out-of-project file → `outside-project`, no emission, no `.impeccable/` footprint.
- Per-edit: file addressed through canonical path while session cwd is a symlink to the project → still scanned.
- Stop: stale cache listing an out-of-project path → silently filtered (`stop-clean`, `scannedFiles: 0`).
- Direct unit coverage for the helper: inside / root itself / sibling / empty / symlink equivalence / not-yet-written files under symlinked roots.

`bun run test` fully green (67 sub-suites, 0 failures); `bun run build` validators pass.

*Written with AI assistance (Claude Code), under maintainer direction.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hook scanning and path containment only; fixes incorrect cross-project scans without touching auth, data, or core app logic. Symlink canonicalization is the main subtlety, covered by tests.
> 
> **Overview**
> Design hook passes were scanning **throwaway or sibling-repo files** (harness scratchpads, temp HTML) and judging them against **this** project's config and DESIGN.md. This PR adds a shared **project containment gate** so those targets are skipped with audit reason `outside-project`.
> 
> **`isScanTargetInsideProject`** in `hook-lib.mjs` compares **canonical** paths (symlink-aware, including nearest-existing-ancestor for not-yet-written Write targets). The Cursor **before-edit** hook drops its local helper and uses this everywhere it checks containment.
> 
> **Per-edit** (`runHook`) skips out-of-project files **before** cache mutation so scratchpad paths never enter the session cache. **Stop deep pass** re-checks containment because older caches may still list out-of-project paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62a2026afcd8223bed178b0348fc84d9c03690f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->