### PR TITLE
Fix Codex pinned skill frontmatter

### DIFF
--- a/skill/scripts/pin.mjs
+++ b/skill/scripts/pin.mjs
@@ -93,15 +93,17 @@ function commandPrefixForSkillsDir(skillsDir) {
   return CODEX_HARNESSES.has(basename(dirname(skillsDir))) ? '$' : '/';
 }
 
-function generatePinnedSkill(command, metadata, commandPrefix) {
+function generatePinnedSkill(command, metadata, commandPrefix, isCodex) {
   const desc = metadata[command]?.description || `Shortcut for ${commandPrefix}impeccable ${command}.`;
   const hint = metadata[command]?.argumentHint || '[target]';
+  const providerFrontmatter = isCodex
+    ? `metadata:\n  argument-hint: "${hint}"`
+    : `argument-hint: "${hint}"\nuser-invocable: true`;
 
   return `---
 name: ${command}
 description: "${desc}"
-argument-hint: "${hint}"
-user-invocable: true
+${providerFrontmatter}
 ---
 
 ${PIN_MARKER}
@@ -128,7 +130,7 @@ function pin(command, projectRoot) {
 
   for (const skillsDir of harnessDirs) {
     const commandPrefix = commandPrefixForSkillsDir(skillsDir);
-    const content = generatePinnedSkill(command, metadata, commandPrefix);
+    const content = generatePinnedSkill(command, metadata, commandPrefix, commandPrefix === '$');
     // Check if skill already exists (and isn't a pin)
     const skillDir = join(skillsDir, command);
     if (existsSync(skillDir)) {

--- a/tests/pin.test.mjs
+++ b/tests/pin.test.mjs
@@ -35,12 +35,17 @@ describe('pin command provider syntax', () => {
       const skill = fs.readFileSync(path.join(project, harness, 'skills', 'audit', 'SKILL.md'), 'utf8');
       assert.match(skill, /\/impeccable audit/);
       assert.doesNotMatch(skill, /\$impeccable audit/);
+      assert.match(skill, /^argument-hint:/m);
+      assert.match(skill, /^user-invocable: true$/m);
     }
 
     for (const harness of ['.agents', '.codex']) {
       const skill = fs.readFileSync(path.join(project, harness, 'skills', 'audit', 'SKILL.md'), 'utf8');
       assert.match(skill, /\$impeccable audit/);
       assert.doesNotMatch(skill, /\/impeccable audit/);
+      assert.doesNotMatch(skill, /^argument-hint:/m);
+      assert.doesNotMatch(skill, /^user-invocable:/m);
+      assert.match(skill, /^metadata:\n  argument-hint:/m);
     }
   });
 });


### PR DESCRIPTION
## Summary

- emit Codex-compatible pinned skill frontmatter for `.codex` and `.agents`
- move the existing argument hint under the allowed `metadata` key
- preserve Claude-style `argument-hint` and `user-invocable` fields for other harnesses
- add provider-specific regression coverage

Closes #513.

## Reproduction

On upstream main `ae5e9510`, `pin audit` generated both `.agents/skills/audit/SKILL.md` and `.codex/skills/audit/SKILL.md` with top-level `argument-hint` and `user-invocable`. Those keys are outside the bundled Codex validator's allowlist.

After this change, both generated pins expose only `name`, `description`, and `metadata` at the top level, while retaining the `$impeccable audit` invocation.

## Validation

- `node --test tests/pin.test.mjs` — 1/1 passed
- generated `.agents` and `.codex` pin frontmatter checked against the bundled validator allowlist — passed
- `bun run build` — passed
- `bun run test` — passed, including browser 121/121, live 820/820 with 2 intentional skips, framework 216/216, and plugin E2E 4/4
- `git diff --check` — passed

## Generated output

Generated provider/root harness output was intentionally omitted. `bun run build` used the source-first `--skip-root-sync` path.

## AI assistance disclosure

Codex implemented, tested, and prepared this PR under maintainer pbakaus's standing authorization. The commit body also discloses AI assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to pin script output formatting and test coverage; no runtime auth, data, or API behavior changes.
> 
> **Overview**
> **Pinned skill generation** now branches frontmatter by harness so Codex targets pass validation.
> 
> For **`.codex` and `.agents`**, generated `SKILL.md` no longer includes top-level `argument-hint` or `user-invocable`. The hint moves under **`metadata.argument-hint`**, leaving only `name`, `description`, and `metadata` at the root. Invocation text still uses **`$impeccable`**.
> 
> **Claude/Cursor-style harnesses** keep top-level `argument-hint` and `user-invocable: true` with **`/impeccable`** wording.
> 
> **`tests/pin.test.mjs`** adds assertions for both frontmatter shapes per harness family.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b61b3db50cce1120a0cd3174e6559392c93d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->