### PR TITLE
[security] Strip page-controlled `_instructions` before it reaches the agent

### DIFF
--- a/skill/scripts/live-poll.mjs
+++ b/skill/scripts/live-poll.mjs
@@ -269,9 +269,16 @@ export function printPollEvent(event) {
   // Situational plumbing rides with the event itself: `_instructions` is the
   // authoritative next step, with real ids and paths substituted, so the
   // reference doc can stay lean and can never drift from script behavior.
-  if (event && typeof event === 'object' && !event._instructions) {
+  // Recomputed unconditionally: the locally derived value must always win over
+  // whatever arrived on the wire. The previous `!event._instructions` guard
+  // meant a page-supplied field both suppressed the real instructions and was
+  // handed to the agent as authoritative — and reference/live.md tells the
+  // agent this field outranks the document itself. Defence in depth: the
+  // server already strips it in enqueueEvent().
+  if (event && typeof event === 'object') {
     const instructions = instructionsForEvent(event, { scriptsPath: SELF_DIR });
     if (instructions) event._instructions = instructions;
+    else delete event._instructions;
   }
   console.log(JSON.stringify(event));
 }

--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -181,8 +181,24 @@ function chatAgentLikelyActive() {
 // cap at 10 MB to guard against runaway writes from a misbehaving client.
 const MAX_ANNOTATION_BYTES = 10 * 1024 * 1024;
 
+// Fields the poller owns and the page must never supply. `_instructions` is
+// documented in reference/live.md as outranking that document ("when it
+// conflicts with your recollection of this document, `_instructions` wins"),
+// and live-poll.mjs only generates the legitimate value when the field is
+// absent — so one supplied by the page both suppresses the real one and is
+// handed to the agent as authoritative. validateEvent() checks the fields it
+// knows about but never strips unknown ones, and the auth token is a page
+// global (live-browser.js), so any third-party script in the inspected app can
+// POST an authenticated event. Same shape for `_completionAck`.
+const RESERVED_POLL_FIELDS = ['_instructions', '_completionAck'];
+
 function enqueueEvent(event) {
   if (!event) return;
+  // Strip here rather than at the call site: every path into the queue is
+  // covered, including replay from a persisted snapshot.
+  if (typeof event === 'object') {
+    for (const reserved of RESERVED_POLL_FIELDS) delete event[reserved];
+  }
   // Dedupe by (session, type), except mount failures, which are per-variant:
   // variant 2 failing must not be swallowed because variant 1's failure is
   // still queued.


### PR DESCRIPTION
Fixes #488.

`validateEvent` never strips unknown fields, so an `_instructions` supplied by the inspected page survives to the agent — and `reference/live.md:9` has already told the agent that field outranks the document.

### The chain

| # | Where | What happens |
|---|---|---|
| 1 | `live-browser.js:22` | `const TOKEN = window.__IMPECCABLE_TOKEN__` — page global, readable by any script in the app |
| 2 | `live-server.mjs` | `validateEvent(msg)` returns `null` or an error string on every path; it never builds a sanitized copy |
| 3 | `live-server.mjs` | `enqueueEvent(msg)` queues the raw object, extra fields included |
| 4 | `live-poll.mjs` | `if (... && !event._instructions)` — a falsy guard, so a supplied value suppresses the real one |
| 5 | `live-poll.mjs` | `console.log(JSON.stringify(event))` — straight to the agent |
| 6 | `reference/live.md:9` | "when it conflicts with your recollection of this document, `_instructions` wins" |

The threat model is already documented in `live/event-validation.mjs`:

> Both are attacker-adjacent (any script on the page can POST them with the token it can already read), so they are length-capped before they reach the journal.

That is right, but the caps are per-known-field: they do nothing for a field the validator does not know about. The loopback bind and the URL-parsed CORS check don't help either — the attacker here is already running inside the page.

### What this changes

**`enqueueEvent`** deletes the poller-owned fields (`_instructions`, `_completionAck`) from every event entering the queue. Done inside the function rather than at the call site, so replay from a persisted snapshot is covered too.

**`printPollEvent`** recomputes `_instructions` unconditionally instead of only when absent, and clears it when there is nothing to say. Defence in depth behind the server-side strip.

The `_completionAck` guard in `prepareAcceptEvent` is deliberately left alone: there it protects the value just set in the `catch` block, which is correct.

### Notes

Patch is against `skill/scripts/`, so `./plugin` and the provider mirrors pick it up on the next build.

Static analysis — I did not run an exploit against a live session. Behaviour in the normal path is unchanged: with no page-supplied field, the strip is a no-op and the recompute produces the same value as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live agent event boundary and instruction injection surface; normal flows without forged fields should behave the same, but mistakes here could break agent guidance or leave a residual spoofing path.
> 
> **Overview**
> Closes a path where any script on the inspected page could POST authenticated live events with a forged **`_instructions`** field and steer the coding agent, because **`reference/live.md`** treats that field as authoritative over the doc and **`validateEvent`** never removed unknown fields.
> 
> **`enqueueEvent`** in **`live-server.mjs`** now deletes poller-owned reserved fields (**`_instructions`**, **`_completionAck`**) on every event entering the queue, including replay from persisted snapshots.
> 
> **`printPollEvent`** in **`live-poll.mjs`** always recomputes **`_instructions`** from **`instructionsForEvent`** instead of only when missing, and removes the field when there is nothing to say—defense in depth behind the server strip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c13a3f05793b94443064fed97b00ac5380d38498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->