### PR TITLE
Simplify Svelte accept orchestration

### DIFF
--- a/skill/scripts/live-accept.mjs
+++ b/skill/scripts/live-accept.mjs
@@ -170,51 +170,35 @@ Output (JSON):
   }
 
   if (svelteComponentManifest) {
-    if (isDiscard) {
-      let result;
-      try {
-        result = withSourceLockSync(
-          path.resolve(process.cwd(), svelteComponentManifest.sourceFile),
-          'discard:' + id,
-          () => {
-            removeSvelteComponentSession(id, process.cwd());
-            return { handled: true };
-          },
-          { waitMs: ACCEPT_LOCK_WAIT_MS },
-        );
-      } catch (err) {
-        result = operationFailure(err);
-      }
-      emitResult({
-        ...result,
-        file: svelteComponentManifest.sourceFile,
-        carbonize: false,
-        previewMode: 'svelte-component',
-        componentDir: svelteComponentManifest.componentDir,
-      });
-      return;
-    }
-
-    let result;
-    try {
-      result = withSourceLockSync(
-        path.resolve(process.cwd(), svelteComponentManifest.sourceFile),
-        'accept:' + id,
-        () => inlineSvelteComponentAccept(
+    const { sourceFile, componentDir } = svelteComponentManifest;
+    const resultContext = {
+      file: sourceFile,
+      ...(isDiscard ? { carbonize: false } : { sourceFile }),
+      previewMode: 'svelte-component',
+      componentDir,
+    };
+    const runOperation = isDiscard
+      ? () => {
+          removeSvelteComponentSession(id, process.cwd());
+          return { handled: true, ...resultContext };
+        }
+      : () => inlineSvelteComponentAccept(
           svelteComponentManifest,
           variantNum,
           paramValues,
           process.cwd(),
-        ),
+        );
+
+    let result;
+    try {
+      result = withSourceLockSync(
+        path.resolve(process.cwd(), sourceFile),
+        requestedOperation + ':' + id,
+        runOperation,
         { waitMs: ACCEPT_LOCK_WAIT_MS },
       );
     } catch (err) {
-      result = operationFailure(err, {
-        file: svelteComponentManifest.sourceFile,
-        sourceFile: svelteComponentManifest.sourceFile,
-        previewMode: 'svelte-component',
-        componentDir: svelteComponentManifest.componentDir,
-      });
+      result = operationFailure(err, resultContext);
     }
     if (result.carbonize) {
       result.todo = 'REQUIRED before next poll: carbonize cleanup in ' + result.file + '. See reference/live.md "Required after accept".';

--- a/tests/live-svelte-component-accept.test.mjs
+++ b/tests/live-svelte-component-accept.test.mjs
@@ -1,7 +1,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, symlinkSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import {
@@ -17,6 +18,7 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_NODE_MODULES = join(__dirname, '..', 'node_modules');
+const ACCEPT = resolve(__dirname, '..', 'skill/scripts/live-accept.mjs');
 
 const ROUTE_SOURCE = `<script>
   let stages = [
@@ -52,6 +54,14 @@ function write(root, rel, content) {
   const abs = join(root, rel);
   mkdirSync(dirname(abs), { recursive: true });
   writeFileSync(abs, content);
+}
+
+function runAccept(cwd, args) {
+  const output = execFileSync(process.execPath, [ACCEPT, ...args], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  return JSON.parse(output.trim());
 }
 
 describe('svelte component scaffold + accept pipeline', () => {
@@ -103,6 +113,50 @@ describe('svelte component scaffold + accept pipeline', () => {
     assert.match(v1, /let \{ stages = \[\] \} = \$props\(\)/);
     // Stub CSS is seeded from the route's matching rules.
     assert.match(v1, /border-top: 1px solid #333/);
+  });
+
+  it('accepts a Svelte component session through the CLI', () => {
+    const session = scaffold('cliacc1');
+    write(tmp, join(session.componentDir, 'v1.svelte'), `<script>
+  let { stages = [] } = $props();
+</script>
+
+<ol class="accepted-board">
+  {#each stages as stage, i}
+    <li class="stage">
+      <span class="label">{stage.label}</span>
+      <p class="detail">{stage.detail}</p>
+    </li>
+  {/each}
+</ol>
+
+<style>
+  .accepted-board { display: grid; }
+</style>
+`);
+
+    const result = runAccept(tmp, ['--id', 'cliacc1', '--variant', '1']);
+    assert.equal(result.handled, true, result.error);
+    assert.equal(result.file, 'src/routes/+page.svelte');
+    assert.equal(result.previewMode, 'svelte-component');
+    assert.equal(result.componentDir, session.componentDir);
+    assert.match(readFileSync(join(tmp, result.file), 'utf-8'), /class="[^"]*\baccepted-board\b/);
+    assert.equal(findSvelteComponentManifest('cliacc1', tmp), null);
+  });
+
+  it('discards a Svelte component session through the CLI', () => {
+    const session = scaffold('clidisc1');
+
+    const result = runAccept(tmp, ['--id', 'clidisc1', '--discard']);
+    assert.deepEqual(result, {
+      handled: true,
+      file: 'src/routes/+page.svelte',
+      carbonize: false,
+      previewMode: 'svelte-component',
+      componentDir: session.componentDir,
+    });
+    assert.equal(readFileSync(join(tmp, result.file), 'utf-8'), ROUTE_SOURCE);
+    assert.equal(findSvelteComponentManifest('clidisc1', tmp), null);
   });
 
   it('falls back to source-preview for markup with component tags', () => {


### PR DESCRIPTION
## Summary

- Select Svelte component accept or discard once, then run both operations through one source-lock, error-normalization, and result-emission path.
- Preserve the existing CLI result shapes, receipt behavior, source mutation, and session cleanup.
- Add direct CLI characterization tests for both Svelte component operations.

## Hindsight architecture review

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No. The Svelte component branch had grown two parallel orchestration paths that repeated the same source resolution, lock acquisition, error conversion, preview metadata, and output concerns. The leaner design keeps the operation-specific action small and shares the durable orchestration rule.

Before:
- `skill/scripts/live-accept.mjs`: 954 lines
- Svelte accept and discard used separate lock/error/result pipelines
- the public CLI plus nine named exports remained the contract

After:
- `skill/scripts/live-accept.mjs`: 938 lines (-16 production lines)
- one operation selector feeds one lock/error/result pipeline
- no new module or abstraction layer
- public exports and CLI JSON contracts are unchanged
- two CLI characterization tests cover accept and discard end to end

## Validation

- `node --test tests/live-accept.test.mjs tests/live-svelte-component-accept.test.mjs` — 47/47 passed
- `bun run build` — passed; root harness sync intentionally skipped by the source-first build
- `bun run test:live-e2e` — 34 passed, 1 known Astro skip; one stateful Svelte scenario timed out before reaching accept
- `IMPECCABLE_E2E_ONLY=vite8-sveltekit-stateful bun run test:live-e2e` — isolated rerun passed 4/4, including tuned accept
- `bun run test:live-e2e-accept-cleanup` — completed with its single DeepSeek-backed case skipped because `DEEPSEEK_API_KEY` is unavailable
- `bun run test` — passed all core, detector/browser, live, framework, and plugin-E2E phases
- `git diff --check` — passed

Generated provider and tracked root harness output was intentionally omitted under the source-first policy.

## Risk

Low and localized to Svelte component CLI dispatch. Operation-specific mutation remains in the existing functions, direct characterization coverage pins both output contracts, and the full live/framework suite passed.

Prepared with AI assistance under maintainer @pbakaus's standing scheduled-refactor authorization. This PR is ready for review and must not be auto-merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of CLI dispatch with unchanged mutation helpers and new tests pinning accept/discard JSON contracts.
> 
> **Overview**
> **Svelte component sessions** in `live-accept.mjs` no longer use separate accept vs discard branches for locking, errors, and JSON output. Both modes share one `resultContext`, a single `runOperation` callback (`removeSvelteComponentSession` vs `inlineSvelteComponentAccept`), and one `withSourceLockSync` path keyed by `requestedOperation + ':' + id`.
> 
> CLI **JSON shape and behavior** are meant to stay the same: discard still sets `carbonize: false`; accept still passes through `inlineSvelteComponentAccept` results (including optional `sourceFile` and carbonize `todo`).
> 
> **Tests** add end-to-end CLI coverage via `execFileSync` on `live-accept.mjs` for accepting a variant (source inlined, manifest cleared) and for discard (route restored, exact result object).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b71115038768ee8fdff8c07debbc77ff59fe1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->