### PR TITLE
[security] Contain project-supplied hook.auditLog to the project root

### DIFF
--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -1483,9 +1483,19 @@ export function writeAuditLog(env, entry, cwd = process.cwd()) {
   // process cwd can differ from the project being edited.
   const baseCwd = entry && typeof entry.cwd === 'string' && entry.cwd ? entry.cwd : cwd;
   // Env wins; otherwise fall back to the unified config's hook.auditLog path.
+  // The two sources are NOT equally trusted: IMPECCABLE_HOOK_LOG is set by the
+  // person running the harness, while hook.auditLog is read from
+  // <project>/.impeccable/config.json — i.e. it ships with whatever repository
+  // you happen to open. Since this hook runs on every Edit/Write, an untrusted
+  // checkout could otherwise point it at an absolute or ~/ path and have the
+  // hook create directories and append lines anywhere the user can write.
   let target = env?.IMPECCABLE_HOOK_LOG;
+  let fromProjectConfig = false;
   if (!target || typeof target !== 'string') {
-    try { target = readConfig(baseCwd).auditLog; } catch { target = null; }
+    try {
+      target = readConfig(baseCwd).auditLog;
+      fromProjectConfig = true;
+    } catch { target = null; }
   }
   if (!target || typeof target !== 'string') return false;
   try {
@@ -1497,6 +1507,10 @@ export function writeAuditLog(env, entry, cwd = process.cwd()) {
     } else {
       expanded = path.resolve(baseCwd, target);
     }
+    // Project-supplied paths are contained to the project, using the same
+    // canonicalizing gate the scan passes use for reads. Env-supplied paths
+    // keep working anywhere, which is the point of the escape hatch.
+    if (fromProjectConfig && !isScanTargetInsideProject(expanded, baseCwd)) return false;
     fs.mkdirSync(path.dirname(expanded), { recursive: true });
     const line = JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n';
     fs.appendFileSync(expanded, line);


### PR DESCRIPTION
`writeAuditLog` takes its target from `IMPECCABLE_HOOK_LOG` or, failing that, from `hook.auditLog` in `<project>/.impeccable/config.json`. It then expands `~/`, accepts absolute paths, and does `mkdirSync(recursive)` + `appendFileSync` with no containment check.

Those two sources are not equally trusted:

- `IMPECCABLE_HOOK_LOG` is set by the person running the harness.
- `hook.auditLog` ships with whatever repository you open — and this hook runs on **every** `Edit`/`Write` and on `Stop`.

So a checkout you cloned just to look at can have the hook create directories and append NDJSON anywhere the user can write. No exotic trick required: it is a plain string in a config file the repo carries.

### What this changes

Paths that came from the project config must resolve inside the project root. `IMPECCABLE_HOOK_LOG` keeps working anywhere, which is the point of having an env escape hatch.

The containment gate already existed and is used for reads — `isScanTargetInsideProject`, which canonicalizes symlinks before comparing. It simply was not applied to this write path. Reusing it keeps one definition of "inside the project" instead of adding a second, weaker one.

### Verification

Sandboxed harness with `HOME`/`USERPROFILE` redirected to a temp dir, five cases:

| Case | Expected | Result |
|---|---|---|
| project config, absolute path outside | rejected, no file created | pass |
| project config, `~/…` | rejected, nothing written to home | pass |
| project config, relative path inside project | still works | pass |
| project config, `../` traversal | rejected | pass |
| `IMPECCABLE_HOOK_LOG`, absolute path | still permitted | pass |

Patch is against `skill/scripts/`, so `./plugin` and the provider mirrors pick it up on the next build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted security fix in hook audit logging with no change to env-controlled logging behavior; regression risk is limited to projects that relied on out-of-project `hook.auditLog` paths.
> 
> **Overview**
> **Closes a path where untrusted repo config could make the design hook write audit NDJSON outside the project.**
> 
> `writeAuditLog` now treats `hook.auditLog` from `.impeccable/config.json` as untrusted (unlike `IMPECCABLE_HOOK_LOG`, which still allows any path). After expanding `~/`, absolute, or relative targets, project-supplied paths must pass **`isScanTargetInsideProject`**—the same canonicalizing containment check used for scan reads—before `mkdirSync` / `appendFileSync`; otherwise the write is skipped.
> 
> Relative paths inside the project continue to work; traversal, absolute paths outside the root, and `~/…` escapes from project config are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a4bf414125960a930b504177ad61a0e04f430d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->