### PR TITLE
Map polish's evidence and verify steps per platform

### DIFF
--- a/skill/reference/polish.md
+++ b/skill/reference/polish.md
@@ -19,7 +19,7 @@ Fix the cause at the narrowest correct level. Ask when a binding system principl
 
 ## 2. Gather the evidence
 
-Use the feature yourself at representative desktop and mobile sizes. Determine:
+Use the feature yourself at the surface's representative sizes: desktop and mobile on the web; on a native platform (`ios` / `android` / `adaptive`), the shipped device classes on the simulator, emulator, or hardware, captured per the platform reference's Verifying the build section. Determine:
 
 - whether the path is functionally complete;
 - the intended quality bar and time available;
@@ -86,10 +86,10 @@ Do not perfect one corner while leaving the rest below the same quality bar.
 
 Walk the complete path again with mouse, keyboard, and touch where applicable. Check:
 
-- mobile, intermediate, and wide layouts;
+- mobile, intermediate, and wide layouts (on native: phone and tablet size classes, both orientations where supported);
 - loading, empty, error, success, disabled, long-content, and missing-content states;
 - zoom, contrast, focus, semantics, and screen-reader names;
-- console errors, layout shift, interaction latency, image loading, and supported browsers;
+- console errors, layout shift, interaction latency, image loading, and supported browsers (on native: runtime warnings, dropped frames, and the supported OS versions);
 - agreement with DESIGN.md, neighboring features, and the user's scope.
 
 Follow the quality guidance supplied by `context.mjs` and hooks, then run any other relevant QA commands. Context requests a manual scan only when no automatic detector is active; never add another detector pass. Fix real defects and document only narrow intentional exceptions. A clean scan does not replace visual judgment.

--- a/skill/reference/polish.md
+++ b/skill/reference/polish.md
@@ -86,10 +86,10 @@ Do not perfect one corner while leaving the rest below the same quality bar.
 
 Walk the complete path again with mouse, keyboard, and touch where applicable. Check:
 
-- mobile, intermediate, and wide layouts (on native: phone and tablet size classes, both orientations where supported);
+- mobile, intermediate, and wide layouts on the web; phone and tablet size classes in both supported orientations on native;
 - loading, empty, error, success, disabled, long-content, and missing-content states;
 - zoom, contrast, focus, semantics, and screen-reader names;
-- console errors, layout shift, interaction latency, image loading, and supported browsers (on native: runtime warnings, dropped frames, and the supported OS versions);
+- console errors, layout shift, interaction latency, and image loading everywhere; supported browsers on the web, supported OS versions and dropped frames on native;
 - agreement with DESIGN.md, neighboring features, and the user's scope.
 
 Follow the quality guidance supplied by `context.mjs` and hooks, then run any other relevant QA commands. Context requests a manual scan only when no automatic detector is active; never add another detector pass. Fix real defects and document only narrow intentional exceptions. A clean scan does not replace visual judgment.

--- a/skill/reference/polish.md
+++ b/skill/reference/polish.md
@@ -89,7 +89,7 @@ Walk the complete path again with mouse, keyboard, and touch where applicable. C
 - mobile, intermediate, and wide layouts on the web; phone and tablet size classes in both supported orientations on native;
 - loading, empty, error, success, disabled, long-content, and missing-content states;
 - zoom, contrast, focus, semantics, and screen-reader names;
-- console errors, layout shift, interaction latency, and image loading everywhere; supported browsers on the web, supported OS versions and dropped frames on native;
+- console errors, layout shift, interaction latency, and image loading everywhere; supported browsers on the web; supported OS versions, runtime warnings, and dropped frames on native;
 - agreement with DESIGN.md, neighboring features, and the user's scope.
 
 Follow the quality guidance supplied by `context.mjs` and hooks, then run any other relevant QA commands. Context requests a manual scan only when no automatic detector is active; never add another detector pass. Fix real defects and document only narrow intentional exceptions. A clean scan does not replace visual judgment.


### PR DESCRIPTION
> Held for Paul's review; do not merge without his approval.

Follow-up to #546, which noted this as the one piece of remaining debt: `polish.md` was the last command reference that verified through web-only vocabulary. Source-first: no version bump, no changelog entry, no generated harness dirs.

Three targeted mappings, following the in-file precedent #546 set for new-work.md rather than a `polish.native.md` variant. Polish's structure (classify, triage, polish the path, verify) is platform-neutral; only the evidence and verification vocabulary was web-bound:

1. **Evidence gathering** (step 2): "representative desktop and mobile sizes" becomes per-platform: desktop and mobile on the web; on native, the shipped device classes on the simulator, emulator, or hardware, captured per the platform reference's Verifying the build section that #546 added.
2. **Verify checklist, layouts** (step 5): "mobile, intermediate, and wide layouts" gains the native mapping: phone and tablet size classes, both orientations where supported.
3. **Verify checklist, "supported browsers"** (step 5): native has no browsers, so the line names the analogues: runtime warnings, dropped frames, and the supported OS versions.

Untouched on purpose: "platform-appropriate touch targets" and "mouse, keyboard, and touch where applicable" already read correctly on native, and the `critique-storage.mjs` flow is platform-agnostic.

## Gates

- `bun run build` passes: counts, plugin manifest shape, version agreement, `validateProse`, `validateSkillProse`.
- No opt-in suite owed: polish.md is not Setup-adjacent, and routing text is unchanged (the routing scenario for `/impeccable polish` keys on loading polish.md, not its body).

---

🤖 AI assistance: prepared by Claude Code, under instructions from @pbakaus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only guidance in a skill reference; no runtime, routing, or generated harness changes.
> 
> **Overview**
> **Extends `polish.md` so polish workflows are not web-only** in the evidence-gathering and final verification steps, using the same inline mapping pattern as `new-work.md` (no separate native variant).
> 
> **Step 2 (gather evidence)** now says to exercise the feature at representative sizes on **desktop/mobile on the web**, and on **native** (`ios` / `android` / `adaptive`) at shipped device classes on simulator, emulator, or hardware, per each platform reference’s **Verifying the build** section.
> 
> **Step 5 (verify and finish)** splits layout checks (**web** breakpoints vs **native** phone/tablet classes and orientations) and quality checks (**supported browsers** on web vs **OS versions, runtime warnings, and dropped frames** on native), while keeping shared items (states, a11y, console/layout/latency/images) platform-agnostic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d841a2e9c1a2dec7f15184d638c75283298547b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->