### PR TITLE
Fix: honor a repo-root DESIGN.md above monorepo subpackage package.json boundaries

### DIFF
--- a/cli/engine/design-system.mjs
+++ b/cli/engine/design-system.mjs
@@ -558,6 +558,10 @@ function designSystemStartDir(targetPath, cwd = process.cwd()) {
 //   - A directory carrying a project marker (.git / package.json / .impeccable)
 //     but no DESIGN.md is a project BOUNDARY: the walk stops with no design
 //     system, so a sibling project never inherits a parent's or cwd's rules.
+//     Exception: a package.json nested inside a git repository marks a monorepo
+//     subpackage, not an independent project — the walk continues so a
+//     repo-root DESIGN.md still governs files under the subpackage. The walk
+//     can never escape the repo, because the .git directory itself stops it.
 //   - Reaching the home directory / filesystem root with neither means no
 //     design system at all — never process.cwd()'s.
 //
@@ -568,12 +572,35 @@ export function findDesignRoot(startDir) {
   const homeDir = path.resolve(os.homedir());
   while (true) {
     if (resolveDesignMdPath(dir)) return { dir, hasDesign: true };
-    if (PROJECT_ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dir, marker)))) {
-      return { dir, hasDesign: false };
-    }
+    if (isProjectBoundary(dir)) return { dir, hasDesign: false };
     if (dir === homeDir) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// .git and .impeccable always mark a project root. package.json marks one only
+// outside a git repository: inside one it is a subpackage (e.g. web/ in a
+// monorepo) whose files are still governed by a design root higher in the same
+// repo.
+function isProjectBoundary(dir) {
+  if (PROJECT_ROOT_MARKERS.some(
+    (marker) => marker !== 'package.json' && fs.existsSync(path.join(dir, marker)),
+  )) {
+    return true;
+  }
+  return fs.existsSync(path.join(dir, 'package.json')) && !hasGitAncestor(path.dirname(dir));
+}
+
+// True when `startDir` or any ancestor contains a .git entry (a directory in a
+// normal checkout, a file in a git worktree — existsSync covers both).
+function hasGitAncestor(startDir) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) return true;
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
     dir = parent;
   }
 }

--- a/tests/detect-cli-design-contamination.test.mjs
+++ b/tests/detect-cli-design-contamination.test.mjs
@@ -115,6 +115,68 @@ describe('detect CLI DESIGN.md resolution', () => {
     );
   });
 
+  it('applies a repo-root DESIGN.md to a file inside a monorepo subpackage', () => {
+    // gitRoot/DESIGN.md must govern gitRoot/web/page.html even though web/ has
+    // its own package.json: inside a git repository, package.json marks a
+    // subpackage, not an independent project boundary.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-mono-'));
+    tempRoots.push(root);
+    fs.mkdirSync(path.join(root, '.git'));
+    fs.writeFileSync(path.join(root, 'package.json'), '{"name":"mono-root"}');
+    fs.writeFileSync(path.join(root, 'DESIGN.md'), DESIGN_MD);
+    const web = path.join(root, 'web');
+    fs.mkdirSync(web);
+    fs.writeFileSync(path.join(web, 'package.json'), '{"name":"web"}');
+    const page = path.join(web, 'page.html');
+    fs.writeFileSync(page, PAGE_HTML);
+
+    const findings = runDetect(projB.dir, [page]);
+    assert.ok(
+      fontFindingsFor(findings, page).some((f) => f.ignoreValue === 'verdana'),
+      'the repo-root DESIGN.md must govern files under a subpackage with its own package.json',
+    );
+  });
+
+  it('treats a .git worktree file the same as a .git directory for the subpackage walk', () => {
+    // In a git worktree checkout, .git is a file, not a directory. It must
+    // still let the walk continue past the subpackage package.json.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-wt-'));
+    tempRoots.push(root);
+    fs.writeFileSync(path.join(root, '.git'), 'gitdir: /nonexistent/worktrees/x\n');
+    fs.writeFileSync(path.join(root, 'DESIGN.md'), DESIGN_MD);
+    const web = path.join(root, 'web');
+    fs.mkdirSync(web);
+    fs.writeFileSync(path.join(web, 'package.json'), '{"name":"web"}');
+    const page = path.join(web, 'page.html');
+    fs.writeFileSync(page, PAGE_HTML);
+
+    const findings = runDetect(projB.dir, [page]);
+    assert.ok(
+      fontFindingsFor(findings, page).some((f) => f.ignoreValue === 'verdana'),
+      'a worktree-style .git file must behave like a .git directory',
+    );
+  });
+
+  it('still stops at the repo boundary: a monorepo without DESIGN.md inherits nothing from cwd', () => {
+    // The walk continues past web/'s package.json but must stop at the .git
+    // root — it may never escape the repository and pick up cwd's DESIGN.md.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-mono-bare-'));
+    tempRoots.push(root);
+    fs.mkdirSync(path.join(root, '.git'));
+    const web = path.join(root, 'web');
+    fs.mkdirSync(web);
+    fs.writeFileSync(path.join(web, 'package.json'), '{"name":"web"}');
+    const page = path.join(web, 'page.html');
+    fs.writeFileSync(page, PAGE_HTML);
+
+    const findings = runDetect(projA.dir, [page]);
+    assert.equal(
+      fontFindingsFor(findings, page).length,
+      0,
+      'a design-less monorepo must not inherit the cwd project\'s DESIGN.md',
+    );
+  });
+
   it('falls back to no design system for a bare file with no project markers above it', () => {
     // A lone file whose directory has neither .git, package.json, nor .impeccable.
     const bareDir = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-detect-bare-'));


### PR DESCRIPTION
## Problem

`findDesignRoot` in `cli/engine/design-system.mjs` treats **any** `package.json` as a hard project boundary. In a monorepo, that stops the design-root walk one level too early: a `DESIGN.md` at the repository root never governs files under a subpackage that carries its own `package.json` (e.g. `web/` in a workspace repo), and the detector silently runs those files with no design system at all.

Concretely, with:

```
repo/            <- .git + DESIGN.md
  web/           <- package.json (workspace subpackage)
    page.html    <- off-system font
```

`impeccable detect repo/web/page.html` reported no `design-system-*` findings, because the walk stopped at `web/package.json` with `hasDesign: false`.

## Fix

Inside a git repository, a `package.json` now marks a monorepo **subpackage**, not an independent project: the walk continues upward so the repo-root `DESIGN.md` applies. The walk can never escape the repository, because the `.git` entry itself (a directory in a normal checkout, a file in a git worktree — `fs.existsSync` covers both) still stops it.

Everything else about the boundary semantics is unchanged, so the cross-project contamination fix is preserved:

- `.git` and `.impeccable` remain hard boundaries.
- A `package.json` **outside** any git repository remains a hard boundary (a sibling project still never inherits cwd's rules).
- A design-less monorepo still resolves to no design system rather than inheriting the invoking project's `DESIGN.md`.

This mirrors the spirit of `skill/scripts/context.mjs`'s `resolveProject`, which already resolves subpackages against the repo root's context rather than stranding them.

## Validation

- Added three regression tests to `tests/detect-cli-design-contamination.test.mjs`: repo-root `DESIGN.md` governs a subpackage file; a worktree-style `.git` file behaves like a `.git` directory; a design-less monorepo inherits nothing from cwd (boundary still holds).
- `bun run test:detector` — 124/124 pass.
- `bun run test` (default suites) — all pass, 0 failures.

Generated provider output is intentionally omitted per AGENTS.md (source-first PR; `.github/workflows/sync-generated-output.yml` refreshes harness folders after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes project-boundary logic used by detect’s design-system resolution; wrong boundaries could mis-apply or skip DESIGN.md rules, though behavior outside git repos is preserved and tests cover contamination and monorepo cases.
> 
> **Overview**
> **`findDesignRoot`** no longer stops at every `package.json`. Inside a git repository, a nested `package.json` is treated as a monorepo subpackage, so the walk can continue to a repo-root **`DESIGN.md`**. **`.git`** and **`.impeccable`** remain hard boundaries; **`package.json`** still stops the walk when there is no git ancestor (sibling projects do not inherit cwd rules).
> 
> The change introduces **`isProjectBoundary`** and **`hasGitAncestor`** (including worktree-style **`.git`** files via **`existsSync`**). Three CLI regression tests cover subpackage inheritance, worktree **`.git`**, and design-less monorepos not picking up the invoking project’s **`DESIGN.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d1b02731b81f564690ab2c72d7c9d0fdbea01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->