### PR TITLE
Fix Claude copy-edit prompt transport

### DIFF
--- a/skill/scripts/live-copy-edit-agent.mjs
+++ b/skill/scripts/live-copy-edit-agent.mjs
@@ -470,12 +470,11 @@ function runClaude(prompt, { cwd, env, resultPath, logPath, timeoutMs = DEFAULT_
   if (env.IMPECCABLE_LIVE_COPY_AGENT_MODEL) {
     args.push('--model', env.IMPECCABLE_LIVE_COPY_AGENT_MODEL);
   }
-  args.push(prompt);
   // Forward env as-is so CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_API_KEY flow
   // through. On macOS, `claude /login` stores creds in the Keychain, which a
   // non-TTY subprocess cannot read; setting CLAUDE_CODE_OAUTH_TOKEN (via
   // `claude setup-token`) is the supported headless auth path.
-  return runAgentProcess('claude', args, '', { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
+  return runAgentProcess('claude', args, prompt, { cwd, env, logPath, timeoutMs, mirrorOutputPath: resultPath });
 }
 
 function runAgentProcess(command, args, stdin, { cwd, env, logPath, timeoutMs, mirrorOutputPath }) {

--- a/tests/live-copy-edit-agent.test.mjs
+++ b/tests/live-copy-edit-agent.test.mjs
@@ -305,6 +305,48 @@ describe('live-copy-edit-agent', () => {
     );
   });
 
+  it('passes large Claude prompts on stdin instead of argv', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'copy-agent-claude-stdin-'));
+    try {
+      const fakeClaude = path.join(tmp, 'claude');
+      fs.writeFileSync(fakeClaude, [
+        '#!/usr/bin/env node',
+        "let input = '';",
+        "process.stdin.setEncoding('utf8');",
+        "process.stdin.on('data', (chunk) => { input += chunk; });",
+        "process.stdin.on('end', () => {",
+        "  const promptLeakedToArgv = process.argv.slice(2).some((arg) => arg.includes('large-prompt-sentinel'));",
+        "  if (!input.includes('large-prompt-sentinel') || promptLeakedToArgv) process.exit(2);",
+        "  process.stdout.write(JSON.stringify({ status: 'done', appliedEntryIds: ['large'], files: [], notes: [] }));",
+        '});',
+        '',
+      ].join('\n'));
+      fs.chmodSync(fakeClaude, 0o755);
+
+      const result = await runCopyEditBatchAgent({
+        pageUrl: '/',
+        entries: [{
+          id: 'large',
+          pageUrl: '/',
+          ops: [{ originalText: 'Old', newText: `large-prompt-sentinel${'x'.repeat(1_100_000)}` }],
+        }],
+      }, {
+        provider: 'claude',
+        outDir: path.join(tmp, 'out'),
+        timeoutMs: 5_000,
+        env: {
+          ...process.env,
+          PATH: `${tmp}${path.delimiter}${process.env.PATH || ''}`,
+        },
+      });
+
+      assert.equal(result.status, 'done');
+      assert.deepEqual(result.appliedEntryIds, ['large']);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('describeNoProviderError mentions starting impeccable live when chat is the missing piece', () => {
     const noChatPolling = describeNoProviderError({
       exists: () => false,


### PR DESCRIPTION
Closes #524.

## Summary

- pass staged copy-edit prompts to the Claude CLI over stdin instead of argv
- preserve the existing Claude flags and result handling
- add a regression that exercises a 1.1 MB prompt through a fake Claude executable

## Validation

- `node --test tests/live-copy-edit-agent.test.mjs` — 18/18 passed
- `bun run build` — passed
- `bun run test:live-e2e` — 35 passed, 1 documented pre-existing skip
- `bun run test` — passed (core, browser 121/121, live 821 pass with 2 intentional skips, framework 216/216, plugin E2E 4/4)
- `git diff --check` — passed

## Generated output

Generated provider and root harness output was intentionally omitted per the repository's source-first policy.

## AI assistance disclosure

Implemented, tested, and documented with OpenAI Codex assistance under standing maintainer authorization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow transport fix in the Claude subprocess path; behavior and flags are unchanged aside from how the prompt is delivered.
> 
> **Overview**
> Fixes **Apply copy edits** failing when staged batches produce very large Claude prompts (e.g. big `newText` or heavy batch JSON), which previously hit OS **argv length limits** because the full prompt was appended as a CLI argument.
> 
> **`runClaude`** now sends the batch prompt through **`runAgentProcess` stdin** (same pattern as Codex), while keeping existing flags (`--print`, permission mode, JSON output) and result mirroring unchanged.
> 
> Adds a regression test with a **~1.1 MB** prompt and a fake `claude` binary that asserts the sentinel appears on stdin and **not** in `argv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd78be5630acc8c83d26e525d2b012cf653d39f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->