### PR TITLE
Stop emitting the "agents" key so the four plugin subagents load

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -627,22 +627,18 @@ async function build() {
 
     const rootManifest = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, '.claude-plugin/plugin.json'), 'utf-8'));
     const claudeAgentsSrc = path.join(DIST_DIR, 'claude-code', '.claude', 'agents');
-    const pluginAgentEntries = fs.existsSync(claudeAgentsSrc)
-      ? fs.readdirSync(claudeAgentsSrc)
-          .filter(file => file.endsWith('.md'))
-          .sort()
-          .map(file => `./agents/${file}`)
-      : [];
     // Trailing slash on the skills path matches the documented schema in
     // code.claude.com/docs/en/plugins-reference. Issue #86 has 3 reporters
     // converging on "add trailing slash to fix slash commands not registering";
     // the docs schema example consistently uses `"./custom/skills/"` form.
     const pluginManifest = { ...rootManifest, skills: './skills/' };
-    if (pluginAgentEntries.length) {
-      pluginManifest.agents = pluginAgentEntries;
-    } else {
-      delete pluginManifest.agents;
-    }
+    // No `agents` key: Claude Code discovers agents/*.md by itself, and the
+    // identifier it uses is the file name. Declaring the key as an array of
+    // file paths makes it load ZERO agents, so the four shipped subagents were
+    // never reachable. The other plausible shapes are worse: a string, or an
+    // array containing a directory, and the whole plugin fails to load.
+    // Omitting the key is the only shape that works.
+    delete pluginManifest.agents;
     fs.mkdirSync(pluginManifestDir, { recursive: true });
     fs.writeFileSync(
       path.join(pluginManifestDir, 'plugin.json'),


### PR DESCRIPTION
The four subagents shipped in `./plugin` never load in Claude Code. `build.js` injects an `agents` array into the generated manifest, and that array is exactly what stops them.

### Reproduction

Tested on a throwaway local marketplace, all plausible shapes of the key:

| `"agents"` value | Result in Claude Code |
|---|---|
| array of file paths (what `build.js` emits) | **0 agents load**; skills fine |
| a string, e.g. `"./agents"` | whole plugin fails to load |
| array containing a directory | whole plugin fails to load |
| key omitted | all agents load; skills fine |

Claude Code discovers `agents/*.md` on its own, and the identifier it uses is the **file name**, not the frontmatter `name`. The key isn't needed, and every present form of it is worse than its absence.

Confirmed end to end on this repo:

```
# with the key emitted
Agents (0)

# with it omitted
Agents (4)  impeccable-asset-producer, impeccable-documenter,
            impeccable-finish-reviewer, impeccable-manual-edit-applier
```

### Why it's easy to miss

With a breaking shape, `claude plugin details <name>` prints `Plugin not found` rather than a validation error — it reads as if the plugin weren't installed at all. And `claude plugin validate` doesn't catch it, because it validates the *marketplace* manifest, not the plugin manifest. The only reliable signal is the `Agents (N)` line.

The same defect is reported against another project at addyosmani/agent-skills#449, with the full reproduction.

### What this changes

`build.js` stops emitting the key. The agent files themselves are still copied by the existing `copyDirSync` a few lines below — only the manifest entry goes away, and `pluginAgentEntries` becomes dead code.

### Scope

Verified on Claude Code only. `./plugin` is the Claude Code / Grok subtree and the Grok manifest is written separately just below, so this doesn't touch the other harnesses. If Grok turns out to need the key, it can be re-added on that side alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time manifest generation only; no runtime auth or data paths. Low risk with clear behavioral fix for plugin installs.
> 
> **Overview**
> **Fixes four shipped plugin subagents never loading in Claude Code** by changing how `build.js` writes `./plugin/.claude-plugin/plugin.json`.
> 
> The build used to populate an `agents` array with paths like `./agents/<file>.md`. In Claude Code that shape loads **zero** agents; discovery works only when the key is omitted and `agents/*.md` are present on disk. The agent markdown is still copied into `./plugin/agents/`; only the manifest no longer declares `agents`, and the dead `pluginAgentEntries` logic is removed.
> 
> Scope is the Claude Code / Grok `./plugin` subtree; the separate Grok manifest block below is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81b675160cafb09047a264ac2512e4f0dc73eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->