### PR TITLE
Resolve repo-root DESIGN.md through monorepo subpackage boundaries

### DIFF
--- a/.agents/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.agents/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.claude/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.claude/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.cursor/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.cursor/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.gemini/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.gemini/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.github/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.github/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.grok/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.grok/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.kiro/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.kiro/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.opencode/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.opencode/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.pi/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.pi/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.qoder/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.qoder/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.rovodev/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.rovodev/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.trae-cn/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.trae-cn/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.trae/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.trae/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/.vibe/skills/impeccable/scripts/detector/design-system.mjs
+++ b/.vibe/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/cli/engine/design-system.mjs
+++ b/cli/engine/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/plugin/skills/impeccable/scripts/detector/design-system.mjs
+++ b/plugin/skills/impeccable/scripts/detector/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/tests/design-system.test.mjs
+++ b/tests/design-system.test.mjs
@@ -12,11 +12,13 @@ import path from 'node:path';
 import {
   checkSourceDesignSystem,
   collectStaticDesignSystemFindings,
+  findDesignRoot,
   isAllowedColorRaw,
   isAllowedFont,
   isAllowedRadiusRaw,
   isAllowedFontSizeRaw,
   loadDesignSystemForCwd,
+  loadDesignSystemForTarget,
   normalizeDesignSystem,
 } from '../cli/engine/design-system.mjs';
 
@@ -351,6 +353,89 @@ small { font-family: "IBM Plex Serif", serif; }
 pre { font-family: "Space Grotesk", sans-serif; }
 `, '/tmp/escaped-fonts.css', { designSystem: loaded });
     assert.deepEqual(findings, []);
+  });
+});
+
+describe('findDesignRoot()', () => {
+  const MINIMAL_DESIGN = `---
+typography:
+  body:
+    fontFamily: "Palatino, Georgia, serif"
+---
+# Design System
+`;
+
+  // A monorepo: repo-root DESIGN.md + .git, with a web/ subpackage carrying
+  // its own package.json but no DESIGN.md of its own.
+  function mkMonorepo({ gitAs = 'dir' } = {}) {
+    const repo = mkTmp();
+    if (gitAs === 'dir') fs.mkdirSync(path.join(repo, '.git'));
+    else fs.writeFileSync(path.join(repo, '.git'), 'gitdir: /elsewhere/.git/worktrees/x\n');
+    fs.writeFileSync(path.join(repo, 'DESIGN.md'), MINIMAL_DESIGN);
+    fs.writeFileSync(path.join(repo, 'package.json'), '{"name":"root"}');
+    const sub = path.join(repo, 'web', 'app', 'assets');
+    fs.mkdirSync(sub, { recursive: true });
+    fs.writeFileSync(path.join(repo, 'web', 'package.json'), '{"name":"web"}');
+    return { repo, sub };
+  }
+
+  it('walks past a subpackage package.json to the repo-root DESIGN.md (monorepo)', () => {
+    const { repo, sub } = mkMonorepo();
+    const found = findDesignRoot(sub);
+    assert.deepEqual(found, { dir: repo, hasDesign: true });
+  });
+
+  it('honors the repo-root DESIGN.md when .git is a worktree file, not a directory', () => {
+    const { repo, sub } = mkMonorepo({ gitAs: 'file' });
+    const found = findDesignRoot(sub);
+    assert.deepEqual(found, { dir: repo, hasDesign: true });
+  });
+
+  it('loadDesignSystemForTarget applies the repo-root DESIGN.md to a subpackage file', () => {
+    const { repo, sub } = mkMonorepo();
+    const target = path.join(sub, 'application.css');
+    fs.writeFileSync(target, '.card { font-family: Verdana, sans-serif; }');
+    const loaded = loadDesignSystemForTarget(target);
+    assert.equal(loaded?.present, true);
+    assert.equal(loaded.sourcePath, path.join(repo, 'DESIGN.md'));
+    assert.equal(isAllowedFont('verdana', loaded), false);
+  });
+
+  it('prefers a subpackage DESIGN.md over the repo root (nearest wins)', () => {
+    const { repo, sub } = mkMonorepo();
+    fs.writeFileSync(path.join(repo, 'web', 'DESIGN.md'), MINIMAL_DESIGN);
+    const found = findDesignRoot(sub);
+    assert.deepEqual(found, { dir: path.join(repo, 'web'), hasDesign: true });
+  });
+
+  it('still stops at a package.json boundary outside any git repo (sibling isolation)', () => {
+    // No .git anywhere above: package.json marks an independent project, so a
+    // DESIGN.md in a parent directory must NOT leak in.
+    const parent = mkTmp();
+    fs.writeFileSync(path.join(parent, 'DESIGN.md'), MINIMAL_DESIGN);
+    const project = path.join(parent, 'standalone');
+    fs.mkdirSync(project);
+    fs.writeFileSync(path.join(project, 'package.json'), '{"name":"standalone"}');
+    const found = findDesignRoot(project);
+    assert.deepEqual(found, { dir: project, hasDesign: false });
+  });
+
+  it('never crosses a .git boundary: a nested repo ignores the outer repo\'s DESIGN.md', () => {
+    const { repo } = mkMonorepo();
+    const inner = path.join(repo, 'vendor', 'other-repo');
+    fs.mkdirSync(inner, { recursive: true });
+    fs.mkdirSync(path.join(inner, '.git'));
+    fs.writeFileSync(path.join(inner, 'package.json'), '{"name":"other"}');
+    const found = findDesignRoot(inner);
+    assert.deepEqual(found, { dir: inner, hasDesign: false });
+  });
+
+  it('treats .impeccable as a hard boundary even inside a git repo', () => {
+    const { repo } = mkMonorepo();
+    const sub = path.join(repo, 'web');
+    fs.mkdirSync(path.join(sub, '.impeccable'), { recursive: true });
+    const found = findDesignRoot(sub);
+    assert.deepEqual(found, { dir: sub, hasDesign: false });
   });
 });
 

--- a/tests/detect-cli-design-contamination.test.mjs
+++ b/tests/detect-cli-design-contamination.test.mjs
@@ -136,6 +136,44 @@ describe('detect CLI DESIGN.md resolution', () => {
     );
   });
 
+  it('treats a .git worktree file the same as a .git directory for the subpackage walk', () => {
+    // In a git worktree checkout, .git is a file, not a directory. It must
+    // still let the walk continue past the subpackage package.json.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-wt-'));
+    tempRoots.push(root);
+    fs.writeFileSync(path.join(root, '.git'), 'gitdir: /nonexistent/worktrees/x\n');
+    fs.writeFileSync(path.join(root, 'DESIGN.md'), DESIGN_MD);
+    fs.mkdirSync(path.join(root, 'web'));
+    fs.writeFileSync(path.join(root, 'web', 'package.json'), '{"name":"web"}');
+    const page = path.join(root, 'web', 'page.html');
+    fs.writeFileSync(page, PAGE_HTML);
+
+    const findings = runDetect(projB.dir, [page]);
+    assert.ok(
+      fontFindingsFor(findings, page).some((f) => f.ignoreValue === 'verdana'),
+      'a worktree-style .git file must behave like a .git directory',
+    );
+  });
+
+  it('still stops at the repo boundary: a monorepo without DESIGN.md inherits nothing from cwd', () => {
+    // The walk continues past web/'s package.json but must stop at the .git
+    // root — it may never escape the repository and pick up cwd's DESIGN.md.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-mono-bare-'));
+    tempRoots.push(root);
+    fs.mkdirSync(path.join(root, '.git'));
+    fs.mkdirSync(path.join(root, 'web'));
+    fs.writeFileSync(path.join(root, 'web', 'package.json'), '{"name":"web"}');
+    const page = path.join(root, 'web', 'page.html');
+    fs.writeFileSync(page, PAGE_HTML);
+
+    const findings = runDetect(projA.dir, [page]);
+    assert.equal(
+      fontFindingsFor(findings, page).length,
+      0,
+      'a design-less monorepo must not inherit the cwd project\'s DESIGN.md',
+    );
+  });
+
   it('falls back to no design system for a bare file with no project markers above it', () => {
     // A lone file whose directory has neither .git, package.json, nor .impeccable.
     const bareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-bare-'));

--- a/tests/detect-cli-design-contamination.test.mjs
+++ b/tests/detect-cli-design-contamination.test.mjs
@@ -115,6 +115,27 @@ describe('detect CLI DESIGN.md resolution', () => {
     );
   });
 
+  it('applies a repo-root DESIGN.md to a file under a monorepo subpackage boundary', () => {
+    // Monorepo shape: .git + DESIGN.md at the repo root, a web/ subpackage with
+    // its own package.json and no DESIGN.md. The subpackage boundary must not
+    // hide the repo root's design system from files under web/.
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-mono-'));
+    tempRoots.push(repo);
+    fs.mkdirSync(path.join(repo, '.git'));
+    fs.writeFileSync(path.join(repo, 'package.json'), '{"name":"monorepo-root"}');
+    fs.writeFileSync(path.join(repo, 'DESIGN.md'), DESIGN_MD);
+    fs.mkdirSync(path.join(repo, 'web'));
+    fs.writeFileSync(path.join(repo, 'web', 'package.json'), '{"name":"web"}');
+    const page = path.join(repo, 'web', 'page.html');
+    fs.writeFileSync(page, PAGE_HTML);
+
+    const findings = runDetect(repo, [page]);
+    assert.ok(
+      fontFindingsFor(findings, page).some((f) => f.ignoreValue === 'verdana'),
+      'the repo-root DESIGN.md must govern files under the web/ subpackage',
+    );
+  });
+
   it('falls back to no design system for a bare file with no project markers above it', () => {
     // A lone file whose directory has neither .git, package.json, nor .impeccable.
     const bareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-bare-'));

--- a/tests/hook-build.test.mjs
+++ b/tests/hook-build.test.mjs
@@ -6,6 +6,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -388,6 +389,37 @@ describe('generated hook artifacts in repo', () => {
       const hookLib = await import(pathToFileURL(path.join(abs, 'hook-lib.mjs')));
       const detector = await hookLib.loadDetector();
       assert.equal(typeof detector.detectText, 'function');
+    }
+  });
+
+  it('bundled detectors resolve a repo-root DESIGN.md through a monorepo subpackage', async () => {
+    // The engine fix (findDesignRoot walking past a subpackage package.json
+    // inside a git repo) must ship in every generated detector bundle, or the
+    // packaged hook reports subpackage files clean instead of applying the
+    // repo-root DESIGN.md.
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-hook-monorepo-'));
+    try {
+      fs.mkdirSync(path.join(repo, '.git'));
+      fs.writeFileSync(path.join(repo, 'DESIGN.md'), '# Design System\n');
+      fs.writeFileSync(path.join(repo, 'package.json'), '{"name":"root"}');
+      const sub = path.join(repo, 'web', 'app', 'assets');
+      fs.mkdirSync(sub, { recursive: true });
+      fs.writeFileSync(path.join(repo, 'web', 'package.json'), '{"name":"web"}');
+
+      for (const scriptDir of [
+        '.claude/skills/impeccable/scripts',
+        '.cursor/skills/impeccable/scripts',
+        '.agents/skills/impeccable/scripts',
+        'plugin/skills/impeccable/scripts',
+      ]) {
+        const modPath = path.join(REPO_ROOT, scriptDir, 'detector', 'design-system.mjs');
+        const { findDesignRoot } = await import(pathToFileURL(modPath));
+        const found = findDesignRoot(sub);
+        assert.deepEqual(found, { dir: repo, hasDesign: true },
+          `${scriptDir} detector stops at the subpackage package.json - regenerate with bun run build:release`);
+      }
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## The bug

`findDesignRoot` in `cli/engine/design-system.mjs` walks up from a scan target looking for `DESIGN.md`, and stops at the first directory carrying a project marker (`.git` / `package.json` / `.impeccable`) that has no `DESIGN.md`. That boundary rule is what keeps sibling projects isolated — but in a monorepo it creates a blind spot: a subpackage's `package.json` is such a directory, so it hides the repo-root `DESIGN.md` from every CLI scan of files under it.

Real-world case that surfaced this: a Rails monorepo with `DESIGN.md` and `.git` at the repo root and an npm subpackage at `web/`. Any `impeccable detect` run against files under `web/` silently resolved *no* design system, so `DESIGN.md` violations (off-palette fonts, colors, radii) in the app's actual frontend went unreported.

## The fix

Keep `.git` and `.impeccable` as hard boundaries, but treat a `package.json` that is nested inside a git repository as a monorepo subpackage rather than an independent project — the walk continues upward. This can never leak across repos: the walk still stops at the `.git` entry itself (a directory in a normal checkout, a file in a git worktree — `existsSync` covers both).

Two small helpers implement this:

- `isProjectBoundary(dir)` — `.git`/`.impeccable` always bound; `package.json` bounds only when no ancestor is a git repo.
- `hasGitAncestor(startDir)` — walks up checking for a `.git` entry.

Behavior outside git repos is unchanged: a bare `package.json` still marks an independent project, so the sibling-isolation guarantees from the cross-project contamination fix are preserved.

## Tests

8 new tests, all passing alongside the existing suites (`node --test tests/design-system.test.mjs tests/detect-cli-design-contamination.test.mjs` → 28 pass, 0 fail):

**`tests/design-system.test.mjs`** (7 unit tests on `findDesignRoot` / `loadDesignSystemForTarget`):
- monorepo subpackage resolves the repo-root `DESIGN.md`
- same, with `.git` as a worktree *file* instead of a directory
- `loadDesignSystemForTarget` applies the repo-root system to a subpackage file
- nearest `DESIGN.md` wins (subpackage `DESIGN.md` beats repo root)
- `package.json` outside any git repo still bounds (sibling isolation)
- a nested `.git` repo never inherits the outer repo's `DESIGN.md`
- `.impeccable` stays a hard boundary even inside a git repo

**`tests/detect-cli-design-contamination.test.mjs`** (1 e2e): a full `detect` run applies the repo-root `DESIGN.md` to a file under the subpackage boundary.

The pre-existing contamination tests (cwd project A must not govern project B's files) still pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to design-root path resolution with broad regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **silent skips of `DESIGN.md` enforcement** when scanning files under a monorepo subpackage (e.g. `web/` with its own `package.json` but no local `DESIGN.md`). The upward walk used to treat any `package.json` as a hard project boundary and stop with no design system.
> 
> **`findDesignRoot`** now delegates boundary detection to **`isProjectBoundary`** and **`hasGitAncestor`**: `.git` and `.impeccable` still always stop the walk; `package.json` stops only when there is **no** git ancestor (standalone projects). Inside a repo, nested `package.json` is ignored so the walk can reach a repo-root `DESIGN.md` (still capped at `.git`, including worktree `.git` files). Nearest `DESIGN.md` still wins; nested repos and `.impeccable` boundaries behave as before.
> 
> The same logic is mirrored across **`cli/engine/design-system.mjs`** and every bundled **impeccable** detector copy. **Tests** cover unit resolution, `detect` e2e, and hook bundle parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ca9082cedbb3188e4c1ee579fac77b54b3c7ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->