### PR TITLE
🐛 Fix DESIGN.md Layout and Shapes parsing

### DIFF
--- a/skill/scripts/lib/design-parser.mjs
+++ b/skill/scripts/lib/design-parser.mjs
@@ -2,7 +2,7 @@
 // the live-mode design-system panel can render. Deterministic, dependency-free.
 //
 // Two-layer: YAML frontmatter (machine-readable tokens) + markdown body
-// (prose with six canonical H2 sections). When frontmatter is present, it's
+// (prose with eight canonical H2 sections). When frontmatter is present, it's
 // exposed on `model.frontmatter` alongside the prose-scraped sections;
 // consumers can prefer frontmatter values and fall back to prose.
 
@@ -10,7 +10,9 @@ const CANONICAL_SECTIONS = [
   'Overview',
   'Colors',
   'Typography',
+  'Layout',
   'Elevation',
+  'Shapes',
   'Components',
   "Do's and Don'ts",
 ];
@@ -601,6 +603,16 @@ function parseTypeBullet(bullet) {
   };
 }
 
+function extractGuidance(section) {
+  if (!section) return null;
+  const subs = splitSubsections(section.lines);
+  return {
+    subtitle: section.subtitle,
+    description: collectParagraphs(subs[0].lines).join(' ') || null,
+    rules: extractNamedRules(section.lines),
+  };
+}
+
 function extractElevation(section) {
   if (!section) return null;
   const subs = splitSubsections(section.lines);
@@ -795,11 +807,25 @@ function assessCoverage(model) {
       }
     : 'missing';
 
+  report.layout = model.layout
+    ? {
+        description: Boolean(model.layout.description),
+        rules: model.layout.rules.length,
+      }
+    : 'missing';
+
   report.elevation = model.elevation
     ? {
         shadows: model.elevation.shadows.length,
         rules: model.elevation.rules.length,
         description: Boolean(model.elevation.description),
+      }
+    : 'missing';
+
+  report.shapes = model.shapes
+    ? {
+        description: Boolean(model.shapes.description),
+        rules: model.shapes.rules.length,
       }
     : 'missing';
 
@@ -832,7 +858,9 @@ export function parseDesignMd(md) {
     overview: extractOverview(sections['Overview']),
     colors: extractColors(sections['Colors']),
     typography: extractTypography(sections['Typography']),
+    layout: extractGuidance(sections['Layout']),
     elevation: extractElevation(sections['Elevation']),
+    shapes: extractGuidance(sections['Shapes']),
     components: extractComponents(sections['Components']),
     dosDonts: extractDosDonts(sections["Do's and Don'ts"]),
   };

--- a/skill/scripts/lib/design-parser.mjs
+++ b/skill/scripts/lib/design-parser.mjs
@@ -6,6 +6,9 @@
 // exposed on `model.frontmatter` alongside the prose-scraped sections;
 // consumers can prefer frontmatter values and fall back to prose.
 
+// Array order is also match precedence: matchCanonicalSection's keyword-contained
+// pass returns the first entry a heading contains, so reordering this changes
+// which section an ambiguous heading resolves to.
 const CANONICAL_SECTIONS = [
   'Overview',
   'Colors',
@@ -614,10 +617,8 @@ function extractGuidance(section) {
 }
 
 function extractElevation(section) {
-  if (!section) return null;
-  const subs = splitSubsections(section.lines);
-
-  const description = collectParagraphs(subs[0].lines).join(' ') || null;
+  const guidance = extractGuidance(section);
+  if (!guidance) return null;
 
   const shadows = [];
   const seen = new Set();
@@ -642,12 +643,7 @@ function extractElevation(section) {
     for (const inline of extractInlineShadows(b)) dedupe(inline);
   }
 
-  return {
-    subtitle: section.subtitle,
-    description,
-    shadows,
-    rules: extractNamedRules(section.lines),
-  };
+  return { ...guidance, shadows };
 }
 
 function extractInlineShadows(text) {
@@ -779,6 +775,15 @@ function extractDosDonts(section) {
 
 // ---------- Coverage assessment ----------
 
+// Sections whose model is description-plus-rules only (see extractGuidance).
+const guidanceCoverage = (guidance) =>
+  guidance
+    ? {
+        description: Boolean(guidance.description),
+        rules: guidance.rules.length,
+      }
+    : 'missing';
+
 function assessCoverage(model) {
   const report = {};
 
@@ -807,12 +812,7 @@ function assessCoverage(model) {
       }
     : 'missing';
 
-  report.layout = model.layout
-    ? {
-        description: Boolean(model.layout.description),
-        rules: model.layout.rules.length,
-      }
-    : 'missing';
+  report.layout = guidanceCoverage(model.layout);
 
   report.elevation = model.elevation
     ? {
@@ -822,12 +822,7 @@ function assessCoverage(model) {
       }
     : 'missing';
 
-  report.shapes = model.shapes
-    ? {
-        description: Boolean(model.shapes.description),
-        rules: model.shapes.rules.length,
-      }
-    : 'missing';
+  report.shapes = guidanceCoverage(model.shapes);
 
   report.components = model.components
     ? {

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -11975,7 +11975,9 @@ void main() {
       rules: [
         ...(md.colors?.rules || []).map((r) => ({ ...r, section: 'colors' })),
         ...(md.typography?.rules || []).map((r) => ({ ...r, section: 'typography' })),
+        ...(md.layout?.rules || []).map((r) => ({ ...r, section: 'layout' })),
         ...(md.elevation?.rules || []).map((r) => ({ ...r, section: 'elevation' })),
+        ...(md.shapes?.rules || []).map((r) => ({ ...r, section: 'shapes' })),
       ],
       dos: md.dosDonts?.dos || [],
       donts: md.dosDonts?.donts || [],

--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -873,7 +873,7 @@ function createRequestHandler({ detectScript, liveScriptParts }) {
     //                            { present, parsed, sidecar, hasMd, hasSidecar,
     //                              mdNewerThanJson, parseError?, sidecarError? }
     //                          - parsed: output of parseDesignMd (frontmatter
-    //                            + six canonical sections) when DESIGN.md exists.
+    //                            + the canonical sections) when DESIGN.md exists.
     //                          - sidecar: .impeccable/design.json contents when present.
     //                            Expected shape: schemaVersion 2, carrying
     //                            extensions + components + narrative.

--- a/tests/design-parser.test.mjs
+++ b/tests/design-parser.test.mjs
@@ -235,6 +235,11 @@ Repeated geometry must remain recognizable without color.
     }]);
 
     const coverage = assessCoverage(model);
+    assert.deepEqual(
+      Object.entries(coverage).filter(([, v]) => v === 'missing').map(([k]) => k),
+      [],
+      'a section present in the markdown must not be reported as missing',
+    );
     assert.deepEqual(Object.keys(coverage), [
       'overview',
       'colors',

--- a/tests/design-parser.test.mjs
+++ b/tests/design-parser.test.mjs
@@ -5,7 +5,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseDesignMd } from '../skill/scripts/lib/design-parser.mjs';
+import { assessCoverage, parseDesignMd } from '../skill/scripts/lib/design-parser.mjs';
 
 describe('parseDesignMd frontmatter branch', () => {
   it('returns null frontmatter when the file has no YAML header', () => {
@@ -166,5 +166,86 @@ describe('parseDesignMd overview branch', () => {
       'Navigation controls remain visible when the viewport becomes narrow.',
     ]);
     assert.deepEqual(overview.philosophy, []);
+  });
+});
+
+describe('parseDesignMd canonical sections', () => {
+  it('preserves content and named rules from all eight canonical sections', () => {
+    const md = `# Design System: Complete
+
+## Overview
+
+**Creative North Star: "Structured clarity"**
+
+## Colors
+
+### Primary
+- **Ink** (#111111): Primary text.
+
+## Typography
+
+**Body Font:** Inter (with sans-serif)
+
+## Layout: Responsive rhythm
+
+Primary regions use a twelve-column grid that collapses to one column on narrow screens.
+
+### Named Rules
+**The Spatial Hierarchy Rule.** Primary content must remain visually dominant.
+
+## Elevation & Depth
+
+Surfaces use tonal layering instead of shadows.
+
+## Shapes
+
+Selected objects use a double outline and clipped corners.
+
+### The "Recognizable Silhouette" Rule
+Repeated geometry must remain recognizable without color.
+
+## Components
+
+### Button
+- **Primary:** Uses the accent color.
+
+## Do's and Don'ts
+
+### Do
+- Preserve the spatial hierarchy.
+
+### Don't
+- Flatten every surface.
+`;
+    const model = parseDesignMd(md);
+
+    assert.equal(model.layout.subtitle, 'Responsive rhythm');
+    assert.equal(
+      model.layout.description,
+      'Primary regions use a twelve-column grid that collapses to one column on narrow screens.',
+    );
+    assert.deepEqual(model.layout.rules, [{
+      name: 'The Spatial Hierarchy Rule',
+      body: 'Primary content must remain visually dominant.',
+    }]);
+    assert.equal(model.shapes.description, 'Selected objects use a double outline and clipped corners.');
+    assert.deepEqual(model.shapes.rules, [{
+      name: 'The Recognizable Silhouette Rule',
+      body: 'Repeated geometry must remain recognizable without color.',
+    }]);
+
+    const coverage = assessCoverage(model);
+    assert.deepEqual(Object.keys(coverage), [
+      'overview',
+      'colors',
+      'typography',
+      'layout',
+      'elevation',
+      'shapes',
+      'components',
+      'dosDonts',
+    ]);
+    assert.deepEqual(coverage.layout, { description: true, rules: 1 });
+    assert.deepEqual(coverage.shapes, { description: true, rules: 1 });
   });
 });

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -1334,11 +1334,19 @@ describe('live-browser.js regression guards', () => {
   });
 
   it('includes named rules from every canonical narrative section', () => {
-    assert.match(
-      SOURCE,
-      /function synthesizeNarrative\(parsed\)[\s\S]{0,900}?md\.colors\?\.rules[\s\S]{0,180}?md\.typography\?\.rules[\s\S]{0,180}?md\.layout\?\.rules[\s\S]{0,180}?md\.elevation\?\.rules[\s\S]{0,180}?md\.shapes\?\.rules/,
-      'the design panel must retain named rules from Layout and Shapes alongside the older canonical sections',
-    );
+    const narrativeStart = SOURCE.indexOf('  function synthesizeNarrative(parsed) {');
+    const narrativeEnd = SOURCE.indexOf('\n  function renderColorTiles', narrativeStart);
+    assert.notEqual(narrativeStart, -1, 'synthesizeNarrative must exist');
+    assert.notEqual(narrativeEnd, -1, 'synthesizeNarrative must end before renderColorTiles');
+    const narrativeSource = SOURCE.slice(narrativeStart, narrativeEnd);
+
+    for (const section of ['colors', 'typography', 'layout', 'elevation', 'shapes']) {
+      assert.match(
+        narrativeSource,
+        new RegExp(`md\\.${section}\\?\\.rules[^\\n]*section: '${section}'`),
+        `the design panel must carry named rules tagged with their ${section} section`,
+      );
+    }
   });
 
   it('editing focus timeout does not read a stale inline edit row', () => {

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -1333,6 +1333,14 @@ describe('live-browser.js regression guards', () => {
     );
   });
 
+  it('includes named rules from every canonical narrative section', () => {
+    assert.match(
+      SOURCE,
+      /function synthesizeNarrative\(parsed\)[\s\S]{0,900}?md\.colors\?\.rules[\s\S]{0,180}?md\.typography\?\.rules[\s\S]{0,180}?md\.layout\?\.rules[\s\S]{0,180}?md\.elevation\?\.rules[\s\S]{0,180}?md\.shapes\?\.rules/,
+      'the design panel must retain named rules from Layout and Shapes alongside the older canonical sections',
+    );
+  });
+
   it('editing focus timeout does not read a stale inline edit row', () => {
     assert.doesNotMatch(
       SOURCE,


### PR DESCRIPTION
Fixes #462.

## Summary 

The `DESIGN.md `parser now recognizes all eight canonical sections. `Layout` and `Shapes` retain their guidance and named rules in the parsed model, coverage reporting includes both sections, and Impeccable Live surfaces their named rules.

## Validation

- `node --test tests/design-parser.test.mjs tests/live-browser-regression.test.mjs` — 62 tests passed
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser and design-panel narrative changes only; no auth, persistence, or generation pipeline behavior beyond richer parsed output.
> 
> **Overview**
> **Adds `Layout` and `Shapes` as canonical `DESIGN.md` sections** so their prose, subtitles, and named rules survive parsing instead of being dropped when headings matched only the older six-section set.
> 
> `design-parser.mjs` registers both sections in `CANONICAL_SECTIONS` (with a note that order affects ambiguous heading resolution), introduces **`extractGuidance`** for description-plus-rules sections, and refactors **`extractElevation`** to build on that helper while still extracting shadows. **`assessCoverage`** and **`parseDesignMd`** now emit `layout` and `shapes` on the v2 model.
> 
> **Impeccable Live** merges **`layout` and `shapes` named rules** into the synthesized design-panel narrative (alongside colors, typography, and elevation). A server comment is updated to refer to canonical sections generically rather than “six.”
> 
> Tests cover full eight-section parsing, coverage keys, and a regression guard on `synthesizeNarrative`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1989905e23ba454c8f2adf8b6e174ef24b3fc305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->