### PR TITLE
Restore reduced-motion animation guidance

### DIFF
--- a/scripts/test-suites.mjs
+++ b/scripts/test-suites.mjs
@@ -68,6 +68,7 @@ export const SUITES = {
           'tests/release.test.mjs',
           'tests/doctor.test.mjs',
           'tests/staleness.test.mjs',
+          'tests/skill-reference.test.mjs',
           'tests/target-args.test.mjs',
           'tests/surface-brief.test.mjs',
           'tests/template-extensions.test.mjs',

--- a/skill/reference/animate.md
+++ b/skill/reference/animate.md
@@ -74,7 +74,7 @@ Keep content visible in the default state so failed scripts do not hide the page
 
 Respect autoplay and sound preferences. Any nonessential loop must stop when offscreen or hidden.
 
-Every web animation needs a `prefers-reduced-motion` path with an intentional alternative. Remove or reduce spatial movement while preserving opacity, color, and state transitions that carry meaning. Reduced motion means fewer and gentler animations, not no motion; feedback that confirms an action should remain legible.
+Every web animation needs a `prefers-reduced-motion` path with an intentional alternative. Remove or reduce spatial movement while preserving opacity, color, and state transitions that carry meaning. Reduced motion means fewer and gentler animations, not disabling all motion; feedback that confirms an action should remain legible.
 
 ## Verify
 

--- a/skill/reference/animate.md
+++ b/skill/reference/animate.md
@@ -74,12 +74,15 @@ Keep content visible in the default state so failed scripts do not hide the page
 
 Respect autoplay and sound preferences. Any nonessential loop must stop when offscreen or hidden.
 
+Every web animation needs a `prefers-reduced-motion` path with an intentional alternative. Remove or reduce spatial movement while preserving opacity, color, and state transitions that carry meaning. Reduced motion means fewer and gentler animations, not no motion; feedback that confirms an action should remain legible.
+
 ## Verify
 
 - The focal motion is specific to the selected world and surface.
 - Every supporting animation explains feedback, state, or relationship.
 - Interruption and repeated use behave correctly.
 - Desktop, mobile, and keyboard paths remain usable.
+- The `prefers-reduced-motion` path reduces movement without erasing meaningful feedback or state changes.
 - Expensive effects stay smooth on the target device.
 - Removing an animation would lose meaning or authored character, not merely decoration.
 

--- a/tests/skill-reference.test.mjs
+++ b/tests/skill-reference.test.mjs
@@ -2,8 +2,9 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = process.cwd();
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 describe('skill reference authoring contracts', () => {
   it('keeps reduced-motion guidance on the animation build path', () => {

--- a/tests/skill-reference.test.mjs
+++ b/tests/skill-reference.test.mjs
@@ -14,7 +14,7 @@ describe('skill reference authoring contracts', () => {
 
     assert.match(accessibility, /prefers-reduced-motion/);
     assert.match(accessibility, /intentional alternative/);
-    assert.match(accessibility, /not no motion/);
+    assert.match(accessibility, /not disabling all motion/);
     assert.match(verify, /reduced[- ]motion/i);
   });
 });

--- a/tests/skill-reference.test.mjs
+++ b/tests/skill-reference.test.mjs
@@ -7,13 +7,13 @@ const ROOT = process.cwd();
 
 describe('skill reference authoring contracts', () => {
   it('keeps reduced-motion guidance on the animation build path', () => {
-    const animate = readFileSync(join(ROOT, 'skill/reference/animate.md'), 'utf-8');
+    const animate = readFileSync(join(ROOT, 'skill/reference/animate.md'), 'utf-8').replace(/\r\n?/g, '\n');
     const accessibility = animate.match(/## Accessibility and control\n([\s\S]*?)\n## Verify/)?.[1] ?? '';
     const verify = animate.match(/## Verify\n([\s\S]*?)(?:\n## |$)/)?.[1] ?? '';
 
     assert.match(accessibility, /prefers-reduced-motion/);
     assert.match(accessibility, /intentional alternative/);
     assert.match(accessibility, /not no motion/);
-    assert.match(verify, /reduced-motion/);
+    assert.match(verify, /reduced[- ]motion/i);
   });
 });

--- a/tests/skill-reference.test.mjs
+++ b/tests/skill-reference.test.mjs
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+describe('skill reference authoring contracts', () => {
+  it('keeps reduced-motion guidance on the animation build path', () => {
+    const animate = readFileSync(join(ROOT, 'skill/reference/animate.md'), 'utf-8');
+    const accessibility = animate.match(/## Accessibility and control\n([\s\S]*?)\n## Verify/)?.[1] ?? '';
+    const verify = animate.match(/## Verify\n([\s\S]*?)(?:\n## |$)/)?.[1] ?? '';
+
+    assert.match(accessibility, /prefers-reduced-motion/);
+    assert.match(accessibility, /intentional alternative/);
+    assert.match(accessibility, /not no motion/);
+    assert.match(verify, /reduced-motion/);
+  });
+});


### PR DESCRIPTION
Closes #514.

## Summary

- restore `prefers-reduced-motion` guidance to the animation build playbook
- require an intentional reduced-motion alternative that preserves meaningful feedback and state changes
- add a verification item and a focused regression that keeps this accessibility requirement on the build path

## Validation

- `node --test tests/skill-reference.test.mjs` — passed (1/1)
- `node --test tests/test-suites.test.mjs` — passed (5/5)
- `bun run build` — passed
- `bun run test` — passed (core, browser 121/121, live 827 pass with 2 intentional skips, framework 216/216, plugin E2E 4/4)
- `git diff --check` — passed

## Generated output

Generated provider and root harness output was intentionally omitted per the repository's source-first policy.

## AI assistance disclosure

Implemented, tested, and documented with OpenAI Codex assistance under standing maintainer authorization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes with no runtime or security impact.
> 
> **Overview**
> Restores **`prefers-reduced-motion`** requirements in the animation skill reference (`skill/reference/animate.md`): authors must provide an intentional reduced-motion alternative that keeps meaningful opacity/color/state feedback, and a new **Verify** bullet checks that path.
> 
> Adds **`tests/skill-reference.test.mjs`** to lock those accessibility and verify strings in place, and wires it into the core test suite via **`scripts/test-suites.mjs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8d42a263b1604f8ab447302ff11fcfae307120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->