### PR TITLE
Share browser detector bundling

### DIFF
--- a/scripts/build-browser-detector.js
+++ b/scripts/build-browser-detector.js
@@ -10,35 +10,15 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { bundleBrowserDetectorModules } from './lib/browser-detector-bundle.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 
-const MODULES = [
-  'cli/engine/shared/constants.mjs',
-  'cli/engine/registry/antipatterns.mjs',
-  'cli/engine/shared/color.mjs',
-  'cli/engine/shared/fonts.mjs',
-  'cli/engine/rules/checks.mjs',
-  'cli/engine/browser/injected/index.mjs',
-];
 const OUTPUT = path.join(ROOT, 'cli/engine/detect-antipatterns-browser.js');
 const SITE_OUTPUT = path.join(ROOT, 'site/public/js/detect-antipatterns-browser.js');
 
-function browserSafeModule(relPath) {
-  let code = fs.readFileSync(path.join(ROOT, relPath), 'utf-8');
-  if (relPath === 'cli/engine/registry/antipatterns.mjs') {
-    const match = code.match(/const ANTIPATTERNS = \[[\s\S]*?\n\];/);
-    if (!match) throw new Error('Could not extract browser antipattern registry');
-    code = match[0];
-  }
-  code = code.replace(/^import[\s\S]*?;\n/gm, '');
-  code = code.replace(/^export\s+\{[^}]*\};\n?/gm, '');
-  code = code.replace(/^export\s+\{[\s\S]*?^};\n?/gm, '');
-  return `// --- ${relPath} ---\n${code.trim()}\n`;
-}
-
-const code = MODULES.map(browserSafeModule).join('\n');
+const code = bundleBrowserDetectorModules(ROOT);
 
 const output = `/**
  * Anti-Pattern Browser Detector for Impeccable

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -19,36 +19,16 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { ANTIPATTERNS } from '../cli/engine/registry/antipatterns.mjs';
+import { bundleBrowserDetectorModules } from './lib/browser-detector-bundle.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const EXT_DIR = path.join(ROOT, 'extension');
 
-const BROWSER_MODULES = [
-  'cli/engine/shared/constants.mjs',
-  'cli/engine/registry/antipatterns.mjs',
-  'cli/engine/shared/color.mjs',
-  'cli/engine/shared/fonts.mjs',
-  'cli/engine/rules/checks.mjs',
-  'cli/engine/browser/injected/index.mjs',
-];
 const DETECTOR_OUTPUT = path.join(EXT_DIR, 'detector/detect.js');
 const AP_OUTPUT = path.join(EXT_DIR, 'detector/antipatterns.json');
 
-function browserSafeModule(relPath) {
-  let code = fs.readFileSync(path.join(ROOT, relPath), 'utf-8');
-  if (relPath === 'cli/engine/registry/antipatterns.mjs') {
-    const match = code.match(/const ANTIPATTERNS = \[[\s\S]*?\n\];/);
-    if (!match) throw new Error('Could not extract browser antipattern registry');
-    code = match[0];
-  }
-  code = code.replace(/^import[\s\S]*?;\n/gm, '');
-  code = code.replace(/^export\s+\{[^}]*\};\n?/gm, '');
-  code = code.replace(/^export\s+\{[\s\S]*?^};\n?/gm, '');
-  return `// --- ${relPath} ---\n${code.trim()}\n`;
-}
-
-const code = BROWSER_MODULES.map(browserSafeModule).join('\n');
+const code = bundleBrowserDetectorModules(ROOT);
 
 // --- 1. Build detector ---
 

--- a/scripts/lib/browser-detector-bundle.js
+++ b/scripts/lib/browser-detector-bundle.js
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const BROWSER_DETECTOR_MODULES = [
+  'cli/engine/shared/constants.mjs',
+  'cli/engine/registry/antipatterns.mjs',
+  'cli/engine/shared/color.mjs',
+  'cli/engine/shared/fonts.mjs',
+  'cli/engine/rules/checks.mjs',
+  'cli/engine/browser/injected/index.mjs',
+];
+
+function browserSafeModule(root, relPath) {
+  let code = fs.readFileSync(path.join(root, relPath), 'utf-8');
+  if (relPath === 'cli/engine/registry/antipatterns.mjs') {
+    const match = code.match(/const ANTIPATTERNS = \[[\s\S]*?\n\];/);
+    if (!match) throw new Error('Could not extract browser antipattern registry');
+    code = match[0];
+  }
+  code = code.replace(/^import[\s\S]*?;\n/gm, '');
+  code = code.replace(/^export\s+\{[^}]*\};\n?/gm, '');
+  code = code.replace(/^export\s+\{[\s\S]*?^};\n?/gm, '');
+  return `// --- ${relPath} ---\n${code.trim()}\n`;
+}
+
+export function bundleBrowserDetectorModules(root) {
+  return BROWSER_DETECTOR_MODULES
+    .map((relPath) => browserSafeModule(root, relPath))
+    .join('\n');
+}


### PR DESCRIPTION
## Summary

- move the browser-safe detector module list and source-stripping transform into one small shared helper
- make both the browser detector builder and extension builder consume that single rule
- preserve every existing entry point, generated wrapper, manifest, archive, and console message

## Hindsight review

**Hindsight is 20/20: if we were implementing these requirements today, would we design `scripts/build-extension.js` this way?** No. The extension builder independently owned the exact module list and bundling transform already present in `scripts/build-browser-detector.js`. Those copies represent one durable generation policy and could drift.

The smallest cleaner architecture is a shared `bundleBrowserDetectorModules(root)` helper. Packaging, Firefox manifest derivation, registry JSON generation, and output ownership remain in their existing builders.

## Architecture evidence

| Measure | Before | After |
| --- | ---: | ---: |
| Primary file: `scripts/build-extension.js` | 161 lines | 141 lines |
| Affected source architecture | 230 lines across 2 builders | 220 lines across 2 builders + 1 focused helper |
| Browser module lists | 2 | 1 |
| Source-stripping transforms | 2 | 1 |
| Public build entry points | 2 | 2, unchanged |

Generated browser detector, extension detector, and registry JSON hashes are byte-identical before and after.

## Validation

- `bun run build:browser`
- `bun run build:extension`
- `bun run test` — full Bun + Node suite passed, including browser and framework coverage
- `git diff --check`
- exact SHA-1 comparison of:
  - `cli/engine/detect-antipatterns-browser.js`
  - `extension/detector/detect.js`
  - `extension/detector/antipatterns.json`

## Generated output

Generated detector artifacts and root harness/provider output were intentionally omitted: all tracked generated files remained byte-identical after validation.

## Risk

Low. Both build paths now share one helper, so a defect there would affect both; exact output equality plus the full test suite directly exercises that risk. No runtime code, public API, CLI output, manifest, schema, or release metadata changed.

## Authorization and AI disclosure

This ready-for-review PR was prepared with AI assistance by Codex under maintainer **pbakaus's explicit scheduled architecture-simplification authorization**. It is not authorized to merge this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time refactor only; generated outputs are intended to stay byte-identical and no runtime or public API code changed.
> 
> **Overview**
> **Centralizes** the duplicated browser-detector build logic that lived in `build-browser-detector.js` and `build-extension.js` into `scripts/lib/browser-detector-bundle.js`.
> 
> The shared `bundleBrowserDetectorModules(root)` owns the module list, antipattern-registry extraction, and import/export stripping; both builders now call it and keep their own IIFE wrappers, output paths, and extension packaging unchanged.
> 
> **No change** to generated detector artifacts or runtime behavior—this is build-script deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e3618b51e8d266410621e8b6d5fe7bd7ad486e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->