### PR TITLE
Fix live-server hang against deployed https sites (PNA preflight)

### DIFF
--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -712,7 +712,26 @@ function createRequestHandler({ detectScript, liveScriptParts }) {
     }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+    if (req.method === 'OPTIONS') {
+      // Private Network Access: Chrome inserts this preflight for any request
+      // from a public or private page to a loopback target, independent of
+      // CORS mode -- including the plain <script src> live-browser.js uses to
+      // load /detect.js from a page under review at a real https origin. It
+      // answers a different question than the Origin/token check above
+      // ("may this network path be reached at all" vs. "may the response be
+      // read"), so granting it here does not loosen that check: routes that
+      // matter (/live.js, the POST endpoints) still enforce their own
+      // `?token=` regardless of this header, and /detect.js is already
+      // unauthenticated by design. Only emit it when the browser actually
+      // asked (Access-Control-Request-Private-Network: true), never blanket.
+      // https://developer.chrome.com/blog/private-network-access-preflight
+      if (req.headers['access-control-request-private-network'] === 'true') {
+        res.setHeader('Access-Control-Allow-Private-Network', 'true');
+      }
+      res.writeHead(204);
+      res.end();
+      return;
+    }
 
     const p = url.pathname;
 

--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -715,7 +715,7 @@ function createRequestHandler({ detectScript, liveScriptParts }) {
     if (req.method === 'OPTIONS') {
       // Private Network Access: Chrome inserts this preflight for any request
       // from a public or private page to a loopback target, independent of
-      // CORS mode -- including the plain <script src> live-browser.js uses to
+      // CORS mode, including the plain <script src> live-browser.js uses to
       // load /detect.js from a page under review at a real https origin. It
       // answers a different question than the Origin/token check above
       // ("may this network path be reached at all" vs. "may the response be

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -475,6 +475,40 @@ describe('live-server integration', () => {
     assert.equal(res.headers.get('access-control-allow-origin'), origin);
   });
 
+  it('CORS: Private Network Access preflight gets Access-Control-Allow-Private-Network', async () => {
+    // Chrome sends this preflight whenever a public or private page requests
+    // a loopback subresource, e.g. the <script src="http://localhost:PORT/detect.js">
+    // live-browser.js injects into a deployed https page under review. Without
+    // this header the browser refuses the request outright and the load hangs
+    // rather than erroring. This must work even for an origin that gets no
+    // Access-Control-Allow-Origin, since PNA gates network reachability, not
+    // response readability.
+    const deployed = 'https://example.com';
+    const preflight = await fetch(`http://localhost:${server.port}/detect.js`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: deployed,
+        'Access-Control-Request-Method': 'GET',
+        'Access-Control-Request-Private-Network': 'true',
+      },
+    });
+    assert.equal(preflight.status, 204);
+    assert.equal(preflight.headers.get('access-control-allow-private-network'), 'true');
+    // Untouched: an unauthorized origin still gets no ACAO, so a CORS-mode
+    // fetch still cannot read the response even though PNA now lets the
+    // request reach the server.
+    assert.equal(preflight.headers.get('access-control-allow-origin'), null);
+  });
+
+  it('CORS: a preflight that does not ask for PNA does not get the header', async () => {
+    const preflight = await fetch(`http://localhost:${server.port}/health`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://example.com', 'Access-Control-Request-Method': 'GET' },
+    });
+    assert.equal(preflight.status, 204);
+    assert.equal(preflight.headers.get('access-control-allow-private-network'), null);
+  });
+
   it('/design-system.json reads DESIGN.md plus .impeccable/design.json', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'impeccable-design-system-'));
     let designServer;


### PR DESCRIPTION
## Before opening

- Linked issue: #539 (this PR fixes the second bug reported there; see the comment I left on that issue with a corrected diagnosis)
- Contributor status:
  - [ ] I am `pbakaus` or `abdulwahabone`
  - [ ] A maintainer approved this PR in the linked issue

I am not a maintainer and #539 has not been explicitly triaged for a PR. I'm opening this anyway because I have a verified root cause and fix in hand; happy to have it closed if that is not welcome, but wanted to save the round trip given the diagnosis in #539 was incomplete.

## Summary

`live-server.mjs` serves the browser bundle that Live/Critique injects into the page under review (`<script src="http://localhost:PORT/detect.js">`, `skill/scripts/live-browser.js:11221`). Against `http://localhost`-style dev servers this always worked. Against any real `https://` site it silently hangs: no console error, no failed network entry the page's own JS can see, just nothing happening.

Issue #539 reports the same symptom and attributes it to mixed-content blocking. That is not the mechanism: loopback hosts (`localhost`, `127.0.0.1`, `::1`) are defined as "potentially trustworthy" origins in the Secure Contexts spec, so Chrome's mixed-content checker does not flag `http://localhost` subresources on an `https://` page. I left a comment on #539 with the corrected diagnosis and a link to this PR.

### Mechanism

The actual cause is Chrome's Private Network Access (PNA) check. When a page whose origin is in the "public" IP address space requests a subresource whose target is in the "loopback" address space, Chrome inserts a CORS preflight carrying `Access-Control-Request-Private-Network: true`, and requires `Access-Control-Allow-Private-Network: true` on the preflight response before it will let the real request through, regardless of the real request's CORS mode. `live-server.mjs` answers every `OPTIONS` request with `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, and a 204, but never emitted this header, so PNA silently blocks the request before the script ever loads.

This is invisible in the normal dev workflow because loopback-to-loopback requests (a page served from `http://localhost:5173` loading `http://localhost:8400/detect.js`) never cross an address-space boundary, so PNA never triggers a preflight. It only shows up once the page under review is served from a real domain, which is exactly the Critique/deployed-review path.

### Reproduction

Before (current `main`):

```
$ curl -i -X OPTIONS http://localhost:8400/detect.js \
    -H "Origin: https://crate.mokkenstorm.dev" \
    -H "Access-Control-Request-Method: GET" \
    -H "Access-Control-Request-Private-Network: true"

HTTP/1.1 204 No Content
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Allow-Headers: Content-Type
```

No `Access-Control-Allow-Private-Network`. Chrome's PNA check fails and the request never reaches the server.

After this fix:

```
HTTP/1.1 204 No Content
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Allow-Headers: Content-Type
Access-Control-Allow-Private-Network: true
```

Verified by starting the patched server standalone (`node skill/scripts/live-server.mjs --port=8400`) and re-running the exact curl above.

### Security reasoning for where the header is placed

The CORS block above this fix (`skill/scripts/live-server.mjs`, around the `isLoopbackOrigin` check) has a documented model: `Access-Control-Allow-Origin` is reflected only for loopback origins or requests carrying the valid session token, specifically so a random page cannot use `fetch`/`XHR` to read a response meant for the tool's own overlay. I did not touch that check.

PNA answers a different question than `Access-Control-Allow-Origin` does. ACAO gates whether a CORS-mode response body is *readable* by the calling page's JavaScript. PNA gates whether the network request can reach a loopback target *at all*, independent of CORS mode; it applies equally to a plain `<script src>` load (`no-cors`, opaque, never readable regardless of ACAO) and to a `fetch()` call. Granting PNA does not grant response-readability: an origin that fails the existing loopback-or-token check still gets no `Access-Control-Allow-Origin`, so a CORS-mode `fetch` from that origin still cannot read anything. And every route that carries an actual capability (`/live.js`, the `POST` endpoints for events/annotations/manual-edit) independently checks `?token=` inside its own handler, so PNA does not bypass those either. `/detect.js` itself is already served without any origin or token check today (`skill/scripts/live-server.mjs:758`), so letting the network path open for it is not a new exposure, only the removal of an incidental block that Chrome's rollout introduced.

Given that, I set the header only on the preflight response (`OPTIONS`), and only when the request actually carries `Access-Control-Request-Private-Network: true`. I considered gating it further behind the same loopback-or-token check used for ACAO, but that would leave the reported bug unfixed: the actual injected `<script src>` call carries no token and the reviewed page's origin is never loopback, so the fix has to apply to exactly the case that check would exclude. Setting it unconditionally on every response (not just preflights) was also considered and rejected as unnecessary: Chrome only inspects this header on the preflight, so setting it elsewhere is pure noise.

Reference: [Private Network Access preflight (Chrome developer docs)](https://developer.chrome.com/blog/private-network-access-preflight)

## Type of change

- [x] Bug fix

## Testing

- Added two regression tests to `tests/live-server.test.mjs`: one asserts `Access-Control-Allow-Private-Network: true` is present on an `OPTIONS /detect.js` preflight from a non-loopback, tokenless origin carrying `Access-Control-Request-Private-Network: true` (and that `Access-Control-Allow-Origin` is still absent for that same request, proving the existing readability boundary is untouched); the other asserts the header is absent when the preflight does not ask for it.
- `node --test tests/live-server.test.mjs`: full file green, 96/96 passing.
- Manual repro: started the patched server standalone and re-ran the exact curl from the Summary above, before and after the fix; confirmed the header appears after, then stopped the server and confirmed the port was released.

## Checklist

- [x] Source files updated in `skill/` (not the generated per-provider copies, which are build output synced by `scripts/build.js` at release time)
- [ ] `bun run build` ran successfully (not run; this change touches only a runtime script, not skill source content, so it doesn't affect the transformed provider output)
- [x] `bun test` passes (`node --test tests/live-server.test.mjs`, 96/96)
- [ ] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Grok Build / Kiro / OpenCode / Qoder / Mistral Vibe): verified the server behavior directly via HTTP, not through a provider's skill invocation
- [ ] README / DEVELOP.md updated if needed (no user-facing behavior change to document)
- [x] I reviewed the full diff myself before requesting human review
- [x] I disclosed any AI assistance in this PR and related commits/comments, or no AI assistance was used

---

Prepared by Claude (Anthropic) operating under instruction from @nmokkenstorm, who reviewed the diagnosis, the diff, and the empirical repro before this PR was opened.
