### PR TITLE
Fix Windows question browser opening

### DIFF
--- a/skill/scripts/lib/open-system-browser.mjs
+++ b/skill/scripts/lib/open-system-browser.mjs
@@ -1,0 +1,26 @@
+import { spawn } from 'node:child_process';
+
+export function browserOpenCommand(url, {
+  platform = process.platform,
+  comspec = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe',
+} = {}) {
+  if (platform === 'darwin') return { command: 'open', args: [url] };
+  if (platform === 'win32') return { command: comspec, args: ['/c', 'start', '', url] };
+  return { command: 'xdg-open', args: [url] };
+}
+
+export function openSystemBrowser(url, {
+  platform = process.platform,
+  comspec = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe',
+  spawnImpl = spawn,
+} = {}) {
+  const { command, args } = browserOpenCommand(url, { platform, comspec });
+  try {
+    const child = spawnImpl(command, args, { stdio: 'ignore', detached: true });
+    child.on('error', () => {});
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -79,6 +79,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { openSystemBrowser } from './lib/open-system-browser.mjs';
 
 function arg(name, fallback = null) {
   const i = process.argv.indexOf(`--${name}`);
@@ -976,8 +977,7 @@ server.listen(portArg, '127.0.0.1', () => {
     console.log('Waiting for the user to choose in the browser (Ctrl-C aborts)...');
   }
   if (!hasFlag('no-open')) {
-    const opener = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-    try { spawn(opener, [url], { stdio: 'ignore', detached: true }).unref(); } catch { /* URL printed anyway */ }
+    openSystemBrowser(url);
   }
   if (timeoutSec > 0) {
     setTimeout(() => {

--- a/tests/serve-question.test.mjs
+++ b/tests/serve-question.test.mjs
@@ -5,6 +5,9 @@ import { writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { EventEmitter } from 'node:events';
+
+import { browserOpenCommand, openSystemBrowser } from '../skill/scripts/lib/open-system-browser.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = path.join(ROOT, 'skill', 'scripts', 'serve-question.mjs');
@@ -39,6 +42,24 @@ const PAYLOAD = {
 };
 
 describe('serve-question', () => {
+  it('opens Windows URLs through cmd.exe and reserves the start title argument', () => {
+    assert.deepEqual(
+      browserOpenCommand('http://127.0.0.1:1234/', { platform: 'win32', comspec: 'cmd.exe' }),
+      { command: 'cmd.exe', args: ['/c', 'start', '', 'http://127.0.0.1:1234/'] },
+    );
+  });
+
+  it('absorbs asynchronous system-opener failures after printing the URL', () => {
+    const child = new EventEmitter();
+    child.unref = () => {};
+    assert.equal(openSystemBrowser('http://127.0.0.1:1234/', {
+      platform: 'linux',
+      spawnImpl: () => child,
+    }), true);
+    assert.equal(child.listenerCount('error'), 1);
+    assert.doesNotThrow(() => child.emit('error', Object.assign(new Error('missing opener'), { code: 'ENOENT' })));
+  });
+
   it('serves the page, records the answer, prints ANSWER, exits 0', async () => {
     const { child, url, read } = await startServer(PAYLOAD);
     const html = await (await fetch(url)).text();


### PR DESCRIPTION
Closes #503.

## Summary

- Open browser URLs on Windows through `cmd.exe /c start "" <url>`, reserving the required title argument.
- Attach an asynchronous error handler before detaching the opener, so a missing system opener does not crash the question server on any platform.
- Cover the Windows command shape and asynchronous `ENOENT` path with focused tests.

## Reproduction

On upstream main, the real `serve-question.mjs` script run under a win32 preload printed the question URL, then exited 1 with an unhandled `spawn start ENOENT`. With this change and the opener unavailable, it stays alive and reaches its normal timeout exit 2.

## Validation

- `node --test tests/serve-question.test.mjs` (10 pass)
- `bun run test:new-work-e2e` (9 pass)
- `bun run build`
- Win32-preload end-to-end reproduction
- `bun run test` (full suite passed, including browser 27/27, framework 216/216, plugin E2E 4/4)
- `git diff --check`

## Generated output

Generated provider and root harness output was intentionally omitted; `bun run build` was used for source-first validation only.

## AI assistance

This pull request was prepared with Codex under maintainer authorization. The change and validation results were reviewed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to optional auto-open behavior in the question server; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **Windows** question-page browser launch by routing URLs through **`cmd.exe /c start "" <url>`** (empty title argument required by `start`), instead of spawning `start` directly and hitting **`ENOENT`**.
> 
> Browser opening is centralized in **`open-system-browser.mjs`**, which **`serve-question.mjs`** now calls instead of inline platform-specific `spawn` logic. The helper registers a **`child.on('error')`** handler before **`unref()`**, so a missing system opener (e.g. async **`ENOENT`**) no longer crashes the question server after the URL is printed.
> 
> Tests cover the Windows command shape and that async opener failures are absorbed without throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1e775471b9d851381fa54a08c36a648ec8bf37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->