### PR TITLE
Simplify import graph scanning

### DIFF
--- a/cli/engine/node/file-system.mjs
+++ b/cli/engine/node/file-system.mjs
@@ -31,6 +31,12 @@ const SCANNABLE_EXTENSIONS = new Set([
 
 const HTML_EXTENSIONS = new Set(['.html', '.htm']);
 
+const IMPORT_SPECIFIER_PATTERNS = [
+  /import\s+(?:[\s\S]*?from\s+)?['"]([^'"]+)['"]/g,
+  /@import\s+(?:url\(\s*)?['"]?([^'");\s]+)['"]?\s*\)?/g,
+  /@(?:use|forward)\s+['"]([^'"]+)['"]/g,
+];
+
 function walkDir(dir) {
   const files = [];
   let entries;
@@ -75,26 +81,11 @@ function buildImportGraph(files) {
     const dir = path.dirname(file);
     const imports = new Set();
 
-    // ES imports: import ... from '...' and import '...'
-    const esRe = /import\s+(?:[\s\S]*?from\s+)?['"]([^'"]+)['"]/g;
-    let m;
-    while ((m = esRe.exec(content)) !== null) {
-      const resolved = resolveImport(m[1], dir, fileSet);
-      if (resolved) imports.add(resolved);
-    }
-
-    // CSS @import
-    const cssRe = /@import\s+(?:url\(\s*)?['"]?([^'");\s]+)['"]?\s*\)?/g;
-    while ((m = cssRe.exec(content)) !== null) {
-      const resolved = resolveImport(m[1], dir, fileSet);
-      if (resolved) imports.add(resolved);
-    }
-
-    // SCSS @use / @forward
-    const scssRe = /@(?:use|forward)\s+['"]([^'"]+)['"]/g;
-    while ((m = scssRe.exec(content)) !== null) {
-      const resolved = resolveImport(m[1], dir, fileSet);
-      if (resolved) imports.add(resolved);
+    for (const pattern of IMPORT_SPECIFIER_PATTERNS) {
+      for (const match of content.matchAll(pattern)) {
+        const resolved = resolveImport(match[1], dir, fileSet);
+        if (resolved) imports.add(resolved);
+      }
     }
 
     graph.set(file, imports);

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -2797,6 +2797,20 @@ describe('buildImportGraph', () => {
     expect(themeImports.has(path.join(MF, 'variables.sass'))).toBe(true);
   });
 
+  test('resolves Sass @use and @forward', async () => {
+    await withStaticFixture({
+      'theme.scss': "@use './variables';\n@forward './tokens';\n",
+      'variables.scss': '$primary: rebeccapurple;\n',
+      'tokens.scss': '$spacing: 1rem;\n',
+    }, ({ dir }) => {
+      const theme = path.join(dir, 'theme.scss');
+      const variables = path.join(dir, 'variables.scss');
+      const tokens = path.join(dir, 'tokens.scss');
+      const graph = buildImportGraph([theme, variables, tokens]);
+      expect(graph.get(theme)).toEqual(new Set([variables, tokens]));
+    });
+  });
+
   test('ignores bare/node_modules imports', () => {
     const graph = buildImportGraph([
       path.join(MF, 'App.tsx'),


### PR DESCRIPTION
## Summary

- replace three duplicated import-specifier scanner loops with one declarative pattern list and one shared resolve-and-add path
- characterize the previously uncovered Sass `@use` and `@forward` behavior
- preserve file walking, import resolution order, graph shape, public exports, CLI output, and error behavior

## Hindsight architecture review

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No. ES imports, CSS `@import`, and Sass `@use`/`@forward` are different syntaxes, but once a specifier is captured they follow the same durable rule. Maintaining three stateful loops duplicated that rule and made each new syntax another control-flow branch.

The smallest cleaner architecture is a private declarative pattern list consumed by one scanner loop. This avoids extracting modules or changing the file's broader responsibilities.

## Before / after

- Primary file: `cli/engine/node/file-system.mjs`
- Line count: **212 → 203** (9 production lines removed, 4.2%)
- Before: three separately constructed global regexes, three `exec` loops, one shared mutable match variable, and three copies of resolve-and-add
- After: one private syntax table and one `matchAll` loop; import resolution remains centralized in the existing `resolveImport`
- Responsibilities unchanged: file walking, import graph construction, framework config discovery, and dev-server probing
- Public exports/entry points unchanged
- Diff accounting: production source **+11/-20**; characterization coverage **+14/-0**

## Validation

- `bun test tests/detect-antipatterns.test.js -t 'buildImportGraph|resolveImport'` — 10 passed
- `bun test tests/detect-antipatterns.test.js` — 299 passed
- `bun run build:browser`
- `bun run build:extension`
- `bun run build`
- `bun run test` — full repository suite passed, including authoritative headless-browser and framework fixture groups

Generated output was validated by the prescribed builds. No tracked generated diff resulted, so generated output is intentionally omitted.

## Risk

Low. The pattern text, pattern order, resolution function, set semantics, and graph API are unchanged. The remaining risk is limited to the switch from manual `RegExp.exec` iteration to `String.matchAll`; this is supported by the repository's Node/Bun targets and exercised across multiple files by the focused and full suites.

AI assistance was used to prepare this refactor. It was created under maintainer pbakaus's standing authorization for the scheduled daily architecture-simplification automation. Nothing in this workflow authorizes merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with identical regex patterns and resolution path; residual risk is only the switch from manual `exec` loops to `matchAll`, which is covered by existing and new graph tests.
> 
> **Overview**
> **Refactors `buildImportGraph` in `file-system.mjs`** so ES `import`, CSS `@import`, and Sass `@use`/`@forward` are driven by one private `IMPORT_SPECIFIER_PATTERNS` list and a single `matchAll` loop, instead of three duplicated `RegExp.exec` scanners.
> 
> **Resolution behavior is unchanged:** each captured specifier still goes through `resolveImport`, and edges are still stored in a `Set` on the same graph API used by the CLI for `importedBy` context.
> 
> **Adds characterization coverage** in `detect-antipatterns.test.js` for a `theme.scss` file that `@use`s and `@forward`s sibling modules, asserting both targets appear in the graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c90faaab558c4abb1dd19798ce32bca75e1ac311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->