### PR TITLE
Take every themed list in an entry, not the first one

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -173,14 +173,17 @@ if (headerIdx === -1) {
 // went out carrying v4.0.0's notes that way, and nothing failed. A mismatch
 // now stops the release instead of publishing another version's words.
 const articleEnd = changelogHtml.indexOf('</article>', headerIdx);
-const listStart = changelogHtml.indexOf('<ul class="cf-items">', headerIdx);
-const listEnd = changelogHtml.indexOf('</ul>', listStart);
-if (listStart === -1 || listEnd === -1) fail('Changelog entry markup is malformed.');
-if (articleEnd !== -1 && listStart > articleEnd) {
+if (articleEnd === -1) fail('Changelog entry markup is malformed.');
+// EVERY list in the entry, not the first. A long release is grouped into
+// themed <ul>s behind cf-group labels, and taking only the first published one
+// theme and silently dropped the rest.
+const entryScope = changelogHtml.slice(headerIdx, articleEnd);
+const lists = entryScope.match(/<ul class="cf-items">[\s\S]*?<\/ul>/g);
+if (!lists || !lists.length) {
   fail(`The changelog entry for "${cfg.changelogLabel}${version}" has no <ul class="cf-items"> of its own. `
-    + 'Its bullets are in a list this script cannot read, and the next entry\'s notes would ship instead.');
+    + 'Its bullets are in a list this script cannot read, and no notes would ship.');
 }
-const entryHtml = changelogHtml.slice(listStart, listEnd + '</ul>'.length);
+const entryHtml = lists.join('\n');
 
 const notes = htmlToMarkdown(entryHtml);
 ok('extracted');

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -180,8 +180,14 @@ if (articleEnd === -1) fail('Changelog entry markup is malformed.');
 const entryScope = changelogHtml.slice(headerIdx, articleEnd);
 const lists = entryScope.match(/<ul class="cf-items">[\s\S]*?<\/ul>/g);
 if (!lists || !lists.length) {
-  fail(`The changelog entry for "${cfg.changelogLabel}${version}" has no <ul class="cf-items"> of its own. `
-    + 'Its bullets are in a list this script cannot read, and no notes would ship.');
+  // An unclosed list and a missing one are different repairs, so they get
+  // different messages. Reporting "no list" for markup that plainly has one
+  // sends you looking for the wrong thing.
+  const opened = entryScope.includes('<ul class="cf-items">');
+  fail(opened
+    ? `The changelog entry for "${cfg.changelogLabel}${version}" opens a <ul class="cf-items"> that is never closed inside its <article>. Fix the markup.`
+    : `The changelog entry for "${cfg.changelogLabel}${version}" has no <ul class="cf-items"> of its own. `
+      + 'Its bullets are in a list this script cannot read, and no notes would ship.');
 }
 const entryHtml = lists.join('\n');
 


### PR DESCRIPTION
A long changelog entry is grouped into themed lists behind `cf-group` labels. The notes extractor stopped at the first one.

**`skill-v4.0.0` shipped 6 of its 19 bullets** because of this, and `v4.1.0` would have shipped 6 of 21 once it was grouped for readability.

This is the same shape as the bounded-search fix in #584: the extractor treated "found a list" as "found the notes". It now collects every `cf-items` list inside the entry's own `</article>` and joins them, so grouping an entry cannot silently truncate what ships.

## Verified

| tag | bullets on the page | bullets published (before) | after |
|---|---|---|---|
| skill-v4.1.0 | 21 | would have been 6 | 21 |
| skill-v4.0.0 | 19 | 6 | 19 |
| skill-v4.0.4 | 14 | wrong entry's text | 14 |
| skill-v4.0.3 | 9 | wrong entry's text | 9 |
| cli-v3.6.0 | 7 | 6 | 7 |

All five GitHub releases are re-synced from the corrected changelog. `tests/release.test.mjs` passes.

## Context

This surfaced while auditing whether v4.1.0's changelog entry was complete. It was not: the entry had been written from `git log --merges`, which saw 24 merges when 43 PRs had actually shipped, so the release's entire native story was missing from the page. That is fixed in impeccable-site, along with a `changelog` skill that says to collect PR titles rather than merge commits.

Written with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to changelog HTML parsing in the release script; reduces risk of wrong or incomplete published notes with no runtime product impact.
> 
> **Overview**
> **Fixes silent truncation of GitHub release notes** when a changelog entry uses multiple themed `<ul class="cf-items">` blocks (e.g. behind `cf-group` labels). The release script previously took only the first list inside the entry’s `<article>`; it now regex-matches **all** such lists in that scope and concatenates them before `htmlToMarkdown`.
> 
> Error handling is tightened: a missing `</article>` fails early, and an opened-but-unclosed `cf-items` list gets a distinct message from a truly missing list (instead of a generic “malformed” or wrong-entry bleed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e58fd61141de7024461470757210666c603ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->