### PR TITLE
Fix Blade files in directory detection

### DIFF
--- a/cli/engine/detect-antipatterns.mjs
+++ b/cli/engine/detect-antipatterns.mjs
@@ -35,6 +35,7 @@ export { detectUrl, createBrowserDetector } from './engines/browser/detect-url.m
 export { detectText, extractStyleBlocks, extractCSSinJS } from './engines/regex/detect-text.mjs';
 export {
   walkDir,
+  hasScannableExtension,
   SCANNABLE_EXTENSIONS,
   SKIP_DIRS,
   buildImportGraph,

--- a/cli/engine/node/file-system.mjs
+++ b/cli/engine/node/file-system.mjs
@@ -33,8 +33,9 @@ const HTML_EXTENSIONS = new Set(['.html', '.htm']);
 
 function hasScannableExtension(filename) {
   const lower = filename.toLowerCase();
+  if (SCANNABLE_EXTENSIONS.has(path.extname(lower))) return true;
   for (const ext of SCANNABLE_EXTENSIONS) {
-    if (lower.endsWith(ext)) return true;
+    if (ext.indexOf('.', 1) !== -1 && lower.endsWith(ext)) return true;
   }
   return false;
 }
@@ -202,6 +203,7 @@ export {
   SKIP_DIRS,
   SCANNABLE_EXTENSIONS,
   HTML_EXTENSIONS,
+  hasScannableExtension,
   walkDir,
   resolveImport,
   buildImportGraph,

--- a/cli/engine/node/file-system.mjs
+++ b/cli/engine/node/file-system.mjs
@@ -26,10 +26,18 @@ const HIDDEN_SOURCE_DIRS = new Set(['.vitepress', '.vuepress', '.storybook']);
 const SCANNABLE_EXTENSIONS = new Set([
   '.html', '.htm', '.css', '.scss', '.sass', '.less',
   '.jsx', '.tsx', '.js', '.ts',
-  '.vue', '.svelte', '.astro',
+  '.vue', '.svelte', '.astro', '.blade.php',
 ]);
 
 const HTML_EXTENSIONS = new Set(['.html', '.htm']);
+
+function hasScannableExtension(filename) {
+  const lower = filename.toLowerCase();
+  for (const ext of SCANNABLE_EXTENSIONS) {
+    if (lower.endsWith(ext)) return true;
+  }
+  return false;
+}
 
 const IMPORT_SPECIFIER_PATTERNS = [
   /import\s+(?:[\s\S]*?from\s+)?['"]([^'"]+)['"]/g,
@@ -46,7 +54,7 @@ function walkDir(dir) {
     if (entry.isDirectory() && entry.name.startsWith('.') && !HIDDEN_SOURCE_DIRS.has(entry.name)) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) files.push(...walkDir(full));
-    else if (SCANNABLE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) files.push(full);
+    else if (hasScannableExtension(entry.name)) files.push(full);
   }
   return files;
 }

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -2071,6 +2071,18 @@ describe('walkDir', () => {
     expect(SCANNABLE_EXTENSIONS.has('.sass')).toBe(true);
   });
 
+  test('finds Blade templates during directory scans', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-walk-'));
+    try {
+      const blade = path.join(tmp, 'resources', 'views', 'card.blade.php');
+      fs.mkdirSync(path.dirname(blade), { recursive: true });
+      fs.writeFileSync(blade, '<div class="bg-orange-900 text-gray-500">Card</div>');
+      expect(walkDir(tmp)).toContain(blade);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('finds scannable files', () => {
     const files = walkDir(FIXTURES);
     expect(files.length).toBeGreaterThanOrEqual(3);

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -6,7 +6,7 @@ import { spawnSync } from 'child_process';
 import {
   ANTIPATTERNS, checkElementBorders, checkElementMotion, checkElementGlow, isNeutralColor, isFullPage,
   detectText, detectHtml, extractStyleBlocks, extractCSSinJS,
-  walkDir, SCANNABLE_EXTENSIONS,
+  walkDir, hasScannableExtension, SCANNABLE_EXTENSIONS,
   buildImportGraph, resolveImport,
   detectFrameworkConfig, isPortListening, FRAMEWORK_CONFIGS,
 } from '../cli/engine/detect-antipatterns.mjs';
@@ -2075,18 +2075,28 @@ describe('walkDir', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-walk-'));
     try {
       const blade = path.join(tmp, 'resources', 'views', 'card.blade.php');
+      const upperBlade = path.join(tmp, 'resources', 'views', 'hero.BLADE.PHP');
       fs.mkdirSync(path.dirname(blade), { recursive: true });
       fs.writeFileSync(blade, '<div class="bg-orange-900 text-gray-500">Card</div>');
-      expect(walkDir(tmp)).toContain(blade);
+      fs.writeFileSync(upperBlade, '<div>Hero</div>');
+      expect(walkDir(tmp)).toEqual(expect.arrayContaining([blade, upperBlade]));
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('compound suffix matching does not broaden scans to module extensions', () => {
+    expect(hasScannableExtension('card.blade.php')).toBe(true);
+    expect(hasScannableExtension('card.BLADE.PHP')).toBe(true);
+    for (const file of ['next.config.mjs', 'vite.config.cjs', 'route.mts', 'route.cts']) {
+      expect(hasScannableExtension(file)).toBe(false);
     }
   });
 
   test('finds scannable files', () => {
     const files = walkDir(FIXTURES);
     expect(files.length).toBeGreaterThanOrEqual(3);
-    expect(files.every(f => SCANNABLE_EXTENSIONS.has(path.extname(f)))).toBe(true);
+    expect(files.every(hasScannableExtension)).toBe(true);
   });
 
   test('returns empty for nonexistent dir', () => {


### PR DESCRIPTION
Closes #460.

## Summary

- Treat `.blade.php` as a supported compound suffix during recursive CLI discovery.
- Match directory-scan candidates by full filename suffix so explicit-file and directory scans agree.
- Add a focused regression for nested Laravel Blade templates.

## Reproduction

On upstream main, an explicit `layout.blade.php` scan reported `gray-on-color`, while scanning its parent `resources/` directory returned `[]`. With this change, the directory scan reports the same finding.

## Validation

- `bun test tests/detect-antipatterns.test.js` (330 pass)
- Direct explicit-file and parent-directory CLI reproduction
- `bun run test` (full suite passed, including browser 27/27, framework 216/216, plugin E2E 4/4)
- `git diff --check`

## Generated output

Generated provider and root harness output was intentionally omitted; this is a source-first CLI fix.

## AI assistance

This pull request was prepared with Codex under maintainer authorization. The change and validation results were reviewed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to CLI file discovery with regression tests; no auth, data, or security-sensitive paths affected.
> 
> **Overview**
> Fixes directory scans skipping Laravel **`.blade.php`** templates while explicit file paths still worked (issue #460).
> 
> **`SCANNABLE_EXTENSIONS`** now includes **`.blade.php`**, and **`hasScannableExtension`** matches compound suffixes (case-insensitive) instead of relying on **`path.extname`**, which only saw **`.php`**. **`walkDir`** uses that helper so recursive discovery matches single-file scans.
> 
> **`hasScannableExtension`** is exported from the detector public API. Tests cover nested Blade paths and confirm config files like **`next.config.mjs`** are not pulled in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc9de447f37ab7daf2c85a418cecb3f284ad9ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->