### PR TITLE
Fix critique routing snapshot metrics

### DIFF
--- a/skill/scripts/context-signals.mjs
+++ b/skill/scripts/context-signals.mjs
@@ -42,7 +42,7 @@ function latestCritique(cwd) {
     if (!latest) return null;
     const get = (key) => latest.meta[key] ?? null;
     const num = (v) => {
-      if (v == null) return null;
+      if (v == null || (typeof v === 'string' && v.trim() === '')) return null;
       const n = Number(v);
       return Number.isFinite(n) ? n : null;
     };

--- a/skill/scripts/context-signals.mjs
+++ b/skill/scripts/context-signals.mjs
@@ -42,14 +42,15 @@ function latestCritique(cwd) {
     if (!latest) return null;
     const get = (key) => latest.meta[key] ?? null;
     const num = (v) => {
+      if (v == null) return null;
       const n = Number(v);
       return Number.isFinite(n) ? n : null;
     };
     return {
       slug: get('slug'),
-      score: num(get('score')),
-      p0: num(get('p0')),
-      p1: num(get('p1')),
+      score: num(get('total_score') ?? get('score')),
+      p0: num(get('p0_count') ?? get('p0')),
+      p1: num(get('p1_count') ?? get('p1')),
       timestamp: get('timestamp'),
       file: path.relative(cwd, latest.path),
     };

--- a/tests/context-signals.test.mjs
+++ b/tests/context-signals.test.mjs
@@ -76,6 +76,24 @@ describe('gatherSignals', () => {
     assert.equal(s.critique.latest.slug, 'home');
   });
 
+  it('reads the documented critique snapshot metadata keys', async () => {
+    write('.impeccable/critique/2026-05-02T10-00-00Z__pricing.md',
+      '---\nslug: pricing\ntotal_score: 24\np0_count: 2\np1_count: 5\ntimestamp: 2026-05-02T10-00-00Z\n---\nbody\n');
+    const s = await gatherSignals(scratch);
+    assert.equal(s.critique.latest.score, 24);
+    assert.equal(s.critique.latest.p0, 2);
+    assert.equal(s.critique.latest.p1, 5);
+  });
+
+  it('reports missing critique metrics as null', async () => {
+    write('.impeccable/critique/2026-05-02T10-00-00Z__pricing.md',
+      '---\nslug: pricing\ntimestamp: 2026-05-02T10-00-00Z\n---\nbody\n');
+    const s = await gatherSignals(scratch);
+    assert.equal(s.critique.latest.score, null);
+    assert.equal(s.critique.latest.p0, null);
+    assert.equal(s.critique.latest.p1, null);
+  });
+
   it('reads the newest critique snapshot across target slugs', async () => {
     write('.impeccable/critique/2026-05-01T10-00-00Z__home.md',
       '---\nslug: home\nscore: 6\np0: 1\np1: 3\ntimestamp: 2026-05-01T10-00-00Z\n---\nbody\n');

--- a/tests/context-signals.test.mjs
+++ b/tests/context-signals.test.mjs
@@ -94,6 +94,15 @@ describe('gatherSignals', () => {
     assert.equal(s.critique.latest.p1, null);
   });
 
+  it('reports empty and invalid critique metrics as null', async () => {
+    write('.impeccable/critique/2026-05-02T10-00-00Z__pricing.md',
+      '---\nslug: pricing\ntotal_score: \np0_count:   \np1_count: nope\ntimestamp: 2026-05-02T10-00-00Z\n---\nbody\n');
+    const s = await gatherSignals(scratch);
+    assert.equal(s.critique.latest.score, null);
+    assert.equal(s.critique.latest.p0, null);
+    assert.equal(s.critique.latest.p1, null);
+  });
+
   it('reads the newest critique snapshot across target slugs', async () => {
     write('.impeccable/critique/2026-05-01T10-00-00Z__home.md',
       '---\nslug: home\nscore: 6\np0: 1\np1: 3\ntimestamp: 2026-05-01T10-00-00Z\n---\nbody\n');


### PR DESCRIPTION
Closes #561.

## What changed

- Read the documented critique snapshot keys (`total_score`, `p0_count`, and `p1_count`) in `context-signals.mjs`.
- Preserve compatibility with legacy `score`, `p0`, and `p1` snapshots.
- Report absent metrics as `null` instead of silently turning them into plausible zeroes.

## Reproduction

Before the fix, a stored `24/40` critique with two P0 and five P1 findings produced `score: 0, p0: 0, p1: 0`. The same reproduction now produces `score: 24, p0: 2, p1: 5`.

## Validation

- `node --test tests/context-signals.test.mjs` — 37/37 passed
- `bun run build` — passed
- `bun run test` — passed (core, detector/browser, live, framework, and plugin E2E; two documented live skips)
- `git diff --check` — passed
- `bun run test:skill-behavior` — executed as required; current-model stochastic scenarios reported unrelated failures, and every failing trace omitted `context-signals.mjs` while the suite contains no critique/context-signals fixture

Generated provider and root harness output was intentionally omitted under the source-first contribution policy.

Prepared with AI assistance under maintainer @pbakaus's standing automation authorization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, test-covered change to signal parsing for critique snapshots; no auth, persistence, or routing logic beyond metadata field names.
> 
> **Overview**
> Fixes **critique routing** for bare `/impeccable` by aligning `latestCritique` in `context-signals.mjs` with the snapshot format documented for critique storage (`total_score`, `p0_count`, `p1_count`), while still accepting legacy `score` / `p0` / `p1` front matter.
> 
> **Numeric parsing** now treats missing, blank, or non-numeric metadata as **`null`** instead of coercing to `0`, so agents no longer see plausible zero scores when a snapshot actually has values like 24/40 with 2 P0 and 5 P1 findings.
> 
> Adds **unit tests** for the documented keys, absent metrics, and empty/invalid values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 357f358050050acb36da3d418fe11e6e8f852b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->