### PR TITLE
Drop deprecated craft alias from the generated argument-hint

### DIFF
--- a/scripts/lib/skill-categories.js
+++ b/scripts/lib/skill-categories.js
@@ -6,8 +6,10 @@
 
 export const SKILL_CATEGORIES = {
   // CREATE - build something new
+  // craft is deliberately unmapped: it is a deprecated compatibility alias
+  // (see the router table), and a command without a category stays out of
+  // the generated argument-hint while continuing to route.
   impeccable: 'create',
-  craft: 'create',
   shape: 'create',
   // EVALUATE - review and assess
   critique: 'evaluate',


### PR DESCRIPTION
Part 1 of the fix for #475 (merge this first).

`craft` is a deprecated compatibility alias, but its `SKILL_CATEGORIES` entry kept it advertised in every generated `argument-hint`. This unmaps it: the hint stops listing craft, the alias keeps routing via the router table and `command-metadata.json`.

Needed before the impeccable-site fix for #475 deploys: the site will start building bundles with the current transformers, and without this line removed the served hint would re-advertise craft.

Validated with `bun run build` (hint now reads `[shape · audit|critique · ...]`) and `bun run test` (all pass). No version bump, no generated output staged.

AI-assisted change, prepared under maintainer direction.

Made with [Cursor](https://cursor.com)