### PR TITLE
Fix: stop reading comments as markup in the regex engine

### DIFF
--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -18,6 +18,71 @@ const hasBorderRadius = (line) => /border-radius/i.test(line);
 const isSafeElement = (line) => /<(?:blockquote|nav[\s>]|pre[\s>]|code[\s>]|a\s|input[\s>]|span[\s>])/i.test(line);
 
 
+/**
+ * Blank out comment bodies so the line matchers never read prose as markup.
+ *
+ * The line matchers scan raw source, so a comment that merely NAMES a tag is
+ * scanned as if it were that tag. A block comment explaining "the CDN answers
+ * 403 for an img loaded from another origin" reports `broken-image` in a file
+ * that contains no img element at all. Every matcher has the same exposure —
+ * documentation about markup gets read as markup.
+ *
+ * Comment bodies are replaced with spaces instead of removed, so byte offsets,
+ * line numbers and column math are unchanged. Reported lines stay correct and
+ * line-scoped inline ignores keep working.
+ *
+ * This is a small scanner rather than a regex on purpose: `"https://x"` has to
+ * survive. Stripping `//` with a regex would swallow the rest of that string
+ * and could HIDE a real finding, which is worse than the false positive being
+ * fixed. So the scan tracks strings and template literals, and only treats a
+ * line or block comment as a comment when it opens outside one.
+ */
+function maskComments(source) {
+  const out = source.split('');
+  const blank = (from, to) => {
+    for (let k = from; k < to && k < out.length; k++) if (out[k] !== '\n') out[k] = ' ';
+  };
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const c = source[i];
+    const d = source[i + 1];
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      i++;
+      while (i < n) {
+        if (source[i] === '\\') { i += 2; continue; }
+        if (source[i] === quote) { i++; break; }
+        i++;
+      }
+      continue;
+    }
+    if (c === '/' && d === '/') {
+      let j = i;
+      while (j < n && source[j] !== '\n') j++;
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    if (c === '/' && d === '*') {
+      const end = source.indexOf('*/', i + 2);
+      const j = end === -1 ? n : end + 2;
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    if (c === '<' && source.startsWith('<!--', i)) {
+      const end = source.indexOf('-->', i + 4);
+      const j = end === -1 ? n : end + 3;
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    i++;
+  }
+  return out.join('');
+}
+
 /** Strip HTML to plain text — drops script/style/comments/tags so
  *  content-text analyzers don't false-positive on code or CSS. */
 function stripHtmlToText(html) {
@@ -1032,7 +1097,11 @@ function detectText(content, filePath, options = {}) {
   // Run regex matchers on the full file content (catches Tailwind classes, inline styles)
   // Enable block context for CSS files where related properties span multiple lines
   const cssLike = new Set(['.css', '.scss', '.sass', '.less']);
-  findings.push(...runRegexMatchers(lines, filePath, 0, cssLike.has(ext) || null, {
+  // Comments are blanked first: the matchers look for markup, and a comment
+  // that merely names a tag is prose. Masking keeps length and newlines, so
+  // every reported line number is still the real one.
+  const sourceLines = maskComments(content).split('\n');
+  findings.push(...runRegexMatchers(sourceLines, filePath, 0, cssLike.has(ext) || null, {
     profile,
     phase: 'source',
   }));

--- a/tests/detect-comments-are-not-code.test.mjs
+++ b/tests/detect-comments-are-not-code.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * Comments are prose, not markup.
+ *
+ * The line matchers scan raw source, so a comment that merely names a tag used
+ * to be scanned as if it were that tag: a block comment explaining why an image
+ * is proxied reported `broken-image` in a file with no img element in it.
+ *
+ * These tests pin both directions — the false positive is gone AND the rule
+ * still catches the real thing. A fix that only silenced the rule would pass
+ * the first half and fail the second.
+ *
+ * Run via Node's built-in test runner (not bun):
+ *   node --test tests/detect-comments-are-not-code.test.mjs
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectText } from '../cli/engine/detect-antipatterns.mjs';
+
+const ids = (source, file = 'sample.tsx') =>
+  detectText(source, file).map((f) => f.antipattern);
+
+describe('detectText - comments are not scanned as markup', () => {
+  it('ignores a block comment that names an img tag', () => {
+    const source = [
+      'export function Avatar() {',
+      '  /* The CDN answers 403 for an `<img>` loaded from another origin, so the',
+      '     picture is proxied through our own route. */',
+      '  return <div />;',
+      '}',
+      '',
+    ].join('\n');
+    assert.ok(!ids(source).includes('broken-image'));
+  });
+
+  it('ignores a line comment that names an img tag', () => {
+    const source = ['// never ship an <img> without a src here', 'const x = 1;', ''].join('\n');
+    assert.ok(!ids(source).includes('broken-image'));
+  });
+
+  it('ignores an HTML comment that names an img tag', () => {
+    const source = ['<!-- an <img> with no src ships as a broken box -->', '<div></div>', ''].join('\n');
+    assert.ok(!ids(source, 'sample.html').includes('broken-image'));
+  });
+
+  it('still flags an img element with no src', () => {
+    const source = ['export function B() {', '  return <img className="w-4" />;', '}', ''].join('\n');
+    assert.ok(ids(source).includes('broken-image'));
+  });
+
+  it('still flags an img element with an empty src', () => {
+    const source = ['const markup = \'<img src="" alt="x">\';', ''].join('\n');
+    assert.ok(ids(source).includes('broken-image'));
+  });
+
+  it('does not swallow the rest of a line after a URL in a string', () => {
+    /* A regex-based strip of `//` would eat from `https://` to end of line and,
+       in a minified or single-line source, hide everything after it. */
+    const source = ['const a = "https://example.com/x";', 'const b = <img />;', ''].join('\n');
+    assert.ok(ids(source).includes('broken-image'));
+  });
+
+  it('keeps reported line numbers pointing at the real line', () => {
+    const source = [
+      '/* a comment mentioning <img> so the mask has work to do */',
+      '//',
+      'const b = <img />;',
+      '',
+    ].join('\n');
+    const found = detectText(source, 'sample.tsx').filter((f) => f.antipattern === 'broken-image');
+    assert.equal(found.length, 1);
+    assert.equal(found[0].line, 3);
+  });
+});


### PR DESCRIPTION
## The problem

The line matchers in `cli/engine/engines/regex/detect-text.mjs` scan raw source, so a comment that merely **names** a tag is scanned as if it were that tag.

A block comment explaining why an image is proxied:

```jsx
/* The CDN answers 403 for an `<img>` loaded from another origin, so the
   picture goes through our own route. */
```

reports `broken-image` in a file that contains no `img` element at all. Every matcher has the same exposure — documentation about markup gets read as markup. In one 256-file Next.js app this produced 11 phantom `broken-image` findings and 1 phantom `gray-on-color` (a docblock quoting `text-slate-700`).

## The fix

`maskComments()` blanks comment bodies before the line matchers run.

Bodies are replaced with **spaces** rather than removed, so byte offsets, line numbers and column math are unchanged — reported lines stay correct and line-scoped inline ignores keep working.

It is a small scanner rather than a regex on purpose. Stripping `//` with a regex would swallow the rest of `"https://x"` and could **hide a real finding**, which is worse than the false positive being fixed. The scan tracks strings and template literals and only treats a comment opener as a comment when it opens outside one.

## Validation

**New tests** — `node --test tests/detect-comments-are-not-code.test.mjs`, 7 passing. They pin **both directions**, because a fix that only silenced the rule would pass the first half:

- block / line / HTML comment naming an img tag → not flagged
- `<img>` with no `src` → still flagged
- `<img src="">` → still flagged
- `<img />` on the line after a `"https://…"` string → still flagged
- reported line number still points at the real line

**No regression** — `node --test` on `detect-antipatterns-fixtures`, `detect-antipatterns-browser` and `framework-fixtures` gives **identical pass/fail counts with and without this change** (41/32, 0/27, 211/5). Those failures are this environment lacking `bun` and build artifacts, not this patch; I baselined by stashing the change and re-running.

**Measured impact** — on the 256-file app above: 14 findings became 2. All 12 that disappeared were comments, checked one by one. No code line stopped being seen.

## Notes

Generated provider output is intentionally omitted, per the Generated Provider Output Policy in `AGENTS.md`. I could not run `bun run build` / `build:browser` / `build:extension` — `bun` is not available in this environment — so the browser and extension bundles will need regenerating on your side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to regex detection preprocessing with regression tests; no security, data, or API surface impact.
> 
> **Overview**
> **Regex line matchers** no longer treat comment prose as markup. Before `runRegexMatchers` runs on the full file, **`maskComments()`** replaces comment bodies with spaces (keeping newlines and offsets) so tags or class names mentioned only in `//`, `/* */`, or `<!-- -->` do not trigger rules like `broken-image` or `gray-on-color`.
> 
> The mask is a small scanner, not a naive regex strip: it skips strings and template literals so a `https://` URL inside quotes is not mistaken for a line comment and real findings on the same line are not hidden.
> 
> New tests in `tests/detect-comments-are-not-code.test.mjs` assert comments are ignored, real `<img>` issues still fire, URL-in-string behavior is safe, and reported line numbers stay correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f930bfb30931ac134b89435e7a290f139d871aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->