### PR TITLE
Centralize critique snapshot reading

### DIFF
--- a/skill/scripts/context-signals.mjs
+++ b/skill/scripts/context-signals.mjs
@@ -22,7 +22,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { loadContext, extractPlatform } from './context.mjs';
-import { getCritiqueDir } from './lib/impeccable-paths.mjs';
+import { readLatestSnapshotAcrossTargets } from './critique-storage.mjs';
 
 /** Is there code here at all, or just context files / an empty repo? */
 function hasCode(cwd) {
@@ -34,23 +34,13 @@ function hasCode(cwd) {
 }
 
 /**
- * The most recent critique snapshot across all targets. Filenames are
- * timestamp-prefixed (`<iso>__<slug>.md`), so a lexical sort is chronological.
- * Parses the small frontmatter for score + P0/P1 counts.
+ * Summarize the most recent critique snapshot across all targets.
  */
 function latestCritique(cwd) {
   try {
-    const dir = getCritiqueDir(cwd);
-    if (!fs.existsSync(dir)) return null;
-    const files = fs.readdirSync(dir).filter((f) => f.endsWith('.md')).sort();
-    if (!files.length) return null;
-    const newest = files[files.length - 1];
-    const text = fs.readFileSync(path.join(dir, newest), 'utf-8');
-    const front = text.split('---')[1] || '';
-    const get = (k) => {
-      const m = front.match(new RegExp(`^${k}:\\s*(.+)$`, 'm'));
-      return m ? m[1].trim() : null;
-    };
+    const latest = readLatestSnapshotAcrossTargets({ cwd });
+    if (!latest) return null;
+    const get = (key) => latest.meta[key] ?? null;
     const num = (v) => {
       const n = Number(v);
       return Number.isFinite(n) ? n : null;
@@ -61,7 +51,7 @@ function latestCritique(cwd) {
       p0: num(get('p0')),
       p1: num(get('p1')),
       timestamp: get('timestamp'),
-      file: path.relative(cwd, path.join(dir, newest)),
+      file: path.relative(cwd, latest.path),
     };
   } catch {
     return null;

--- a/skill/scripts/critique-storage.mjs
+++ b/skill/scripts/critique-storage.mjs
@@ -105,16 +105,24 @@ function parseFrontmatter(text) {
 }
 
 /**
- * Return all snapshot files for `slug`, sorted oldest → newest.
+ * Return snapshot files matching `suffix`, sorted oldest → newest.
  */
-function listSnapshotsForSlug(slug, cwd) {
+const SNAPSHOT_FILENAME = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z__.+\.md$/;
+
+function listSnapshots(suffix, cwd) {
   const dir = getCritiqueDir(cwd);
   if (!fs.existsSync(dir)) return [];
-  const suffix = `__${slug}.md`;
   return fs.readdirSync(dir)
-    .filter((f) => f.endsWith(suffix))
+    .filter((f) => SNAPSHOT_FILENAME.test(f) && f.endsWith(suffix))
     .sort()
     .map((f) => path.join(dir, f));
+}
+
+function readLatestSnapshotMatching(suffix, cwd) {
+  const filePath = listSnapshots(suffix, cwd).at(-1);
+  if (!filePath) return null;
+  const body = fs.readFileSync(filePath, 'utf-8');
+  return { path: filePath, body, meta: parseFrontmatter(body) };
 }
 
 /**
@@ -122,11 +130,12 @@ function listSnapshotsForSlug(slug, cwd) {
  * to find its fix backlog when the slug matches.
  */
 export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
-  const all = listSnapshotsForSlug(slug, cwd);
-  if (!all.length) return null;
-  const latest = all[all.length - 1];
-  const body = fs.readFileSync(latest, 'utf-8');
-  return { path: latest, body, meta: parseFrontmatter(body) };
+  return readLatestSnapshotMatching(`__${slug}.md`, cwd);
+}
+
+/** Return the most recent snapshot across all targets, or null. */
+export function readLatestSnapshotAcrossTargets({ cwd = process.cwd() } = {}) {
+  return readLatestSnapshotMatching('.md', cwd);
 }
 
 /**
@@ -134,7 +143,7 @@ export function readLatestSnapshot(slug, { cwd = process.cwd() } = {}) {
  * Critique appends a one-line trend to its output using this.
  */
 export function readTrend(slug, { limit = 5, cwd = process.cwd() } = {}) {
-  const all = listSnapshotsForSlug(slug, cwd);
+  const all = listSnapshots(`__${slug}.md`, cwd);
   const slice = all.slice(-limit);
   return slice.map((file) => parseFrontmatter(fs.readFileSync(file, 'utf-8')));
 }

--- a/tests/context-signals.test.mjs
+++ b/tests/context-signals.test.mjs
@@ -76,6 +76,22 @@ describe('gatherSignals', () => {
     assert.equal(s.critique.latest.slug, 'home');
   });
 
+  it('reads the newest critique snapshot across target slugs', async () => {
+    write('.impeccable/critique/2026-05-01T10-00-00Z__home.md',
+      '---\nslug: home\nscore: 6\np0: 1\np1: 3\ntimestamp: 2026-05-01T10-00-00Z\n---\nbody\n');
+    write('.impeccable/critique/2026-05-02T10-00-00Z__pricing.md',
+      '---\nslug: pricing\nscore: 9\np0: 0\np1: 1\ntimestamp: 2026-05-02T10-00-00Z\n---\nbody\n');
+    write('.impeccable/critique/ignore.md', '# Critique ignores\n');
+    write('.impeccable/critique/9999-not-a-snapshot.md', '# Draft\n');
+    const s = await gatherSignals(scratch);
+    assert.equal(s.critique.latest.slug, 'pricing');
+    assert.equal(s.critique.latest.score, 9);
+    assert.equal(
+      s.critique.latest.file,
+      '.impeccable/critique/2026-05-02T10-00-00Z__pricing.md',
+    );
+  });
+
   it('handles a non-git dir without throwing', async () => {
     const s = await gatherSignals(scratch);
     assert.equal(s.git.isRepo, false);

--- a/tests/critique-storage.test.mjs
+++ b/tests/critique-storage.test.mjs
@@ -5,7 +5,7 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -17,6 +17,7 @@ import {
   slugFromTarget,
   writeSnapshot,
   readLatestSnapshot,
+  readLatestSnapshotAcrossTargets,
   readTrend,
   nowFilenameStamp,
 } from '../skill/scripts/critique-storage.mjs';
@@ -111,6 +112,16 @@ describe('writeSnapshot + readLatestSnapshot', () => {
     writeSnapshot({ slug: 'index-astro', meta: { total_score: 30 }, body: 'new', cwd, now: new Date('2026-05-12T00:00:00Z') });
     const latest = readLatestSnapshot('index-astro', { cwd });
     assert.equal(latest.meta.total_score, 30);
+    assert.match(latest.body, /new/);
+  });
+
+  it('picks the newest snapshot across target slugs', () => {
+    writeSnapshot({ slug: 'home', meta: {}, body: 'old', cwd, now: new Date('2026-05-01T00:00:00Z') });
+    writeSnapshot({ slug: 'pricing', meta: {}, body: 'new', cwd, now: new Date('2026-05-12T00:00:00Z') });
+    writeFileSync(join(cwd, '.impeccable', 'critique', 'ignore.md'), '# Critique ignores\n');
+    writeFileSync(join(cwd, '.impeccable', 'critique', '9999-not-a-snapshot.md'), '# Draft\n');
+    const latest = readLatestSnapshotAcrossTargets({ cwd });
+    assert.equal(latest.meta.slug, 'pricing');
     assert.match(latest.body, /new/);
   });
 


### PR DESCRIPTION
## Summary

- Remove critique-directory traversal and frontmatter parsing from `context-signals.mjs`.
- Make `critique-storage.mjs` the single owner of locating and parsing the newest snapshot, including the cross-target case.
- Add characterization and direct storage coverage for newest-snapshot selection across different target slugs and for excluding non-snapshot policy/draft Markdown.

## Hindsight architecture judgment

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No. The signal gatherer should summarize project signals, not maintain a second reader/parser for artifacts whose schema and lifecycle already belong to critique storage.

The smallest cleaner architecture is one explicit storage query—`readLatestSnapshotAcrossTargets()`—with `context-signals.mjs` retaining only its existing public summary shape and never-throw behavior.

## Before / after

| | Before | After |
|---|---:|---:|
| `skill/scripts/context-signals.mjs` | 334 lines | 324 lines |
| `skill/scripts/critique-storage.mjs` | 213 lines | 222 lines |
| Affected source architecture | 547 lines | 546 lines |
| Snapshot discovery/parsers | 2 owners | 1 owner |

Public contracts are unchanged: `gatherSignals(cwd)`, the context-signals CLI JSON shape, per-slug critique reads, trend reads, filenames, and error semantics remain intact. Snapshot discovery now explicitly enforces the persisted timestamp-plus-slug filename contract, so `ignore.md` and other ordinary Markdown cannot masquerade as snapshots.

## Validation

- `node --test tests/context-signals.test.mjs tests/critique-storage.test.mjs` — 58 passed
- `bun run build` — passed on the final review-fixed commit
- `bun run test` — passed on the final review-fixed commit, including browser, framework, and real Claude plugin-loader coverage
- `git diff --check` — passed
- `bun run test:skill-behavior` — required live LLM suite executed; 56/76 passed, with 19 failures and 1 cancellation in untouched setup/redesign prompt workflows. The same scenarios alternated between pass/fail across Claude, GPT, Gemini, and DeepSeek, while all deterministic context/storage tests passed.

Generated provider/root harness output was intentionally omitted. `bun run build` used the source-first `--skip-root-sync` path.

## Review fixes

Copilot and Greptile independently identified that an ordinary Markdown file could sort after snapshots. The final implementation accepts only the persisted `YYYY-MM-DDTHH-MM-SSZ__slug.md` filename shape. Regression fixtures cover both `ignore.md` and `9999-not-a-snapshot.md` at storage and context-signal boundaries.

## Risk

Low. Selection remains lexicographic by timestamp-prefixed filename, the canonical storage parser serves both consumers, and the exact filename contract is now covered. No user-facing schema, CLI output, or compatibility contract is intentionally changed.

## Authorization and AI assistance

Prepared by Codex under pbakaus's standing scheduled architecture-refactor authorization. AI assistance is disclosed in the commit, this PR, and review replies. This PR is ready for review and is not authorized to be merged by the automation.