### PR TITLE
Fix broken-image findings in source comments

### DIFF
--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -42,17 +42,19 @@ function shouldRunPageAnalyzers(content, filePath) {
 }
 
 const JS_SOURCE_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const REGEX_PREFIX_KEYWORDS = new Set(['await', 'case', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'return', 'throw', 'typeof', 'void', 'yield']);
 
 /**
  * Blank JavaScript comments without moving any following source. Regex
  * findings keep their original line numbers, while prose examples inside
  * comments cannot masquerade as rendered markup.
  */
-function stripJsComments(content) {
+function stripJsComments(content, options = {}) {
   let state = 'code';
   let output = '';
   let lastSignificant = '';
   let previousSignificant = '';
+  let currentWord = '';
   let regexCharClass = false;
   const templateExpressionDepths = [];
 
@@ -60,6 +62,7 @@ function stripJsComments(content) {
     if (/\s/.test(char)) return;
     previousSignificant = lastSignificant;
     lastSignificant = char;
+    currentWord = /[\w$]/.test(char) ? currentWord + char : '';
   };
 
   for (let i = 0; i < content.length; i++) {
@@ -129,7 +132,13 @@ function stripJsComments(content) {
       continue;
     }
 
-    if (char === '/' && next === '/') {
+    const jsxUrlSeparator = options.jsx && (output.endsWith('http:') || output.endsWith('https:'));
+    if (char === '/' && next === '/' && jsxUrlSeparator) {
+      output += '//';
+      i++;
+      recordSignificant('/');
+      recordSignificant('/');
+    } else if (char === '/' && next === '/') {
       output += '  ';
       i++;
       state = 'line-comment';
@@ -152,7 +161,7 @@ function stripJsComments(content) {
       }
     } else if (
       char === '/' &&
-      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || (previousSignificant === '=' && lastSignificant === '>'))
+      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || (previousSignificant === '=' && lastSignificant === '>') || REGEX_PREFIX_KEYWORDS.has(currentWord))
     ) {
       output += char;
       state = 'regex';
@@ -756,7 +765,9 @@ function detectText(content, filePath, options = {}) {
   const profile = options?.profile;
   const findings = [];
   const ext = extFromFilePath(filePath);
-  const source = JS_SOURCE_EXTS.has(ext) ? stripJsComments(content) : content;
+  const source = JS_SOURCE_EXTS.has(ext) ? stripJsComments(content, {
+    jsx: ext === '.jsx' || ext === '.tsx',
+  }) : content;
   const lines = source.split('\n');
 
   // Run regex matchers on the full file content (catches Tailwind classes, inline styles)

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -54,6 +54,7 @@ function stripJsComments(content) {
   let lastSignificant = '';
   let previousSignificant = '';
   let regexCharClass = false;
+  const templateExpressionDepths = [];
 
   const recordSignificant = (char) => {
     if (/\s/.test(char)) return;
@@ -102,6 +103,16 @@ function stripJsComments(content) {
       continue;
     }
 
+    if (state === 'template' && char === '$' && next === '{') {
+      output += '${';
+      i++;
+      recordSignificant('$');
+      recordSignificant('{');
+      templateExpressionDepths.push(1);
+      state = 'code';
+      continue;
+    }
+
     if (state !== 'code') {
       output += char;
       if (char === '\\' && next) {
@@ -126,6 +137,19 @@ function stripJsComments(content) {
       output += '  ';
       i++;
       state = 'block-comment';
+    } else if (templateExpressionDepths.length && char === '{') {
+      output += char;
+      templateExpressionDepths[templateExpressionDepths.length - 1]++;
+      recordSignificant(char);
+    } else if (templateExpressionDepths.length && char === '}') {
+      output += char;
+      const depthIndex = templateExpressionDepths.length - 1;
+      templateExpressionDepths[depthIndex]--;
+      recordSignificant(char);
+      if (templateExpressionDepths[depthIndex] === 0) {
+        templateExpressionDepths.pop();
+        state = 'template';
+      }
     } else if (
       char === '/' &&
       (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || (previousSignificant === '=' && lastSignificant === '>'))

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -690,28 +690,75 @@ function extractStyleBlocks(content, ext) {
 // ---------------------------------------------------------------------------
 
 const CSS_IN_JS_EXTENSIONS = new Set(['.js', '.ts', '.jsx', '.tsx']);
-const CSS_IN_JS_TAG_PATTERN = '(?:styled(?:\\.\\w+|\\([^)]+\\))|css)(?:\\s*<[^>\\n]+>)?';
+
+function findCSSinJSTemplates(content) {
+  const templates = [];
+  const tagRe = /\b(?:styled(?:\.\w+|\([^)]+\))|css)/g;
+  let match;
+  while ((match = tagRe.exec(content)) !== null) {
+    let cursor = match.index + match[0].length;
+    while (/\s/.test(content[cursor] || '')) cursor++;
+
+    if (content[cursor] === '<') {
+      let depth = 0;
+      while (cursor < content.length) {
+        const char = content[cursor];
+        if (char === '<') depth++;
+        else if (char === '>' && content[cursor - 1] !== '=') depth--;
+        cursor++;
+        if (depth === 0) break;
+      }
+      if (depth !== 0) continue;
+      while (/\s/.test(content[cursor] || '')) cursor++;
+    }
+
+    if (content[cursor] !== '`') continue;
+    const contentStart = cursor + 1;
+    cursor = contentStart;
+    while (cursor < content.length) {
+      if (content[cursor] === '\\') {
+        cursor += 2;
+        continue;
+      }
+      if (content[cursor] === '`') break;
+      cursor++;
+    }
+    if (cursor >= content.length) continue;
+
+    templates.push({
+      tagStart: match.index,
+      contentStart,
+      contentEnd: cursor,
+    });
+    tagRe.lastIndex = cursor + 1;
+  }
+  return templates;
+}
 
 function extractCSSinJS(content, ext) {
   ext = ext.toLowerCase();
   if (!CSS_IN_JS_EXTENSIONS.has(ext)) return [];
-  const blocks = [];
-  const re = new RegExp(CSS_IN_JS_TAG_PATTERN + '\\s*`([\\s\\S]*?)`', 'g');
-  let m;
-  while ((m = re.exec(content)) !== null) {
-    const before = content.substring(0, m.index);
+  return findCSSinJSTemplates(content).map((template) => {
+    const before = content.substring(0, template.tagStart);
     const startLine = before.split('\n').length;
-    blocks.push({ content: m[1], startLine });
-  }
-  return blocks;
+    return {
+      content: content.slice(template.contentStart, template.contentEnd),
+      startLine,
+    };
+  });
 }
 
 function stripCssInJsComments(content, ext) {
   if (!CSS_IN_JS_EXTENSIONS.has(ext.toLowerCase())) return content;
-  return content.replace(
-    new RegExp(CSS_IN_JS_TAG_PATTERN + '\\s*`[\\s\\S]*?`', 'g'),
-    block => stripCssComments(block),
-  );
+  const templates = findCSSinJSTemplates(content);
+  let output = '';
+  let cursor = 0;
+  for (const template of templates) {
+    output += content.slice(cursor, template.contentStart);
+    output += stripCssComments(content.slice(template.contentStart, template.contentEnd));
+    cursor = template.contentEnd;
+  }
+  return output + content.slice(cursor);
 }
 
 function runRegexMatchers(lines, filePath, lineOffset = 0, blockContext = null, options = {}) {

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -55,14 +55,18 @@ function stripJsComments(content, options = {}) {
   let lastSignificant = '';
   let previousSignificant = '';
   let currentWord = '';
+  let currentWordPrefix = '';
   let regexCharClass = false;
   const templateExpressionDepths = [];
 
   const recordSignificant = (char) => {
     if (/\s/.test(char)) return;
+    const isWordChar = /[\w$]/.test(char);
+    if (isWordChar && !currentWord) currentWordPrefix = lastSignificant;
+    else if (!isWordChar) currentWordPrefix = '';
     previousSignificant = lastSignificant;
     lastSignificant = char;
-    currentWord = /[\w$]/.test(char) ? currentWord + char : '';
+    currentWord = isWordChar ? currentWord + char : '';
   };
 
   for (let i = 0; i < content.length; i++) {
@@ -161,7 +165,7 @@ function stripJsComments(content, options = {}) {
       }
     } else if (
       char === '/' &&
-      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || (previousSignificant === '=' && lastSignificant === '>') || REGEX_PREFIX_KEYWORDS.has(currentWord))
+      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || (previousSignificant === '=' && lastSignificant === '>') || (currentWordPrefix !== '.' && REGEX_PREFIX_KEYWORDS.has(currentWord)))
     ) {
       output += char;
       state = 'regex';

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -191,6 +191,10 @@ function stripJsComments(content, options = {}) {
   return output;
 }
 
+function stripCssComments(content) {
+  return content.replace(/\/\*[\s\S]*?\*\//g, comment => comment.replace(/[^\n]/g, ' '));
+}
+
 function firstOverusedGoogleFont(text) {
   return extractGoogleFontFamilies(text).find(f => OVERUSED_FONTS.has(f)) || '';
 }
@@ -692,6 +696,14 @@ function extractCSSinJS(content, ext) {
   return blocks;
 }
 
+function stripCssInJsComments(content, ext) {
+  if (!CSS_IN_JS_EXTENSIONS.has(ext.toLowerCase())) return content;
+  return content.replace(
+    /(?:styled(?:\.\w+|\([^)]+\))|css)\s*`[\s\S]*?`/g,
+    block => stripCssComments(block),
+  );
+}
+
 function runRegexMatchers(lines, filePath, lineOffset = 0, blockContext = null, options = {}) {
   const { profile, phase = 'regex-matchers' } = options || {};
   const findings = [];
@@ -778,9 +790,10 @@ function detectText(content, filePath, options = {}) {
   const profile = options?.profile;
   const findings = [];
   const ext = extFromFilePath(filePath);
-  const source = JS_SOURCE_EXTS.has(ext) ? stripJsComments(content, {
+  const commentStrippedSource = JS_SOURCE_EXTS.has(ext) ? stripJsComments(content, {
     jsx: ext === '.js' || ext === '.jsx' || ext === '.tsx',
   }) : content;
+  const source = stripCssInJsComments(commentStrippedSource, ext);
   const lines = source.split('\n');
 
   // Run regex matchers on the full file content (catches Tailwind classes, inline styles)
@@ -851,16 +864,17 @@ function detectText(content, filePath, options = {}) {
       phase: 'extract',
       ruleId: 'css-in-js',
       target: filePath,
-    }, () => extractCSSinJS(content, ext))
-    : extractCSSinJS(content, ext);
+    }, () => extractCSSinJS(source, ext))
+    : extractCSSinJS(source, ext);
   for (const block of cssJsBlocks) {
-    const blockLines = block.content.split('\n');
+    const blockContent = stripCssComments(block.content);
+    const blockLines = blockContent.split('\n');
     findings.push(...runRegexMatchers(blockLines, filePath, block.startLine - 1, true, {
       profile,
       phase: 'css-in-js',
     }));
-    findings.push(...scanInsetStripeCss(block.content, filePath, block.startLine - 1));
-    findings.push(...pseudoStripeFindings(block.content, block.startLine - 1));
+    findings.push(...scanInsetStripeCss(blockContent, filePath, block.startLine - 1));
+    findings.push(...pseudoStripeFindings(blockContent, block.startLine - 1));
   }
 
   if (options?.designSystem) {

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -42,7 +42,8 @@ function shouldRunPageAnalyzers(content, filePath) {
 }
 
 const JS_SOURCE_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
-const REGEX_PREFIX_KEYWORDS = new Set(['await', 'case', 'default', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'return', 'throw', 'typeof', 'void', 'yield']);
+const REGEX_PREFIX_KEYWORDS = new Set(['await', 'case', 'default', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'of', 'return', 'throw', 'typeof', 'void', 'yield']);
+const BLOCK_BRACE_PREFIX_KEYWORDS = new Set(['do', 'else', 'finally', 'try']);
 
 /**
  * Blank JavaScript comments without moving any following source. Regex
@@ -60,7 +61,20 @@ function stripJsComments(content, options = {}) {
   let wordSeparated = false;
   let regexCharClass = false;
   let jsxExpressionDepth = 0;
+  let lastClosedBraceKind = '';
+  const braceKinds = [];
   const templateExpressionDepths = [];
+
+  const braceKind = (startsJsxExpression = false) => (
+    !startsJsxExpression && (
+      !lastSignificant ||
+      lastSignificant === ')' ||
+      lastSignificant === ';' ||
+      lastSignificant === '}' ||
+      (previousSignificant === '=' && lastSignificant === '>') ||
+      BLOCK_BRACE_PREFIX_KEYWORDS.has(currentWord)
+    ) ? 'block' : 'expression'
+  );
 
   const recordSignificant = (char) => {
     if (/\s/.test(char)) {
@@ -128,6 +142,7 @@ function stripJsComments(content, options = {}) {
       recordSignificant('$');
       recordSignificant('{');
       templateExpressionDepths.push(1);
+      braceKinds.push('expression');
       if (jsxExpressionDepth) jsxExpressionDepth++;
       state = 'code';
       continue;
@@ -174,12 +189,14 @@ function stripJsComments(content, options = {}) {
     } else if (templateExpressionDepths.length && char === '{') {
       output += char;
       templateExpressionDepths[templateExpressionDepths.length - 1]++;
+      braceKinds.push(braceKind());
       if (jsxExpressionDepth) jsxExpressionDepth++;
       recordSignificant(char);
     } else if (templateExpressionDepths.length && char === '}') {
       output += char;
       const depthIndex = templateExpressionDepths.length - 1;
       templateExpressionDepths[depthIndex]--;
+      lastClosedBraceKind = braceKinds.pop() || '';
       if (jsxExpressionDepth) jsxExpressionDepth--;
       recordSignificant(char);
       if (templateExpressionDepths[depthIndex] === 0) {
@@ -189,7 +206,8 @@ function stripJsComments(content, options = {}) {
     } else if (
       char === '/' &&
       (!lastSignificant ||
-        (/[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) && !afterPostfixUpdate) ||
+        (/[=([{!?:;,&|+\-*%^~<>]/.test(lastSignificant) && !afterPostfixUpdate) ||
+        (lastSignificant === '}' && lastClosedBraceKind === 'block') ||
         (previousSignificant === '=' && lastSignificant === '>') ||
         (currentWordPrefix !== '.' && REGEX_PREFIX_KEYWORDS.has(currentWord)))
     ) {
@@ -200,6 +218,8 @@ function stripJsComments(content, options = {}) {
       output += char;
       const startsJsxExpression = options.jsx && char === '{' && jsxExpressionDepth === 0 &&
         /<[A-Za-z](?:[^>]*[^/])?>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1, -1));
+      if (char === '{') braceKinds.push(braceKind(startsJsxExpression));
+      else if (char === '}') lastClosedBraceKind = braceKinds.pop() || '';
       if (char === '{' && (jsxExpressionDepth || startsJsxExpression)) jsxExpressionDepth++;
       else if (char === '}' && jsxExpressionDepth) jsxExpressionDepth--;
       recordSignificant(char);
@@ -940,8 +960,8 @@ function detectText(content, filePath, options = {}) {
     phase: 'source',
     ruleId: 'codex-grid-background',
     target: filePath,
-  }, () => scanCssTextForGridBackground(content).map(hit => {
-    const line = content.substring(0, hit.index).split('\n').length;
+  }, () => scanCssTextForGridBackground(source).map(hit => {
+    const line = source.substring(0, hit.index).split('\n').length;
     return finding('codex-grid-background', filePath, hit.snippet, line);
   })));
 

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -41,6 +41,102 @@ function shouldRunPageAnalyzers(content, filePath) {
   return !ext || PAGE_ANALYZER_EXTS.has(ext);
 }
 
+const JS_SOURCE_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+
+/**
+ * Blank JavaScript comments without moving any following source. Regex
+ * findings keep their original line numbers, while prose examples inside
+ * comments cannot masquerade as rendered markup.
+ */
+function stripJsComments(content) {
+  let state = 'code';
+  let output = '';
+  let lastSignificant = '';
+  let regexCharClass = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+    const next = content[i + 1];
+
+    if (state === 'line-comment') {
+      if (char === '\n') {
+        output += char;
+        state = 'code';
+      } else {
+        output += ' ';
+      }
+      continue;
+    }
+
+    if (state === 'block-comment') {
+      if (char === '*' && next === '/') {
+        output += '  ';
+        i++;
+        state = 'code';
+      } else {
+        output += char === '\n' ? '\n' : ' ';
+      }
+      continue;
+    }
+
+    if (state === 'regex') {
+      output += char;
+      if (char === '\\' && next) {
+        output += next;
+        i++;
+      } else if (char === '[') {
+        regexCharClass = true;
+      } else if (char === ']') {
+        regexCharClass = false;
+      } else if (char === '/' && !regexCharClass) {
+        state = 'code';
+        lastSignificant = '/';
+      }
+      continue;
+    }
+
+    if (state !== 'code') {
+      output += char;
+      if (char === '\\' && next) {
+        output += next;
+        i++;
+      } else if (
+        (state === 'single-quote' && char === "'") ||
+        (state === 'double-quote' && char === '"') ||
+        (state === 'template' && char === '`')
+      ) {
+        state = 'code';
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      output += '  ';
+      i++;
+      state = 'line-comment';
+    } else if (char === '/' && next === '*') {
+      output += '  ';
+      i++;
+      state = 'block-comment';
+    } else if (
+      char === '/' &&
+      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || output.trimEnd().endsWith('=>'))
+    ) {
+      output += char;
+      state = 'regex';
+      regexCharClass = false;
+    } else {
+      output += char;
+      if (!/\s/.test(char)) lastSignificant = char;
+      if (char === "'") state = 'single-quote';
+      else if (char === '"') state = 'double-quote';
+      else if (char === '`') state = 'template';
+    }
+  }
+
+  return output;
+}
+
 function firstOverusedGoogleFont(text) {
   return extractGoogleFontFamilies(text).find(f => OVERUSED_FONTS.has(f)) || '';
 }
@@ -627,8 +723,9 @@ function runTextContentAnalyzers(content, filePath, options = {}) {
 function detectText(content, filePath, options = {}) {
   const profile = options?.profile;
   const findings = [];
-  const lines = content.split('\n');
   const ext = extFromFilePath(filePath);
+  const source = JS_SOURCE_EXTS.has(ext) ? stripJsComments(content) : content;
+  const lines = source.split('\n');
 
   // Run regex matchers on the full file content (catches Tailwind classes, inline styles)
   // Enable block context for CSS files where related properties span multiple lines

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -690,12 +690,13 @@ function extractStyleBlocks(content, ext) {
 // ---------------------------------------------------------------------------
 
 const CSS_IN_JS_EXTENSIONS = new Set(['.js', '.ts', '.jsx', '.tsx']);
+const CSS_IN_JS_TAG_PATTERN = '(?:styled(?:\\.\\w+|\\([^)]+\\))|css)(?:\\s*<[^>\\n]+>)?';
 
 function extractCSSinJS(content, ext) {
   ext = ext.toLowerCase();
   if (!CSS_IN_JS_EXTENSIONS.has(ext)) return [];
   const blocks = [];
-  const re = /(?:styled(?:\.\w+|\([^)]+\))|css)\s*`([\s\S]*?)`/g;
+  const re = new RegExp(CSS_IN_JS_TAG_PATTERN + '\\s*`([\\s\\S]*?)`', 'g');
   let m;
   while ((m = re.exec(content)) !== null) {
     const before = content.substring(0, m.index);
@@ -708,7 +709,7 @@ function extractCSSinJS(content, ext) {
 function stripCssInJsComments(content, ext) {
   if (!CSS_IN_JS_EXTENSIONS.has(ext.toLowerCase())) return content;
   return content.replace(
-    /(?:styled(?:\.\w+|\([^)]+\))|css)\s*`[\s\S]*?`/g,
+    new RegExp(CSS_IN_JS_TAG_PATTERN + '\\s*`[\\s\\S]*?`', 'g'),
     block => stripCssComments(block),
   );
 }

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -42,7 +42,7 @@ function shouldRunPageAnalyzers(content, filePath) {
 }
 
 const JS_SOURCE_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
-const REGEX_PREFIX_KEYWORDS = new Set(['await', 'case', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'return', 'throw', 'typeof', 'void', 'yield']);
+const REGEX_PREFIX_KEYWORDS = new Set(['await', 'case', 'default', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'return', 'throw', 'typeof', 'void', 'yield']);
 
 /**
  * Blank JavaScript comments without moving any following source. Regex
@@ -56,14 +56,23 @@ function stripJsComments(content, options = {}) {
   let previousSignificant = '';
   let currentWord = '';
   let currentWordPrefix = '';
+  let wordSeparated = false;
   let regexCharClass = false;
   const templateExpressionDepths = [];
 
   const recordSignificant = (char) => {
-    if (/\s/.test(char)) return;
+    if (/\s/.test(char)) {
+      wordSeparated = true;
+      return;
+    }
     const isWordChar = /[\w$]/.test(char);
-    if (isWordChar && !currentWord) currentWordPrefix = lastSignificant;
-    else if (!isWordChar) currentWordPrefix = '';
+    if (isWordChar && (wordSeparated || !currentWord)) {
+      currentWord = '';
+      currentWordPrefix = lastSignificant;
+    } else if (!isWordChar) {
+      currentWordPrefix = '';
+    }
+    wordSeparated = false;
     previousSignificant = lastSignificant;
     lastSignificant = char;
     currentWord = isWordChar ? currentWord + char : '';
@@ -139,7 +148,7 @@ function stripJsComments(content, options = {}) {
     const jsxUrlSeparator = options.jsx && char === '/' && next === '/' &&
       (output.endsWith('http:') ||
         output.endsWith('https:') ||
-        (/<[A-Za-z][^>]*>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1)) &&
+        (/<[A-Za-z](?:[^>]*[^/])?>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1)) &&
           /^[\w.-]+\.[A-Za-z]{2,}(?=[:/?#\s<]|$)/.test(content.slice(i + 2))));
     const afterPostfixUpdate = (lastSignificant === '+' || lastSignificant === '-') &&
       previousSignificant === lastSignificant;

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -52,7 +52,14 @@ function stripJsComments(content) {
   let state = 'code';
   let output = '';
   let lastSignificant = '';
+  let previousSignificant = '';
   let regexCharClass = false;
+
+  const recordSignificant = (char) => {
+    if (/\s/.test(char)) return;
+    previousSignificant = lastSignificant;
+    lastSignificant = char;
+  };
 
   for (let i = 0; i < content.length; i++) {
     const char = content[i];
@@ -90,7 +97,7 @@ function stripJsComments(content) {
         regexCharClass = false;
       } else if (char === '/' && !regexCharClass) {
         state = 'code';
-        lastSignificant = '/';
+        recordSignificant('/');
       }
       continue;
     }
@@ -106,6 +113,7 @@ function stripJsComments(content) {
         (state === 'template' && char === '`')
       ) {
         state = 'code';
+        recordSignificant(char);
       }
       continue;
     }
@@ -120,14 +128,14 @@ function stripJsComments(content) {
       state = 'block-comment';
     } else if (
       char === '/' &&
-      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || output.trimEnd().endsWith('=>'))
+      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || (previousSignificant === '=' && lastSignificant === '>'))
     ) {
       output += char;
       state = 'regex';
       regexCharClass = false;
     } else {
       output += char;
-      if (!/\s/.test(char)) lastSignificant = char;
+      recordSignificant(char);
       if (char === "'") state = 'single-quote';
       else if (char === '"') state = 'double-quote';
       else if (char === '`') state = 'template';

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -54,10 +54,12 @@ function stripJsComments(content, options = {}) {
   let output = '';
   let lastSignificant = '';
   let previousSignificant = '';
+  let antePreviousSignificant = '';
   let currentWord = '';
   let currentWordPrefix = '';
   let wordSeparated = false;
   let regexCharClass = false;
+  let jsxExpressionDepth = 0;
   const templateExpressionDepths = [];
 
   const recordSignificant = (char) => {
@@ -73,6 +75,7 @@ function stripJsComments(content, options = {}) {
       currentWordPrefix = '';
     }
     wordSeparated = false;
+    antePreviousSignificant = previousSignificant;
     previousSignificant = lastSignificant;
     lastSignificant = char;
     currentWord = isWordChar ? currentWord + char : '';
@@ -125,6 +128,7 @@ function stripJsComments(content, options = {}) {
       recordSignificant('$');
       recordSignificant('{');
       templateExpressionDepths.push(1);
+      if (jsxExpressionDepth) jsxExpressionDepth++;
       state = 'code';
       continue;
     }
@@ -146,12 +150,14 @@ function stripJsComments(content, options = {}) {
     }
 
     const jsxUrlSeparator = options.jsx && char === '/' && next === '/' &&
+      jsxExpressionDepth === 0 &&
       (output.endsWith('http:') ||
         output.endsWith('https:') ||
         (/<[A-Za-z](?:[^>]*[^/])?>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1)) &&
           /^[\w.-]+\.[A-Za-z]{2,}(?=[:/?#\s<]|$)/.test(content.slice(i + 2))));
     const afterPostfixUpdate = (lastSignificant === '+' || lastSignificant === '-') &&
-      previousSignificant === lastSignificant;
+      previousSignificant === lastSignificant &&
+      antePreviousSignificant !== lastSignificant;
     if (char === '/' && next === '/' && jsxUrlSeparator) {
       output += '//';
       i++;
@@ -168,11 +174,13 @@ function stripJsComments(content, options = {}) {
     } else if (templateExpressionDepths.length && char === '{') {
       output += char;
       templateExpressionDepths[templateExpressionDepths.length - 1]++;
+      if (jsxExpressionDepth) jsxExpressionDepth++;
       recordSignificant(char);
     } else if (templateExpressionDepths.length && char === '}') {
       output += char;
       const depthIndex = templateExpressionDepths.length - 1;
       templateExpressionDepths[depthIndex]--;
+      if (jsxExpressionDepth) jsxExpressionDepth--;
       recordSignificant(char);
       if (templateExpressionDepths[depthIndex] === 0) {
         templateExpressionDepths.pop();
@@ -190,6 +198,10 @@ function stripJsComments(content, options = {}) {
       regexCharClass = false;
     } else {
       output += char;
+      const startsJsxExpression = options.jsx && char === '{' && jsxExpressionDepth === 0 &&
+        /<[A-Za-z](?:[^>]*[^/])?>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1, -1));
+      if (char === '{' && (jsxExpressionDepth || startsJsxExpression)) jsxExpressionDepth++;
+      else if (char === '}' && jsxExpressionDepth) jsxExpressionDepth--;
       recordSignificant(char);
       if (char === "'") state = 'single-quote';
       else if (char === '"') state = 'double-quote';
@@ -691,6 +703,58 @@ function extractStyleBlocks(content, ext) {
 
 const CSS_IN_JS_EXTENSIONS = new Set(['.js', '.ts', '.jsx', '.tsx']);
 
+function findQuotedStringEnd(content, start, quote) {
+  for (let cursor = start + 1; cursor < content.length; cursor++) {
+    if (content[cursor] === '\\') cursor++;
+    else if (content[cursor] === quote) return cursor;
+  }
+  return -1;
+}
+
+function findTemplateExpressionEnd(content, start) {
+  let depth = 1;
+  for (let cursor = start; cursor < content.length; cursor++) {
+    const char = content[cursor];
+    const next = content[cursor + 1];
+    if (char === "'" || char === '"') {
+      cursor = findQuotedStringEnd(content, cursor, char);
+      if (cursor === -1) return -1;
+    } else if (char === '`') {
+      cursor = findTemplateLiteralEnd(content, cursor);
+      if (cursor === -1) return -1;
+    } else if (char === '/' && next === '/') {
+      const lineEnd = content.indexOf('\n', cursor + 2);
+      if (lineEnd === -1) return -1;
+      cursor = lineEnd;
+    } else if (char === '/' && next === '*') {
+      const commentEnd = content.indexOf('*/', cursor + 2);
+      if (commentEnd === -1) return -1;
+      cursor = commentEnd + 1;
+    } else if (char === '{') {
+      depth++;
+    } else if (char === '}') {
+      depth--;
+      if (depth === 0) return cursor;
+    }
+  }
+  return -1;
+}
+
+function findTemplateLiteralEnd(content, start) {
+  for (let cursor = start + 1; cursor < content.length; cursor++) {
+    const char = content[cursor];
+    if (char === '\\') {
+      cursor++;
+    } else if (char === '`') {
+      return cursor;
+    } else if (char === '$' && content[cursor + 1] === '{') {
+      cursor = findTemplateExpressionEnd(content, cursor + 2);
+      if (cursor === -1) return -1;
+    }
+  }
+  return -1;
+}
+
 function findCSSinJSTemplates(content) {
   const templates = [];
   const tagRe = /\b(?:styled(?:\.\w+|\([^)]+\))|css)/g;
@@ -714,16 +778,8 @@ function findCSSinJSTemplates(content) {
 
     if (content[cursor] !== '`') continue;
     const contentStart = cursor + 1;
-    cursor = contentStart;
-    while (cursor < content.length) {
-      if (content[cursor] === '\\') {
-        cursor += 2;
-        continue;
-      }
-      if (content[cursor] === '`') break;
-      cursor++;
-    }
-    if (cursor >= content.length) continue;
+    cursor = findTemplateLiteralEnd(content, cursor);
+    if (cursor === -1) continue;
 
     templates.push({
       tagStart: match.index,

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -774,9 +774,23 @@ function findRegexLiteralEnd(content, start) {
 function findTemplateExpressionEnd(content, start) {
   let depth = 1;
   let lastSignificant = '';
+  let previousSignificant = '';
+  let antePreviousSignificant = '';
   let currentWord = '';
   let currentWordPrefix = '';
   let wordSeparated = false;
+  let lastClosedBraceKind = '';
+  const braceKinds = [];
+
+  const braceKind = () => (
+    lastSignificant === ')' ||
+    lastSignificant === ';' ||
+    lastSignificant === '}' ||
+    (previousSignificant === '=' && lastSignificant === '>') ||
+    BLOCK_BRACE_PREFIX_KEYWORDS.has(currentWord)
+      ? 'block'
+      : 'expression'
+  );
 
   const recordSignificant = (char) => {
     if (/\s/.test(char)) {
@@ -791,6 +805,8 @@ function findTemplateExpressionEnd(content, start) {
       currentWordPrefix = '';
     }
     wordSeparated = false;
+    antePreviousSignificant = previousSignificant;
+    previousSignificant = lastSignificant;
     lastSignificant = char;
     currentWord = isWordChar ? currentWord + char : '';
   };
@@ -798,6 +814,9 @@ function findTemplateExpressionEnd(content, start) {
   for (let cursor = start; cursor < content.length; cursor++) {
     const char = content[cursor];
     const next = content[cursor + 1];
+    const afterPostfixUpdate = (lastSignificant === '+' || lastSignificant === '-') &&
+      previousSignificant === lastSignificant &&
+      antePreviousSignificant !== lastSignificant;
     if (char === "'" || char === '"') {
       cursor = findQuotedStringEnd(content, cursor, char);
       if (cursor === -1) return -1;
@@ -813,7 +832,9 @@ function findTemplateExpressionEnd(content, start) {
     } else if (
       char === '/' &&
       (!lastSignificant ||
-        /[=([{!?:;,&|+\-*%^~<>]/.test(lastSignificant) ||
+        (/[=([{!?:;,&|+\-*%^~<>]/.test(lastSignificant) && !afterPostfixUpdate) ||
+        (lastSignificant === '}' && lastClosedBraceKind === 'block') ||
+        (previousSignificant === '=' && lastSignificant === '>') ||
         (currentWordPrefix !== '.' && REGEX_PREFIX_KEYWORDS.has(currentWord)))
     ) {
       cursor = findRegexLiteralEnd(content, cursor);
@@ -825,10 +846,12 @@ function findTemplateExpressionEnd(content, start) {
       recordSignificant(')');
     } else if (char === '{') {
       depth++;
+      braceKinds.push(braceKind());
       recordSignificant(char);
     } else if (char === '}') {
       depth--;
       if (depth === 0) return cursor;
+      lastClosedBraceKind = braceKinds.pop() || '';
       recordSignificant(char);
     } else {
       recordSignificant(char);

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -136,7 +136,13 @@ function stripJsComments(content, options = {}) {
       continue;
     }
 
-    const jsxUrlSeparator = options.jsx && (output.endsWith('http:') || output.endsWith('https:'));
+    const jsxUrlSeparator = options.jsx && char === '/' && next === '/' &&
+      (output.endsWith('http:') ||
+        output.endsWith('https:') ||
+        (/<[A-Za-z][^>]*>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1)) &&
+          /^[\w.-]+\.[A-Za-z]{2,}(?=[:/?#\s<]|$)/.test(content.slice(i + 2))));
+    const afterPostfixUpdate = (lastSignificant === '+' || lastSignificant === '-') &&
+      previousSignificant === lastSignificant;
     if (char === '/' && next === '/' && jsxUrlSeparator) {
       output += '//';
       i++;
@@ -165,7 +171,10 @@ function stripJsComments(content, options = {}) {
       }
     } else if (
       char === '/' &&
-      (!lastSignificant || /[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) || (previousSignificant === '=' && lastSignificant === '>') || (currentWordPrefix !== '.' && REGEX_PREFIX_KEYWORDS.has(currentWord)))
+      (!lastSignificant ||
+        (/[=([{!?:;,&|+\-*%^~]/.test(lastSignificant) && !afterPostfixUpdate) ||
+        (previousSignificant === '=' && lastSignificant === '>') ||
+        (currentWordPrefix !== '.' && REGEX_PREFIX_KEYWORDS.has(currentWord)))
     ) {
       output += char;
       state = 'regex';
@@ -770,7 +779,7 @@ function detectText(content, filePath, options = {}) {
   const findings = [];
   const ext = extFromFilePath(filePath);
   const source = JS_SOURCE_EXTS.has(ext) ? stripJsComments(content, {
-    jsx: ext === '.jsx' || ext === '.tsx',
+    jsx: ext === '.js' || ext === '.jsx' || ext === '.tsx',
   }) : content;
   const lines = source.split('\n');
 

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -45,6 +45,25 @@ const JS_SOURCE_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
 const REGEX_PREFIX_KEYWORDS = new Set(['await', 'case', 'default', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'of', 'return', 'throw', 'typeof', 'void', 'yield']);
 const BLOCK_BRACE_PREFIX_KEYWORDS = new Set(['do', 'else', 'finally', 'try']);
 
+function isInsideOpeningJsxTag(source) {
+  const tagStart = source.lastIndexOf('<');
+  if (tagStart === -1 || !/^<[A-Za-z][\w.:-]*/.test(source.slice(tagStart))) return false;
+
+  let quote = '';
+  for (let cursor = tagStart + 1; cursor < source.length; cursor++) {
+    const char = source[cursor];
+    if (quote) {
+      if (char === '\\') cursor++;
+      else if (char === quote) quote = '';
+    } else if (char === "'" || char === '"') {
+      quote = char;
+    } else if (char === '>') {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Blank JavaScript comments without moving any following source. Regex
  * findings keep their original line numbers, while prose examples inside
@@ -217,7 +236,8 @@ function stripJsComments(content, options = {}) {
     } else {
       output += char;
       const startsJsxExpression = options.jsx && char === '{' && jsxExpressionDepth === 0 &&
-        /<[A-Za-z](?:[^>]*[^/])?>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1, -1));
+        (/<[A-Za-z](?:[^>]*[^/])?>[^<]*$/.test(output.slice(output.lastIndexOf('\n') + 1, -1)) ||
+          isInsideOpeningJsxTag(output.slice(0, -1)));
       if (char === '{') braceKinds.push(braceKind(startsJsxExpression));
       else if (char === '}') lastClosedBraceKind = braceKinds.pop() || '';
       if (char === '{' && (jsxExpressionDepth || startsJsxExpression)) jsxExpressionDepth++;
@@ -731,17 +751,57 @@ function findQuotedStringEnd(content, start, quote) {
   return -1;
 }
 
+function findRegexLiteralEnd(content, start) {
+  let inCharacterClass = false;
+  for (let cursor = start + 1; cursor < content.length; cursor++) {
+    const char = content[cursor];
+    if (char === '\\') {
+      cursor++;
+    } else if (char === '[') {
+      inCharacterClass = true;
+    } else if (char === ']') {
+      inCharacterClass = false;
+    } else if (char === '/' && !inCharacterClass) {
+      while (/[A-Za-z]/.test(content[cursor + 1] || '')) cursor++;
+      return cursor;
+    } else if (char === '\n' || char === '\r') {
+      return -1;
+    }
+  }
+  return -1;
+}
+
 function findTemplateExpressionEnd(content, start) {
   let depth = 1;
+  let lastSignificant = '';
+  let currentWord = '';
+  let currentWordPrefix = '';
+  let wordSeparated = false;
+
+  const recordSignificant = (char) => {
+    if (/\s/.test(char)) {
+      wordSeparated = true;
+      return;
+    }
+    const isWordChar = /[\w$]/.test(char);
+    if (isWordChar && (wordSeparated || !currentWord)) {
+      currentWord = '';
+      currentWordPrefix = lastSignificant;
+    } else if (!isWordChar) {
+      currentWordPrefix = '';
+    }
+    wordSeparated = false;
+    lastSignificant = char;
+    currentWord = isWordChar ? currentWord + char : '';
+  };
+
   for (let cursor = start; cursor < content.length; cursor++) {
     const char = content[cursor];
     const next = content[cursor + 1];
     if (char === "'" || char === '"') {
       cursor = findQuotedStringEnd(content, cursor, char);
       if (cursor === -1) return -1;
-    } else if (char === '`') {
-      cursor = findTemplateLiteralEnd(content, cursor);
-      if (cursor === -1) return -1;
+      recordSignificant(')');
     } else if (char === '/' && next === '/') {
       const lineEnd = content.indexOf('\n', cursor + 2);
       if (lineEnd === -1) return -1;
@@ -750,11 +810,28 @@ function findTemplateExpressionEnd(content, start) {
       const commentEnd = content.indexOf('*/', cursor + 2);
       if (commentEnd === -1) return -1;
       cursor = commentEnd + 1;
+    } else if (
+      char === '/' &&
+      (!lastSignificant ||
+        /[=([{!?:;,&|+\-*%^~<>]/.test(lastSignificant) ||
+        (currentWordPrefix !== '.' && REGEX_PREFIX_KEYWORDS.has(currentWord)))
+    ) {
+      cursor = findRegexLiteralEnd(content, cursor);
+      if (cursor === -1) return -1;
+      recordSignificant(')');
+    } else if (char === '`') {
+      cursor = findTemplateLiteralEnd(content, cursor);
+      if (cursor === -1) return -1;
+      recordSignificant(')');
     } else if (char === '{') {
       depth++;
+      recordSignificant(char);
     } else if (char === '}') {
       depth--;
       if (depth === 0) return cursor;
+      recordSignificant(char);
+    } else {
+      recordSignificant(char);
     }
   }
   return -1;

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -309,6 +309,27 @@ describe('detectText — broken images in source comments', () => {
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
   });
 
+  test('keeps regex literals visible after remaining prefix contexts', () => {
+    const sources = [
+      'for (const item of /[/*]/) {} <img src="" alt="After for-of" />',
+      'const match = value < /[/*]/.source; <img src="" alt="After comparison" />',
+      'if (ready) {} /[/*]/.test(value); <img src="" alt="After block" />',
+    ];
+
+    for (const source of sources) {
+      const findings = detectText(source, 'gallery.tsx');
+      expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+    }
+  });
+
+  test('keeps division after an object literal distinct from a regex', () => {
+    const source = 'const ratio = {} / divisor; // <img src="" alt="Comment-only image" />';
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
   test('keeps same-line JSX visible after bare URL text', () => {
     const source = '<p>https://example.com <img src="" alt="Empty source" /></p>';
 
@@ -1693,6 +1714,39 @@ describe('codex-grid-background variants', () => {
     }`;
     const findings = detectText(css, 'timeline.css');
     expect(findings.filter(f => f.antipattern === 'codex-grid-background')).toHaveLength(0);
+  });
+
+  test('regex source engine ignores grids in JavaScript comments', () => {
+    const source = `/* .demo {
+      background-image:
+        linear-gradient(#eee 1px, transparent 1px),
+        linear-gradient(90deg, #eee 1px, transparent 1px);
+      background-size: 24px 24px;
+    } */`;
+    const findings = detectText(source, 'demo.ts');
+    expect(findings.filter(f => f.antipattern === 'codex-grid-background')).toHaveLength(0);
+  });
+
+  test('regex source engine ignores grids in CSS-in-JS comments', () => {
+    const source = `const Demo = styled.div\`
+      /* .demo { background-image:
+        linear-gradient(#eee 1px, transparent 1px),
+        linear-gradient(90deg, #eee 1px, transparent 1px);
+      background-size: 24px 24px; } */
+    \`;`;
+    const findings = detectText(source, 'demo.tsx');
+    expect(findings.filter(f => f.antipattern === 'codex-grid-background')).toHaveLength(0);
+  });
+
+  test('regex source engine still detects live CSS-in-JS grids', () => {
+    const source = `const Demo = styled.div\`
+      .demo { background-image:
+        linear-gradient(#eee 1px, transparent 1px),
+        linear-gradient(90deg, #eee 1px, transparent 1px);
+      background-size: 24px 24px; }
+    \`;`;
+    const findings = detectText(source, 'demo.tsx');
+    expect(findings.filter(f => f.antipattern === 'codex-grid-background')).toHaveLength(1);
   });
 });
 

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -229,6 +229,7 @@ describe('detectText — broken images in source comments', () => {
       '// A regex before this comment must not expose its <img> example.',
       'const ratio = "width" / size;',
       '// Division after a string must not expose its <img> example.',
+      'const template = `value: ${/* <img src=""> */ fallback}`;',
       'export interface Props { imgClassName?: string }',
     ].join('\n');
 

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -261,6 +261,17 @@ describe('detectText — broken images in source comments', () => {
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
   });
 
+  test('does not treat a return-named property division as a regex literal', () => {
+    const source = [
+      'const ratio = obj.return / divisor;',
+      '// <img src="" alt="Comment-only image" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
   test('keeps same-line JSX visible after bare URL text', () => {
     const source = '<p>https://example.com <img src="" alt="Empty source" /></p>';
 

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -247,7 +247,14 @@ describe('detectText — broken images in source comments', () => {
 
     const findings = detectText(source, 'gallery.tsx');
 
-    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(3);
+    expect(findings
+      .filter(r => r.antipattern === 'broken-image')
+      .map(r => r.snippet)
+      .sort()).toEqual([
+      '<img alt="Missing source" />',
+      '<img src=""',
+      '<img src="#"',
+    ]);
   });
 
   test('keeps later JSX visible after a regex literal following return', () => {
@@ -272,10 +279,37 @@ describe('detectText — broken images in source comments', () => {
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
   });
 
+  test('does not treat division after a postfix update as a regex literal', () => {
+    const source = [
+      'const ratio = count++ / divisor;',
+      '// <img src="" alt="Comment-only image" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
   test('keeps same-line JSX visible after bare URL text', () => {
     const source = '<p>https://example.com <img src="" alt="Empty source" /></p>';
 
     const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
+  test('keeps same-line JSX visible after a bare URL in a .js file', () => {
+    const source = '<p>https://example.com <img src="" alt="Empty source" /></p>';
+
+    const findings = detectText(source, 'gallery.js');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
+  test('keeps same-line JSX visible after a protocol-relative URL', () => {
+    const source = '<p>//cdn.example.com/logo.svg <img src="" alt="Empty source" /></p>';
+
+    const findings = detectText(source, 'gallery.jsx');
 
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
   });

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -2488,6 +2488,13 @@ describe('extractCSSinJS', () => {
     expect(blocks.some(b => b.content.includes('border-left: 4px solid'))).toBe(true);
   });
 
+  test('extracts a styled-components template with TypeScript props', () => {
+    const tsx = "const Card = styled.div<Props>`\n  border-left: 4px solid blue;\n`;";
+    const blocks = extractCSSinJS(tsx, '.tsx');
+    expect(blocks.length).toBeGreaterThanOrEqual(1);
+    expect(blocks.some(b => b.content.includes('border-left: 4px solid'))).toBe(true);
+  });
+
   test('extracts styled(Component) template literal', () => {
     const tsx = "const Box = styled(BaseBox)`\n  border-right: 5px solid #8b5cf6;\n`;";
     const blocks = extractCSSinJS(tsx, '.tsx');
@@ -2629,6 +2636,12 @@ describe('detectText -- CSS-in-JS', () => {
 
   test('does not scan CSS-in-JS comments as live rules', () => {
     const tsx = "const style = css`\n  /* .card { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
+    const f = detectText(tsx, 'Card.tsx');
+    expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
+  });
+
+  test('does not scan comments in generic styled templates as live rules', () => {
+    const tsx = "const Card = styled.div<Props>`\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
     const f = detectText(tsx, 'Card.tsx');
     expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
   });

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -2607,6 +2607,12 @@ describe('detectText -- CSS-in-JS', () => {
     const f = detectText(tsx, 'Card.tsx');
     expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
   });
+
+  test('does not scan CSS-in-JS comments as live rules', () => {
+    const tsx = "const style = css`\n  /* .card { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
+    const f = detectText(tsx, 'Card.tsx');
+    expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -301,6 +301,14 @@ describe('detectText — broken images in source comments', () => {
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
   });
 
+  test('keeps a regex visible after a postfix update and binary operator', () => {
+    const source = 'let i = 0; const match = i++ + /[/*]/.test(value); <img src="" alt="Empty source" />';
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
   test('keeps same-line JSX visible after bare URL text', () => {
     const source = '<p>https://example.com <img src="" alt="Empty source" /></p>';
 
@@ -327,6 +335,14 @@ describe('detectText — broken images in source comments', () => {
 
   test('still strips a domain-like comment after self-closing JSX', () => {
     const source = 'const card = <Card />; //cdn.example.com <img src="" alt="Comment-only image" />';
+
+    const findings = detectText(source, 'gallery.jsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
+  test('strips a domain-like comment inside a JSX expression', () => {
+    const source = 'const card = <div>{value //cdn.example.com <img src="" alt="Comment-only image" />';
 
     const findings = detectText(source, 'gallery.jsx');
 
@@ -2502,6 +2518,13 @@ describe('extractCSSinJS', () => {
     expect(blocks.some(b => b.content.includes('border-left: 4px solid'))).toBe(true);
   });
 
+  test('extracts through nested template literals in interpolations', () => {
+    const tsx = "const Card = styled.div`\n  color: ${() => `var(--accent)`};\n  /* after interpolation */\n`;";
+    const blocks = extractCSSinJS(tsx, '.tsx');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].content).toContain('after interpolation');
+  });
+
   test('extracts styled(Component) template literal', () => {
     const tsx = "const Box = styled(BaseBox)`\n  border-right: 5px solid #8b5cf6;\n`;";
     const blocks = extractCSSinJS(tsx, '.tsx');
@@ -2655,6 +2678,12 @@ describe('detectText -- CSS-in-JS', () => {
 
   test('does not scan comments in nested generic styled templates as live rules', () => {
     const tsx = "const Card = styled.div<Props<Foo>>`\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
+    const f = detectText(tsx, 'Card.tsx');
+    expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
+  });
+
+  test('does not scan comments after nested interpolation templates as live rules', () => {
+    const tsx = "const Card = styled.div`\n  color: ${() => `var(--accent)`};\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
     const f = detectText(tsx, 'Card.tsx');
     expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
   });

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -2495,6 +2495,13 @@ describe('extractCSSinJS', () => {
     expect(blocks.some(b => b.content.includes('border-left: 4px solid'))).toBe(true);
   });
 
+  test('extracts a styled-components template with nested TypeScript props', () => {
+    const tsx = "const Card = styled.div<Props<Foo>>`\n  border-left: 4px solid blue;\n`;";
+    const blocks = extractCSSinJS(tsx, '.tsx');
+    expect(blocks.length).toBeGreaterThanOrEqual(1);
+    expect(blocks.some(b => b.content.includes('border-left: 4px solid'))).toBe(true);
+  });
+
   test('extracts styled(Component) template literal', () => {
     const tsx = "const Box = styled(BaseBox)`\n  border-right: 5px solid #8b5cf6;\n`;";
     const blocks = extractCSSinJS(tsx, '.tsx');
@@ -2642,6 +2649,12 @@ describe('detectText -- CSS-in-JS', () => {
 
   test('does not scan comments in generic styled templates as live rules', () => {
     const tsx = "const Card = styled.div<Props>`\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
+    const f = detectText(tsx, 'Card.tsx');
+    expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
+  });
+
+  test('does not scan comments in nested generic styled templates as live rules', () => {
+    const tsx = "const Card = styled.div<Props<Foo>>`\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
     const f = detectText(tsx, 'Card.tsx');
     expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
   });

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -369,6 +369,14 @@ describe('detectText — broken images in source comments', () => {
 
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
   });
+
+  test('strips a domain-like comment inside a JSX attribute expression', () => {
+    const source = 'const card = <Card show={value > limit //cdn.example.com <img src="" alt="Comment-only image" />';
+
+    const findings = detectText(source, 'gallery.jsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
 });
 
 describe('detectText — CSS borders', () => {
@@ -2579,6 +2587,13 @@ describe('extractCSSinJS', () => {
     expect(blocks[0].content).toContain('after interpolation');
   });
 
+  test('extracts through regex literals in interpolations', () => {
+    const tsx = "const Card = styled.div`\n  color: ${/`/.test(value) || /[{}]/.test(value)};\n  /* after interpolation */\n`;";
+    const blocks = extractCSSinJS(tsx, '.tsx');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].content).toContain('after interpolation');
+  });
+
   test('extracts styled(Component) template literal', () => {
     const tsx = "const Box = styled(BaseBox)`\n  border-right: 5px solid #8b5cf6;\n`;";
     const blocks = extractCSSinJS(tsx, '.tsx');
@@ -2738,6 +2753,12 @@ describe('detectText -- CSS-in-JS', () => {
 
   test('does not scan comments after nested interpolation templates as live rules', () => {
     const tsx = "const Card = styled.div`\n  color: ${() => `var(--accent)`};\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
+    const f = detectText(tsx, 'Card.tsx');
+    expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
+  });
+
+  test('does not scan comments after interpolation regexes as live rules', () => {
+    const tsx = "const Card = styled.div`\n  color: ${/`/.test(value) || /[{}]/.test(value)};\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
     const f = detectText(tsx, 'Card.tsx');
     expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
   });

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -268,6 +268,17 @@ describe('detectText — broken images in source comments', () => {
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
   });
 
+  test('keeps later JSX visible after a regex literal following export default', () => {
+    const source = [
+      'export default /[/*]/;',
+      '<img src="" alt="Empty source" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
   test('does not treat a return-named property division as a regex literal', () => {
     const source = [
       'const ratio = obj.return / divisor;',
@@ -312,6 +323,14 @@ describe('detectText — broken images in source comments', () => {
     const findings = detectText(source, 'gallery.jsx');
 
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
+  test('still strips a domain-like comment after self-closing JSX', () => {
+    const source = 'const card = <Card />; //cdn.example.com <img src="" alt="Comment-only image" />';
+
+    const findings = detectText(source, 'gallery.jsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
   });
 });
 

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -249,6 +249,25 @@ describe('detectText — broken images in source comments', () => {
 
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(3);
   });
+
+  test('keeps later JSX visible after a regex literal following return', () => {
+    const source = [
+      'function matches(value) { return /[/*]/.test(value); }',
+      '<img src="" alt="Empty source" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
+  test('keeps same-line JSX visible after bare URL text', () => {
+    const source = '<p>https://example.com <img src="" alt="Empty source" /></p>';
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
 });
 
 describe('detectText — CSS borders', () => {

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -227,6 +227,8 @@ describe('detectText — broken images in source comments', () => {
       ' */',
       'const quoteMatcher = /["\']/;',
       '// A regex before this comment must not expose its <img> example.',
+      'const ratio = "width" / size;',
+      '// Division after a string must not expose its <img> example.',
       'export interface Props { imgClassName?: string }',
     ].join('\n');
 

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -2594,6 +2594,20 @@ describe('extractCSSinJS', () => {
     expect(blocks[0].content).toContain('after interpolation');
   });
 
+  test('extracts through division after a postfix update in interpolations', () => {
+    const tsx = "const Card = styled.div`\n  width: ${i++ / divisor}px;\n  /* after interpolation */\n`;";
+    const blocks = extractCSSinJS(tsx, '.tsx');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].content).toContain('after interpolation');
+  });
+
+  test('extracts through regex literals after statement blocks', () => {
+    const tsx = "const Card = styled.div`\n  color: ${() => { if (enabled) {} /`/.test(value); return 'red'; }};\n  /* after interpolation */\n`;";
+    const blocks = extractCSSinJS(tsx, '.tsx');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].content).toContain('after interpolation');
+  });
+
   test('extracts styled(Component) template literal', () => {
     const tsx = "const Box = styled(BaseBox)`\n  border-right: 5px solid #8b5cf6;\n`;";
     const blocks = extractCSSinJS(tsx, '.tsx');
@@ -2759,6 +2773,12 @@ describe('detectText -- CSS-in-JS', () => {
 
   test('does not scan comments after interpolation regexes as live rules', () => {
     const tsx = "const Card = styled.div`\n  color: ${/`/.test(value) || /[{}]/.test(value)};\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
+    const f = detectText(tsx, 'Card.tsx');
+    expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
+  });
+
+  test('does not scan comments after postfix division or block-following regexes', () => {
+    const tsx = "const Card = styled.div`\n  width: ${i++ / divisor}px;\n  color: ${() => { if (enabled) {} /`/.test(value); return 'red'; }};\n  /* .commented-only { border-left: 4px solid #3b82f6; border-radius: 8px; } */\n`;";
     const f = detectText(tsx, 'Card.tsx');
     expect(f.filter(r => r.antipattern === 'side-tab')).toHaveLength(0);
   });

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -217,6 +217,37 @@ describe('detectText — Tailwind side-tab', () => {
   });
 });
 
+describe('detectText — broken images in source comments', () => {
+  test('ignores img tags mentioned in JavaScript comments', () => {
+    const source = [
+      '/** Extra classes on the <img> itself. */',
+      '// Keep the original URL as an <img> fallback.',
+      '/*',
+      ' * This wrapper eventually renders an <img> element.',
+      ' */',
+      'const quoteMatcher = /["\']/;',
+      '// A regex before this comment must not expose its <img> example.',
+      'export interface Props { imgClassName?: string }',
+    ].join('\n');
+
+    const findings = detectText(source, 'image-wrapper.ts');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
+  test('still detects real JSX img tags with no usable src', () => {
+    const source = [
+      '<img alt="Missing source" />',
+      '<img src="" alt="Empty source" />',
+      '<img src="#" alt="Placeholder source" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'gallery.tsx');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(3);
+  });
+});
+
 describe('detectText — CSS borders', () => {
   test('detects border-left shorthand', () => {
     const f = detectText('.card { border-left: 4px solid #3b82f6; }', 'test.css');


### PR DESCRIPTION
Fixes #486

## Summary
- ignore JavaScript, JSX, and TypeScript comments before running source regex detectors
- preserve source offsets and line numbers while blanking comment text
- keep detecting real JSX image tags with missing, empty, or placeholder sources
- cover quoted regex literals before comments to prevent scanner regressions

## Validation
- `bun test tests/detect-antipatterns.test.js` (301 passed)
- `bun run build:browser`
- `bun run build:extension`
- `bun run build`
- `bun run test` (full Bun + Node suite passed; browser 27/27, framework fixtures 216/216)
- `git diff --check`

Generated root harness/provider output was intentionally omitted. The browser and extension generated detector bundles were rebuilt for validation and remained byte-identical, so no generated files are included.

AI assistance was used to reproduce the defect, implement the fix, add regression coverage, and prepare this pull request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the main `detectText` path for all JS/TS/JSX files via a custom lexer; behavior is well-tested but lexer edge cases could still affect rare syntax.
> 
> **Overview**
> Fixes false **broken-image** (and similar) hits when example markup or CSS lives in **JavaScript/TypeScript comments** by preprocessing source before regex matchers run.
> 
> **Comment stripping** blanks `//` and `/* */` text while keeping **byte offsets and line numbers**, so findings still point at the right lines. A small lexer distinguishes **regex literals from division**, template/`${}` nesting, and **JSX** cases (URLs like `https://` or `//cdn…` vs real line comments).
> 
> **CSS-in-JS** template extraction is no longer a naive backtick regex: it walks **`styled`/`css` templates** through nested generics, interpolations, and nested templates, and **strips CSS comments** inside those blocks so commented example rules do not scan as live CSS (e.g. grid backgrounds, side-tabs).
> 
> Regression tests cover comment-only `<img>` examples, regex-after-`return`, postfix `++` division, and same-line JSX after URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5129065d1b5fa9ed16b6827010d0e377fe76793c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->