### PR TITLE
Flipping to comp demotes the inspiration instead of stacking a second slot

### DIFF
--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -881,6 +881,7 @@ function page() {
 <div id="ambient" aria-hidden="true"></div>
 <div id="scrim" aria-hidden="true"></div>
 <div id="lightbox" hidden><img alt=""></div>
+<template id="tpl-expand-chip">${expandChip}</template>
 ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria-labelledby="bp-confirm-title" hidden>
   <div class="bp-confirm-panel">
     <h2 id="bp-confirm-title">Flip to comp-first?</h2>
@@ -1063,8 +1064,10 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
       return true;
     };
     const tryLoad = () => {
-      // A slot the user flipped back out of leaves the DOM; let its loop die.
-      if (!m.isConnected) { clearInterval(tick); return; }
+      // A slot the user flipped back out of either leaves the DOM or, when it
+      // was an inspiration face converted in place, stays and loses its
+      // pending state. Either way its loop is done.
+      if (!m.isConnected || !m.classList.contains('comp-pending')) { clearInterval(tick); return; }
       const probe = new Image();
       probe.onload = () => { landTracker.last = Date.now(); img.src = probe.src; img.hidden = false; settle(); };
       probe.onerror = () => {
@@ -1101,17 +1104,58 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
       if (noteEl) noteEl.textContent = notes[value];
     };
     set(current);
+    const INSPO_TITLE = 'Inspiration: the world this direction draws from. Your page will not look like this image.';
+    // Every media slot carries the expand affordance. A slot built here after
+    // the deal used to ship without one, so a comp the user waited minutes for
+    // could not be opened.
+    const ensureChips = (m) => {
+      if (m.querySelector('.chips')) return;
+      const tpl = document.getElementById('tpl-expand-chip');
+      if (!tpl) return;
+      const chips = document.createElement('div');
+      chips.className = 'chips';
+      chips.appendChild(tpl.content.cloneNode(true));
+      m.appendChild(chips);
+    };
+    const shimmerHtml = '<div class="shimmer"><span class="comp-note">rendering&hellip;</span></div><img class="comp" alt="" hidden>';
     const enterComp = () => {
       document.querySelectorAll('.card[data-comp-slot]').forEach(card => {
         const front = card.querySelector('.face.front');
         if (!front || front.querySelector('.media.comp-pending') || front.querySelector('.media img.comp:not([hidden])')) return;
-        const m = document.createElement('div');
-        m.className = 'media comp-pending';
-        m.dataset.comp = card.dataset.compSlot;
-        m.innerHTML = '<div class="shimmer"><span class="comp-note">rendering&hellip;</span></div><img class="comp" alt="" hidden>';
-        const wireEl = front.querySelector('.media.wire');
-        if (wireEl) { wireEl.hidden = true; front.insertBefore(m, wireEl); }
-        else { front.classList.remove('text-only'); front.insertBefore(m, front.querySelector('.body')); }
+        // On a code-led card the inspiration IS the face. Comp-first demotes it
+        // to the corner, so convert that slot in place rather than inserting a
+        // second one: two stacked images say the catalog art and the comp are
+        // peers, and the whole point of the corner is that they are not.
+        const inspo = front.querySelector('.media:not(.wire):not(.comp-pending)');
+        let m;
+        if (inspo) {
+          m = inspo;
+          m.dataset.compRestore = 'inspiration';
+          m.dataset.comp = card.dataset.compSlot;
+          m.classList.add('comp-pending');
+          m.removeAttribute('title');
+          m.querySelector('.media-label')?.remove();
+          const art = m.querySelector(':scope > img');
+          if (art) {
+            const pip = document.createElement('figure');
+            pip.className = 'pip';
+            pip.title = INSPO_TITLE;
+            const cap = document.createElement('figcaption');
+            cap.textContent = 'inspiration';
+            pip.append(art, cap);
+            m.appendChild(pip);
+          }
+          m.insertAdjacentHTML('afterbegin', shimmerHtml);
+        } else {
+          m = document.createElement('div');
+          m.className = 'media comp-pending';
+          m.dataset.comp = card.dataset.compSlot;
+          m.innerHTML = shimmerHtml;
+          const wireEl = front.querySelector('.media.wire');
+          if (wireEl) { wireEl.hidden = true; front.insertBefore(m, wireEl); }
+          else { front.classList.remove('text-only'); front.insertBefore(m, front.querySelector('.body')); }
+        }
+        ensureChips(m);
         pollComp(m);
       });
     };
@@ -1120,6 +1164,25 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
         const front = card.querySelector('.face.front');
         const pending = front?.querySelector('.media.comp-pending');
         if (!pending) return; // landed comps stay; they exist either way
+        // A converted slot is restored, not removed: the inspiration goes back
+        // to being the face, so flipping back leaves the card as it was dealt.
+        if (pending.dataset.compRestore === 'inspiration') {
+          pending.classList.remove('comp-pending');
+          delete pending.dataset.compRestore;
+          delete pending.dataset.comp;
+          pending.querySelector('.shimmer')?.remove();
+          pending.querySelector('img.comp')?.remove();
+          const pip = pending.querySelector('.pip');
+          const art = pip?.querySelector('img');
+          if (art) pending.insertBefore(art, pending.firstChild);
+          pip?.remove();
+          const label = document.createElement('p');
+          label.className = 'media-label';
+          label.textContent = 'inspiration';
+          pending.insertBefore(label, pending.querySelector('.chips'));
+          pending.title = INSPO_TITLE;
+          return;
+        }
         pending.remove();
         const wireEl = front.querySelector('.media.wire');
         if (wireEl) wireEl.hidden = false;
@@ -1182,14 +1245,17 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
   });
 
   // Inspiration PIP or body thumb opens the full catalog card in the lightbox.
-  document.querySelectorAll('.pip, .inspo').forEach(p => p.addEventListener('click', (e) => {
+  // Delegated, like every other zoom target: a build-path flip builds media
+  // slots after load, and a per-element listener bound at deal time never
+  // reaches them. That is how a streamed-in comp ended up unopenable.
+  document.addEventListener('click', (e) => {
+    const p = e.target.closest?.('.pip, .inspo');
+    if (!p) return;
     e.stopPropagation();
     const img = p.querySelector('img');
     if (!img) return;
-    lightboxImg.src = img.getAttribute('src');
-    lightbox.hidden = false;
-    requestAnimationFrame(() => lightbox.classList.add('open'));
-  }));
+    openLightbox(img);
+  });
 
   // Deck paging: arrows appear only when the deck overflows its axis, page
   // one card at a time, and follow the aspect-ratio flip between row and column.
@@ -1239,16 +1305,23 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
   // Expand: lightbox for whichever face is showing.
   const lightbox = document.getElementById('lightbox');
   const lightboxImg = lightbox.querySelector('img');
-  document.querySelectorAll('.expand').forEach(b => b.addEventListener('click', (e) => {
+  // Declared, not assigned to a const, so the delegated handlers above can call
+  // it wherever they sit in this file.
+  function openLightbox(img) {
+    lightboxImg.src = img.getAttribute('src');
+    lightbox.hidden = false;
+    requestAnimationFrame(() => lightbox.classList.add('open'));
+  }
+  document.addEventListener('click', (e) => {
+    const b = e.target.closest?.('.expand');
+    if (!b) return;
     e.stopPropagation();
     const card = b.closest('.card');
     const face = card.classList.contains('flipped') ? '.face.back' : '.face.front';
     const img = card.querySelector(face + ' .media img:not([hidden])');
     if (!img || !img.getAttribute('src')) return;
-    lightboxImg.src = img.getAttribute('src');
-    lightbox.hidden = false;
-    requestAnimationFrame(() => lightbox.classList.add('open'));
-  }));
+    openLightbox(img);
+  });
   // Portrait art (native / mobile-first surfaces): the slot takes the
   // image's own ratio so nothing crops, and the whole deck narrows so
   // portrait cards sit side by side. Load events don't bubble; capture.
@@ -1266,13 +1339,13 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
   // The whole image is the zoom target, not just the expand chip; the chip
   // stays as the visible affordance. Chip and PIP handlers stop propagation,
   // so this fires only for clicks on the art itself.
-  document.querySelectorAll('.media').forEach(m => m.addEventListener('click', () => {
+  document.addEventListener('click', (e) => {
+    const m = e.target.closest?.('.media');
+    if (!m) return;
     const img = m.querySelector(':scope > img:not([hidden])');
     if (!img || !img.getAttribute('src')) return;
-    lightboxImg.src = img.getAttribute('src');
-    lightbox.hidden = false;
-    requestAnimationFrame(() => lightbox.classList.add('open'));
-  }));
+    openLightbox(img);
+  });
   const closeLightbox = () => { lightbox.classList.remove('open'); setTimeout(() => { lightbox.hidden = true; }, 250); };
   lightbox.addEventListener('click', closeLightbox);
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !lightbox.hidden) closeLightbox(); });

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -1020,6 +1020,12 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
   const landTracker = { last: Date.now() };
   const pollComp = (m) => {
     const url = m.dataset.comp;
+    // A converted slot is the SAME node across flip cycles, so a probe from an
+    // earlier cycle can still be in flight when the next one starts. Without a
+    // generation stamp its late onload settles the new slot: shimmer stripped,
+    // pending state cleared, comp still hidden, live poll stopped.
+    const generation = String(Number(m.dataset.pollGen || 0));
+    const current = () => String(Number(m.dataset.pollGen || 0)) === generation;
     const img = m.querySelector('img.comp');
     const note = m.querySelector('.comp-note');
     const started = Date.now();
@@ -1067,10 +1073,18 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
       // A slot the user flipped back out of either leaves the DOM or, when it
       // was an inspiration face converted in place, stays and loses its
       // pending state. Either way its loop is done.
-      if (!m.isConnected || !m.classList.contains('comp-pending')) { clearInterval(tick); return; }
+      if (!m.isConnected || !m.classList.contains('comp-pending') || !current()) { clearInterval(tick); return; }
       const probe = new Image();
-      probe.onload = () => { landTracker.last = Date.now(); img.src = probe.src; img.hidden = false; settle(); };
+      probe.onload = () => {
+        if (!current()) return;
+        landTracker.last = Date.now();
+        const target = m.querySelector('img.comp') || img;
+        target.src = probe.src;
+        target.hidden = false;
+        settle();
+      };
       probe.onerror = () => {
+        if (!current()) return;
         const quiet = Date.now() - landTracker.last > 240000;
         if (Date.now() - started > 240000 && quiet && fallback()) return;
         setTimeout(tryLoad, m.classList.contains('stand-in') ? 5000 : 2500);
@@ -1167,20 +1181,29 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
         // A converted slot is restored, not removed: the inspiration goes back
         // to being the face, so flipping back leaves the card as it was dealt.
         if (pending.dataset.compRestore === 'inspiration') {
-          pending.classList.remove('comp-pending');
+          // Everything the pending state added has to leave, presentation
+          // included: a slot that reached stand-in kept its "inspiration comp
+          // pending" label beside a fresh one, and a slot whose art had failed
+          // came back still marked unavailable.
+          pending.classList.remove('comp-pending', 'stand-in');
           delete pending.dataset.compRestore;
           delete pending.dataset.comp;
+          pending.dataset.pollGen = String(Number(pending.dataset.pollGen || 0) + 1);
           pending.querySelector('.shimmer')?.remove();
           pending.querySelector('img.comp')?.remove();
+          pending.querySelector('.stand-in-label')?.remove();
+          pending.querySelectorAll('.media-label').forEach((el) => el.remove());
           const pip = pending.querySelector('.pip');
           const art = pip?.querySelector('img');
           if (art) pending.insertBefore(art, pending.firstChild);
           pip?.remove();
+          // No art means the image failed to load before the flip, so hand the
+          // slot back to the same honest treatment rather than calling it art.
           const label = document.createElement('p');
           label.className = 'media-label';
-          label.textContent = 'inspiration';
+          label.textContent = art ? 'inspiration' : 'artwork unavailable';
           pending.insertBefore(label, pending.querySelector('.chips'));
-          pending.title = INSPO_TITLE;
+          if (art) pending.title = INSPO_TITLE; else pending.classList.add('unavailable');
           return;
         }
         pending.remove();
@@ -1244,17 +1267,41 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
     else img.addEventListener('error', gone, { once: true });
   });
 
-  // Inspiration PIP or body thumb opens the full catalog card in the lightbox.
-  // Delegated, like every other zoom target: a build-path flip builds media
-  // slots after load, and a per-element listener bound at deal time never
-  // reaches them. That is how a streamed-in comp ended up unopenable.
+  // Every zoom target resolves in ONE delegated listener, in priority order.
+  // Delegation is what lets a slot built by a build-path flip work at all, and
+  // a single listener is what keeps the targets from fighting: stopPropagation
+  // ends bubbling, not other listeners on the same target, so split across two
+  // handlers a click on the corner inspiration opened the inspiration and then
+  // the comp overwrote it in the lightbox. Per-element handlers elsewhere (the
+  // flip chip, the raise cycler) still stop bubbling before the event lands
+  // here, so they keep their own behavior.
   document.addEventListener('click', (e) => {
-    const p = e.target.closest?.('.pip, .inspo');
-    if (!p) return;
-    e.stopPropagation();
-    const img = p.querySelector('img');
-    if (!img) return;
-    openLightbox(img);
+    const target = e.target;
+    if (!target || !target.closest) return;
+    // The corner inspiration wins over the slot it sits inside.
+    const pip = target.closest('.pip, .inspo');
+    if (pip) {
+      const art = pip.querySelector('img');
+      if (art) openLightbox(art);
+      return;
+    }
+    const chip = target.closest('.chip');
+    if (chip) {
+      // Only expand zooms. Any other chip owns its click and must not fall
+      // through to the media underneath it.
+      if (!chip.classList.contains('expand')) return;
+      const card = chip.closest('.card');
+      const face = card && card.classList.contains('flipped') ? '.face.back' : '.face.front';
+      const shown = card && card.querySelector(face + ' .media img:not([hidden])');
+      if (shown && shown.getAttribute('src')) openLightbox(shown);
+      return;
+    }
+    // The whole image is the zoom target, not just the chip; the chip stays as
+    // the visible affordance.
+    const media = target.closest('.media');
+    if (!media) return;
+    const art = media.querySelector(':scope > img:not([hidden])');
+    if (art && art.getAttribute('src')) openLightbox(art);
   });
 
   // Deck paging: arrows appear only when the deck overflows its axis, page
@@ -1312,16 +1359,6 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
     lightbox.hidden = false;
     requestAnimationFrame(() => lightbox.classList.add('open'));
   }
-  document.addEventListener('click', (e) => {
-    const b = e.target.closest?.('.expand');
-    if (!b) return;
-    e.stopPropagation();
-    const card = b.closest('.card');
-    const face = card.classList.contains('flipped') ? '.face.back' : '.face.front';
-    const img = card.querySelector(face + ' .media img:not([hidden])');
-    if (!img || !img.getAttribute('src')) return;
-    openLightbox(img);
-  });
   // Portrait art (native / mobile-first surfaces): the slot takes the
   // image's own ratio so nothing crops, and the whole deck narrows so
   // portrait cards sit side by side. Load events don't bubble; capture.
@@ -1335,17 +1372,6 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
       document.querySelector('.grid')?.classList.add('portrait-media');
     }
   }, true);
-
-  // The whole image is the zoom target, not just the expand chip; the chip
-  // stays as the visible affordance. Chip and PIP handlers stop propagation,
-  // so this fires only for clicks on the art itself.
-  document.addEventListener('click', (e) => {
-    const m = e.target.closest?.('.media');
-    if (!m) return;
-    const img = m.querySelector(':scope > img:not([hidden])');
-    if (!img || !img.getAttribute('src')) return;
-    openLightbox(img);
-  });
   const closeLightbox = () => { lightbox.classList.remove('open'); setTimeout(() => { lightbox.hidden = true; }, 250); };
   lightbox.addEventListener('click', closeLightbox);
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !lightbox.hidden) closeLightbox(); });

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -1076,7 +1076,11 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
       if (!m.isConnected || !m.classList.contains('comp-pending') || !current()) { clearInterval(tick); return; }
       const probe = new Image();
       probe.onload = () => {
-        if (!current()) return;
+        // A stale generation also ends this run's clock. tryLoad clears it on
+        // re-entry, and an in-flight probe that finishes stale schedules no
+        // re-entry, so returning without clearing ran the interval for the rest
+        // of the page's life.
+        if (!current()) { clearInterval(tick); return; }
         landTracker.last = Date.now();
         const target = m.querySelector('img.comp') || img;
         target.src = probe.src;
@@ -1084,7 +1088,7 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
         settle();
       };
       probe.onerror = () => {
-        if (!current()) return;
+        if (!current()) { clearInterval(tick); return; }
         const quiet = Date.now() - landTracker.last > 240000;
         if (Date.now() - started > 240000 && quiet && fallback()) return;
         setTimeout(tryLoad, m.classList.contains('stand-in') ? 5000 : 2500);

--- a/tests/new-work-e2e.test.mjs
+++ b/tests/new-work-e2e.test.mjs
@@ -664,16 +664,30 @@ describe('new-work-e2e: serve-question decision page', () => {
       await page.waitForSelector(`${front} .media img.comp:not([hidden])`, { timeout: 15000 });
       await page.click(`${front} .media .chip.expand`);
       await page.waitForSelector('#lightbox:not([hidden])');
-      assert.ok(
-        await page.$eval('#lightbox img', (img) => Boolean(img.getAttribute('src'))),
-        'the streamed-in comp opens full screen',
-      );
+      const compSrc = await page.$eval('#lightbox img', (img) => img.getAttribute('src'));
+      assert.ok(compSrc, 'the streamed-in comp opens full screen');
       await page.click('#lightbox');
+      await page.waitForSelector('#lightbox', { state: 'hidden' });
 
-      // Flipping back restores the card as it was dealt.
+      // The corner inspiration opens the catalog art, not the comp behind it.
+      // Both zoom targets are delegated to document, where stopPropagation
+      // cannot stop a sibling listener, so split handlers let the media one
+      // overwrite the lightbox the pip had just filled.
+      const cornerSrc = await page.$eval(`${front} .media .pip img`, (img) => img.getAttribute('src'));
+      await page.click(`${front} .media .pip`);
+      await page.waitForSelector('#lightbox:not([hidden])');
+      const pipSrc = await page.$eval('#lightbox img', (img) => img.getAttribute('src'));
+      assert.notEqual(pipSrc, compSrc, 'the corner opens the inspiration, not the comp');
+      assert.equal(pipSrc, cornerSrc, 'and it is exactly the art in the corner');
+      await page.click('#lightbox');
+      await page.waitForSelector('#lightbox', { state: 'hidden' });
+
+      // Flipping back keeps a comp that already landed, by design, and must
+      // still leave exactly one slot. exitComp is synchronous, so there is
+      // nothing to wait for.
       await page.click('.bp-opt[data-bp="code"]');
-      await page.waitForTimeout(200);
       assert.equal(await page.$$eval(`${front} .media`, (els) => els.length), 1, 'still one slot after flipping back');
+      assert.ok(await page.$(`${front} .media img.comp:not([hidden])`), 'the landed comp survives the flip back');
       await context.close();
     } finally {
       await stopDaemon(cwd, key);

--- a/tests/new-work-e2e.test.mjs
+++ b/tests/new-work-e2e.test.mjs
@@ -609,6 +609,78 @@ describe('new-work-e2e: serve-question decision page', () => {
     }
   });
 
+  // The flip used to be tested only on a wireframe card, where the schematic
+  // is hidden and a fresh slot inserted. A card carrying catalog art instead
+  // took the other branch: the inspiration stayed the face and the comp slot
+  // was inserted below it, so the card showed two stacked images. Comp-first
+  // demotes the inspiration to the corner, and a flip has to reach the same
+  // shape a comp-first render would have served.
+  it('(f2) flipping to comp demotes an inspiration face to the corner instead of stacking a second slot', async () => {
+    const cwd = makeWorkspace();
+    const key = 'flipinspo';
+    const hero = makeFakeImage(cwd, 'catalog inspiration', 'inspo.png');
+    const payload = {
+      title: 'Choose the visual world',
+      buildPath: { value: 'code', toggle: true },
+      options: [
+        {
+          id: 'assigned', label: 'The Ledger Spine', kicker: 'THE ROLL', hero,
+          comp: '.impeccable/mocks/decision/assigned.webp',
+          viewport: 'A ruled masthead over a dense grid.', risk: 'Reads editorial.',
+        },
+      ],
+    };
+    const { url } = await startDaemon(cwd, payload, key);
+    try {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await page.goto(url, { waitUntil: 'load' });
+
+      const front = '.card[data-id="assigned"] .face.front';
+      // Code-led: the catalog art is the face, labeled so it never reads as a promise.
+      assert.equal(await page.$$eval(`${front} .media`, (els) => els.length), 1, 'one media slot before the flip');
+      assert.ok(await page.$(`${front} .media .media-label`), 'the inspiration face is labeled');
+      assert.equal(await page.$(`${front} .pip`), null, 'no corner inspiration while code-led');
+
+      await page.click('.bp-opt[data-bp="comp"]');
+      await page.waitForSelector('#bp-confirm:not([hidden])');
+      await page.click('#bp-confirm [data-confirm]');
+      await page.waitForSelector(`${front} .media.comp-pending`);
+
+      // The whole point: one slot, not two.
+      assert.equal(await page.$$eval(`${front} .media`, (els) => els.length), 1,
+        'the flip converts the inspiration slot rather than stacking a second one');
+      assert.ok(await page.$(`${front} .media.comp-pending .pip img`), 'the inspiration moved into the corner');
+      assert.equal(await page.$(`${front} .media > .media-label`), null, 'it is no longer presented as the face');
+      assert.ok(await page.$(`${front} .media .chip.expand`), 'the converted slot keeps its expand affordance');
+
+      const flipped = await waitLoop(cwd, key, { poll: 10 });
+      assert.match(flipped.out, /BUILD PATH FLIPPED: comp/);
+
+      // A comp that streams in must be openable. The zoom handlers used to be
+      // bound once at deal time, so anything built by the flip was inert.
+      mkdirSync(path.join(cwd, '.impeccable', 'mocks', 'decision'), { recursive: true });
+      makeFakeImage(path.join(cwd, '.impeccable', 'mocks', 'decision'), 'ledger spine comp', 'assigned.webp');
+      await page.waitForSelector(`${front} .media img.comp:not([hidden])`, { timeout: 15000 });
+      await page.click(`${front} .media .chip.expand`);
+      await page.waitForSelector('#lightbox:not([hidden])');
+      assert.ok(
+        await page.$eval('#lightbox img', (img) => Boolean(img.getAttribute('src'))),
+        'the streamed-in comp opens full screen',
+      );
+      await page.click('#lightbox');
+
+      // Flipping back restores the card as it was dealt.
+      await page.click('.bp-opt[data-bp="code"]');
+      await page.waitForTimeout(200);
+      assert.equal(await page.$$eval(`${front} .media`, (els) => els.length), 1, 'still one slot after flipping back');
+      await context.close();
+    } finally {
+      await stopDaemon(cwd, key);
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('(g) a wireframe card draws its schematic in the media slot and keeps its full read on the front', async () => {
     const cwd = makeWorkspace();
     const key = 'wire';


### PR DESCRIPTION
Reported from a live round: flipping code-first to comp-first left the card showing the catalog inspiration full-bleed with the rendering comp stacked underneath it, and the comps that streamed in could not be clicked open.

Both come from the same place. `enterComp()` hand-builds a media slot after the deal rather than reaching the shape a comp-first render would have served.

## The stack

On a code-led card the inspiration **is** the face (`.media` with the art and a label). The flip inserted a fresh `.media.comp-pending` before `.body` and left that face untouched, so the card ended up with two media slots. Two images at equal weight is exactly what the corner treatment exists to prevent: the comp is the promise, the inspiration is a glance.

The flip now converts that slot in place, moving the art into the `figure.pip` and dropping the face label, which is the markup a comp-led render ships. `exitComp` restores it, so flipping back leaves the card as it was dealt rather than deleting its art.

Only the wireframe branch was covered before. There the schematic is hidden and a fresh slot inserted, which was correct, and that is why this went unseen.

## The dead comps

The slot `enterComp` built contained only the shimmer and the comp `<img>`: no `.chips`, so no expand affordance. And all three lightbox handlers were bound per element at load:

```js
document.querySelectorAll('.media').forEach(m => m.addEventListener('click', ...))
```

Anything built by a flip is created after that runs, so it was inert. A user could wait minutes for a comp and then not be able to look at it.

The three handlers (`.media`, `.expand`, `.pip/.inspo`) are now delegated from `document`, which covers any slot built later, and a converted slot keeps the chips it already had. Polling also learned to stop on a slot that stays in the DOM but loses its pending state, which only became possible now that a flip back restores instead of removes.

## Testing

New case `(f2)` in `tests/new-work-e2e.test.mjs` drives the art-carrying card through flip, comp arrival, lightbox, and flip back. Confirmed it fails on the reported symptom without the fix:

```
✖ (f2) flipping to comp demotes an inspiration face to the corner instead of stacking a second slot
  AssertionError: the flip converts the inspiration slot rather than stacking a second one
```

`bun run test:new-work-e2e` 16/16, default suite and build green.

Written with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side UI and event handling in the question server page only; no auth or persistence changes. Regression risk is limited to build-path flip and zoom behavior, with new e2e coverage.
> 
> **Overview**
> Fixes **code-first → comp-first** on cards whose face is catalog **inspiration** art: the flip no longer inserts a second media slot under the full-bleed image. **`enterComp`** now **converts** that slot in place (shimmer + comp poll, art moved into a corner **pip**), matching comp-led layout; **`exitComp`** restores the original face (or keeps a comp that already landed).
> 
> **Lightbox / expand** no longer bind at page load only. A shared **`openLightbox`** plus **document-level** click delegation (pip → expand chip → media, in that order) covers slots created by the flip; **`ensureChips`** and an expand-chip **template** add the expand affordance when missing.
> 
> **Comp polling** uses a **`pollGen`** stamp so stale image probes from an earlier flip cycle cannot settle a restored slot; polls also stop when pending state is cleared without removing the node.
> 
> New e2e **`(f2)`** covers inspiration-face flip, comp lightbox, pip vs comp zoom, and flip-back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0169d1264575e0ee27e56b150b59071edb0c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->