### PR TITLE
Fix: require session key and origin/host checks on serve-question POSTs (#555)

### DIFF
--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -1019,7 +1019,9 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
   // exits on any pick and has no update channel, so a followup payload there
   // still gets the goodbye screen, never a loading hand nothing will resolve.
   const FOLLOWUP = ${payload.followup === true && Boolean(detachedKey) ? 'true' : 'false'};
-  const beat = () => { try { navigator.sendBeacon('/heartbeat'); } catch { fetch('/heartbeat', { method: 'POST' }); } };
+  const KEY = ${JSON.stringify(detachedKey || '')};
+  const keyQ = KEY ? '?key=' + encodeURIComponent(KEY) : '';
+  const beat = () => { try { navigator.sendBeacon('/heartbeat' + keyQ); } catch { fetch('/heartbeat' + keyQ, { method: 'POST' }); } };
   ${waiting && waitBudgetMs <= 0 ? '' : 'beat();'}
   const beatTimer = setInterval(beat, 5000);
   // A dead server must fail loudly: awaiting a rejected fetch here used to
@@ -1030,7 +1032,7 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
     // is in flight would overwrite the answer being collected.
     document.querySelectorAll('.reroll-btn, #canon').forEach(b => b.setAttribute('disabled', ''));
     try {
-      await fetch('/answer', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId, steer: steer() }) });
+      await fetch('/answer' + keyQ, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId, steer: steer() }) });
     } catch {
       document.body.innerHTML = '<div class="done">The question server went away before this choice could land.<br>Tell the agent your pick in the chat instead.</div>';
       return;
@@ -1472,7 +1474,7 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
     // re-roll and renewed the delivery deadline.
     document.querySelectorAll('.reroll-btn, #canon').forEach(b => b.setAttribute('disabled', ''));
     try {
-      await fetch('/answer', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: steer(), ...(register ? { register } : {}) }) });
+      await fetch('/answer' + keyQ, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: steer(), ...(register ? { register } : {}) }) });
     } catch {
       document.body.innerHTML = '<div class="done">The question server went away before this choice could land.<br>Tell the agent your pick in the chat instead.</div>';
       return;
@@ -1566,8 +1568,35 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
 </script>`;
 }
 
+function allowedHost(host, port) {
+  return host === `127.0.0.1:${port}` || host === `localhost:${port}`;
+}
+
+function allowedOrigin(origin, port) {
+  return origin === `http://127.0.0.1:${port}` || origin === `http://localhost:${port}`;
+}
+
+function rejectDetachedPost(req, res, url, port) {
+  if (detachedKey && url.searchParams.get('key') !== detachedKey) {
+    res.writeHead(401); res.end(); return true;
+  }
+  const origin = req.headers.origin;
+  if (origin && !allowedOrigin(origin, port)) {
+    res.writeHead(403); res.end(); return true;
+  }
+  return false;
+}
+
 const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && req.url === '/') {
+  const { port } = server.address();
+  if (!allowedHost(req.headers.host, port)) {
+    res.writeHead(403); res.end(); return;
+  }
+  let url;
+  try { url = new URL(req.url, 'http://127.0.0.1'); }
+  catch { res.writeHead(400); res.end(); return; }
+  const pathname = url.pathname;
+  if (req.method === 'GET' && pathname === '/') {
     const pending = nextFile();
     if (pending && fs.existsSync(pending)) {
       // A next file the round cannot load has to leave the disk either way:
@@ -1593,7 +1622,8 @@ const server = http.createServer((req, res) => {
     res.end(page(awaitingNext));
     return;
   }
-  if (req.method === 'POST' && req.url === '/heartbeat') {
+  if (req.method === 'POST' && pathname === '/heartbeat') {
+    if (rejectDetachedPost(req, res, url, port)) return;
     res.writeHead(204); res.end();
     server.lastBeatSeen = Date.now();
     if (detachedKey) {
@@ -1609,13 +1639,13 @@ const server = http.createServer((req, res) => {
     }
     return;
   }
-  if (req.method === 'GET' && req.url === '/next-status') {
+  if (req.method === 'GET' && pathname === '/next-status') {
     const pending = nextFile();
     res.writeHead(200, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ ready: Boolean(pending && fs.existsSync(pending)) }));
     return;
   }
-  const imageMatch = req.method === 'GET' && req.url?.match(/^\/img\/(\d+)(?:\?.*)?$/);
+  const imageMatch = req.method === 'GET' && pathname.match(/^\/img\/(\d+)$/);
   if (imageMatch) {
     const abs = localImages[Number(imageMatch[1])];
     if (!abs || !fs.existsSync(abs)) { res.writeHead(404); res.end(); return; }
@@ -1628,7 +1658,7 @@ const server = http.createServer((req, res) => {
     fs.createReadStream(abs).pipe(res);
     return;
   }
-  if (req.method === 'POST' && req.url === '/build-path') {
+  if (req.method === 'POST' && pathname === '/build-path') {
     let body = '';
     req.on('data', (chunk) => { body += chunk; });
     req.on('end', () => {
@@ -1648,7 +1678,8 @@ const server = http.createServer((req, res) => {
     });
     return;
   }
-  if (req.method === 'POST' && req.url === '/answer') {
+  if (req.method === 'POST' && pathname === '/answer') {
+    if (rejectDetachedPost(req, res, url, port)) return;
     let body = '';
     req.on('data', (chunk) => { body += chunk; });
     req.on('end', () => {

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -1306,7 +1306,7 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
     };
     const apply = (value) => {
       set(value);
-      fetch('/build-path', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ value }) });
+      fetch('/build-path' + keyQ, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ value }) });
       if (value === 'comp') enterComp(); else exitComp();
     };
     // Flipping to comp starts real generation, so it confirms first; the
@@ -1659,6 +1659,7 @@ const server = http.createServer((req, res) => {
     return;
   }
   if (req.method === 'POST' && pathname === '/build-path') {
+    if (rejectDetachedPost(req, res, url, port)) return;
     let body = '';
     req.on('data', (chunk) => { body += chunk; });
     req.on('end', () => {

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -1568,12 +1568,16 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
 </script>`;
 }
 
+// Browsers omit the :80 suffix on the default HTTP port, so a server on
+// --port 80 sees bare loopback hosts and origins.
 function allowedHost(host, port) {
-  return host === `127.0.0.1:${port}` || host === `localhost:${port}`;
+  if (host === `127.0.0.1:${port}` || host === `localhost:${port}`) return true;
+  return port === 80 && (host === '127.0.0.1' || host === 'localhost');
 }
 
 function allowedOrigin(origin, port) {
-  return origin === `http://127.0.0.1:${port}` || origin === `http://localhost:${port}`;
+  if (origin === `http://127.0.0.1:${port}` || origin === `http://localhost:${port}`) return true;
+  return port === 80 && (origin === 'http://127.0.0.1' || origin === 'http://localhost');
 }
 
 function rejectDetachedPost(req, res, url, port) {

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -1220,7 +1220,7 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
     };
     const apply = (value) => {
       set(value);
-      fetch('/build-path', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ value }) });
+      fetch('/build-path' + keyQ, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ value }) });
       if (value === 'comp') enterComp(); else exitComp();
     };
     // Flipping to comp starts real generation, so it confirms first; the
@@ -1490,6 +1490,7 @@ const server = http.createServer((req, res) => {
     return;
   }
   if (req.method === 'POST' && pathname === '/build-path') {
+    if (rejectDetachedPost(req, res, url, port)) return;
     let body = '';
     req.on('data', (chunk) => { body += chunk; });
     req.on('end', () => {

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -1417,12 +1417,16 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
 </script>`;
 }
 
+// Browsers omit the :80 suffix on the default HTTP port, so a server on
+// --port 80 sees bare loopback hosts and origins.
 function allowedHost(host, port) {
-  return host === `127.0.0.1:${port}` || host === `localhost:${port}`;
+  if (host === `127.0.0.1:${port}` || host === `localhost:${port}`) return true;
+  return port === 80 && (host === '127.0.0.1' || host === 'localhost');
 }
 
 function allowedOrigin(origin, port) {
-  return origin === `http://127.0.0.1:${port}` || origin === `http://localhost:${port}`;
+  if (origin === `http://127.0.0.1:${port}` || origin === `http://localhost:${port}`) return true;
+  return port === 80 && (origin === 'http://127.0.0.1' || origin === 'http://localhost');
 }
 
 function rejectDetachedPost(req, res, url, port) {

--- a/skill/scripts/serve-question.mjs
+++ b/skill/scripts/serve-question.mjs
@@ -944,11 +944,13 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
   // exits on any pick and has no update channel, so a followup payload there
   // still gets the goodbye screen, never a loading hand nothing will resolve.
   const FOLLOWUP = ${payload.followup === true && Boolean(detachedKey) ? 'true' : 'false'};
-  const beat = () => { try { navigator.sendBeacon('/heartbeat'); } catch { fetch('/heartbeat', { method: 'POST' }); } };
+  const KEY = ${JSON.stringify(detachedKey || '')};
+  const keyQ = KEY ? '?key=' + encodeURIComponent(KEY) : '';
+  const beat = () => { try { navigator.sendBeacon('/heartbeat' + keyQ); } catch { fetch('/heartbeat' + keyQ, { method: 'POST' }); } };
   beat();
   setInterval(beat, 5000);
   async function answer(optionId) {
-    await fetch('/answer', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId, steer: steer() }) });
+    await fetch('/answer' + keyQ, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId, steer: steer() }) });
     if (FOLLOWUP) { await awaitNextRound(); return; }
     document.body.innerHTML = '<div class="done"><svg viewBox="0 0 24 24" width="38" height="38" fill="oklch(84% 0.19 80.46)" aria-hidden="true"><path d="M5 2.5 L13.5 2.5 L5.5 21.5 L5 21.5 Q2.5 21.5 2.5 19 L2.5 5 Q2.5 2.5 5 2.5 Z"/><path d="M16.5 2.5 L19 2.5 Q21.5 2.5 21.5 5 L21.5 19 Q21.5 21.5 19 21.5 L8.5 21.5 Z"/></svg>Choice recorded. The agent is resuming; you can close this tab.</div>';
   }
@@ -1381,7 +1383,7 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !lightbox.hidden) closeLightbox(); });
   document.getElementById('canon')?.addEventListener('click', () => answer('canon'));
   const dealAgain = async (register) => {
-    await fetch('/answer', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: steer(), ...(register ? { register } : {}) }) });
+    await fetch('/answer' + keyQ, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: steer(), ...(register ? { register } : {}) }) });
     await awaitNextRound();
   };
   async function awaitNextRound() {
@@ -1415,8 +1417,35 @@ ${buildPath?.toggle ? `<div id="bp-confirm" role="dialog" aria-modal="true" aria
 </script>`;
 }
 
+function allowedHost(host, port) {
+  return host === `127.0.0.1:${port}` || host === `localhost:${port}`;
+}
+
+function allowedOrigin(origin, port) {
+  return origin === `http://127.0.0.1:${port}` || origin === `http://localhost:${port}`;
+}
+
+function rejectDetachedPost(req, res, url, port) {
+  if (detachedKey && url.searchParams.get('key') !== detachedKey) {
+    res.writeHead(401); res.end(); return true;
+  }
+  const origin = req.headers.origin;
+  if (origin && !allowedOrigin(origin, port)) {
+    res.writeHead(403); res.end(); return true;
+  }
+  return false;
+}
+
 const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && req.url === '/') {
+  const { port } = server.address();
+  if (!allowedHost(req.headers.host, port)) {
+    res.writeHead(403); res.end(); return;
+  }
+  let url;
+  try { url = new URL(req.url, 'http://127.0.0.1'); }
+  catch { res.writeHead(400); res.end(); return; }
+  const pathname = url.pathname;
+  if (req.method === 'GET' && pathname === '/') {
     const pending = nextFile();
     if (pending && fs.existsSync(pending)) {
       try { loadRound(fs.readFileSync(pending, 'utf8')); fs.rmSync(pending); } catch { /* keep current round */ }
@@ -1425,7 +1454,8 @@ const server = http.createServer((req, res) => {
     res.end(page());
     return;
   }
-  if (req.method === 'POST' && req.url === '/heartbeat') {
+  if (req.method === 'POST' && pathname === '/heartbeat') {
+    if (rejectDetachedPost(req, res, url, port)) return;
     res.writeHead(204); res.end();
     if (detachedKey) {
       const now = Date.now();
@@ -1440,13 +1470,13 @@ const server = http.createServer((req, res) => {
     }
     return;
   }
-  if (req.method === 'GET' && req.url === '/next-status') {
+  if (req.method === 'GET' && pathname === '/next-status') {
     const pending = nextFile();
     res.writeHead(200, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ ready: Boolean(pending && fs.existsSync(pending)) }));
     return;
   }
-  const imageMatch = req.method === 'GET' && req.url?.match(/^\/img\/(\d+)(?:\?.*)?$/);
+  const imageMatch = req.method === 'GET' && pathname.match(/^\/img\/(\d+)$/);
   if (imageMatch) {
     const abs = localImages[Number(imageMatch[1])];
     if (!abs || !fs.existsSync(abs)) { res.writeHead(404); res.end(); return; }
@@ -1459,7 +1489,7 @@ const server = http.createServer((req, res) => {
     fs.createReadStream(abs).pipe(res);
     return;
   }
-  if (req.method === 'POST' && req.url === '/build-path') {
+  if (req.method === 'POST' && pathname === '/build-path') {
     let body = '';
     req.on('data', (chunk) => { body += chunk; });
     req.on('end', () => {
@@ -1479,7 +1509,8 @@ const server = http.createServer((req, res) => {
     });
     return;
   }
-  if (req.method === 'POST' && req.url === '/answer') {
+  if (req.method === 'POST' && pathname === '/answer') {
+    if (rejectDetachedPost(req, res, url, port)) return;
     let body = '';
     req.on('data', (chunk) => { body += chunk; });
     req.on('end', () => {

--- a/tests/new-work-e2e.test.mjs
+++ b/tests/new-work-e2e.test.mjs
@@ -843,7 +843,7 @@ describe('new-work-e2e: serve-question decision page', () => {
       // the server keeps its real clock, so its own idle grace never fires.
       await page.clock.install();
       let beats = 0;
-      page.on('request', (r) => { if (r.url().endsWith('/heartbeat')) beats += 1; });
+      page.on('request', (r) => { if (new URL(r.url()).pathname === '/heartbeat') beats += 1; });
       await page.goto(url, { waitUntil: 'load' });
       // Playwright actionability waits on rAF, which the fake clock owns, so
       // dispatch the click directly.

--- a/tests/serve-question.test.mjs
+++ b/tests/serve-question.test.mjs
@@ -192,10 +192,32 @@ describe('serve-question', () => {
     assert.equal(slashSlash.status, 400);
     assert.equal((await fetch(url)).status, 200);
 
+    // The build-path flip commands the agent through --wait, so it takes the
+    // same key and Origin gate as /answer.
+    const flipPath = path.join(dir, '.impeccable', 'questions', `${key}.flip.json`);
+    const flipBody = JSON.stringify({ value: 'comp' });
+    const noKeyFlip = await fetch(`http://${goodHost}/build-path`, { method: 'POST', headers: jsonHeaders, body: flipBody });
+    assert.equal(noKeyFlip.status, 401);
+    assert.equal(existsSync(flipPath), false);
+    const evilOriginFlip = await rawRequest(port, {
+      method: 'POST',
+      path: `/build-path?key=${key}`,
+      headers: { ...jsonHeaders, Origin: 'https://evil.example' },
+    }, flipBody);
+    assert.equal(evilOriginFlip.status, 403);
+    assert.equal(existsSync(flipPath), false);
+    const okFlip = await fetch(`http://${goodHost}/build-path?key=${key}`, { method: 'POST', headers: jsonHeaders, body: flipBody });
+    assert.equal(okFlip.status, 200);
+    assert.equal(existsSync(flipPath), true);
+    const flipped = await run(['--wait', '--key', key, '--poll', '2']);
+    assert.equal(flipped.code, 0);
+    assert.match(flipped.out, /BUILD PATH FLIPPED/);
+
     const html = await (await fetch(url)).text();
     assert.match(html, /const KEY = "seckey"/);
     assert.match(html, /\/answer' \+ keyQ/);
     assert.match(html, /\/heartbeat' \+ keyQ/);
+    assert.match(html, /\/build-path' \+ keyQ/);
 
     const ok = await fetch(`http://${goodHost}/answer?key=${key}`, { method: 'POST', headers: jsonHeaders, body });
     assert.equal(ok.status, 200);

--- a/tests/serve-question.test.mjs
+++ b/tests/serve-question.test.mjs
@@ -185,6 +185,14 @@ describe('serve-question', () => {
     });
     assert.equal(spoofedHostGet.status, 403);
 
+    // The bare-host allowance exists only for --port 80, where browsers omit
+    // the suffix; on any other port a portless Host stays rejected.
+    const bareHostGet = await rawRequest(port, {
+      path: '/',
+      headers: { Host: '127.0.0.1' },
+    });
+    assert.equal(bareHostGet.status, 403);
+
     const slashSlash = await rawRequest(port, {
       path: '//',
       headers: { Host: goodHost },

--- a/tests/serve-question.test.mjs
+++ b/tests/serve-question.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, execSync } from 'node:child_process';
+import http from 'node:http';
 import { writeFileSync, readFileSync, rmSync, utimesSync, mkdtempSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -40,6 +41,25 @@ const PAYLOAD = {
   reroll: true,
   steer: true,
 };
+
+function rawRequest(port, { method = 'GET', path: reqPath = '/', headers = {} } = {}, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1',
+      port,
+      method,
+      path: reqPath,
+      headers,
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
 
 describe('serve-question', () => {
   it('opens Windows URLs through cmd.exe and reserves the start title argument', () => {
@@ -105,8 +125,81 @@ describe('serve-question', () => {
     assert.ok(url, started.out);
     const waiting = await run(['--wait', '--key', 'tk', '--poll', '1']);
     assert.equal(waiting.code, 3);
-    await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'assigned', steer: '' }) });
+    await fetch(`${url}answer?key=tk`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'assigned', steer: '' }) });
     const collected = await run(['--wait', '--key', 'tk', '--poll', '5']);
+    assert.equal(collected.code, 0);
+    assert.match(collected.out, /"optionId":"assigned"/);
+  });
+
+  it('rejects detached POSTs without the session key or with bad Host/Origin', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'serve-question-'));
+    const payloadPath = path.join(dir, 'q.json');
+    const key = 'seckey';
+    const answerPath = path.join(dir, '.impeccable', 'questions', `${key}.answer.json`);
+    writeFileSync(payloadPath, JSON.stringify(PAYLOAD));
+    const run = (args) => new Promise((resolve) => {
+      const child = spawn(process.execPath, [SCRIPT, ...args], { cwd: dir, stdio: ['ignore', 'pipe', 'ignore'] });
+      let out = '';
+      child.stdout.on('data', (chunk) => { out += chunk; });
+      child.on('exit', (code) => resolve({ code, out }));
+    });
+    const started = await run(['--start', '--payload', payloadPath, '--no-open', '--key', key]);
+    assert.equal(started.code, 0);
+    const url = started.out.match(/QUESTION URL: (\S+)/)?.[1];
+    assert.ok(url, started.out);
+    const port = Number(new URL(url).port);
+    const goodHost = `127.0.0.1:${port}`;
+    const body = JSON.stringify({ optionId: 'assigned', steer: '' });
+    const jsonHeaders = { 'content-type': 'application/json', Host: goodHost };
+
+    const noKey = await fetch(`http://${goodHost}/answer`, { method: 'POST', headers: jsonHeaders, body });
+    assert.equal(noKey.status, 401);
+    assert.equal(existsSync(answerPath), false);
+    const waiting = await run(['--wait', '--key', key, '--poll', '1']);
+    assert.equal(waiting.code, 3);
+
+    const wrongKey = await fetch(`http://${goodHost}/answer?key=wrong`, { method: 'POST', headers: jsonHeaders, body });
+    assert.equal(wrongKey.status, 401);
+
+    const evilOrigin = await rawRequest(port, {
+      method: 'POST',
+      path: `/answer?key=${key}`,
+      headers: { ...jsonHeaders, Origin: 'https://evil.example' },
+    }, body);
+    assert.equal(evilOrigin.status, 403);
+    assert.equal(existsSync(answerPath), false);
+
+    const spoofedHostPost = await rawRequest(port, {
+      method: 'POST',
+      path: `/answer?key=${key}`,
+      headers: { ...jsonHeaders, Host: `evil.example:${port}` },
+    }, body);
+    assert.equal(spoofedHostPost.status, 403);
+
+    const noKeyBeat = await fetch(`http://${goodHost}/heartbeat`, { method: 'POST', headers: { Host: goodHost } });
+    assert.equal(noKeyBeat.status, 401);
+
+    const spoofedHostGet = await rawRequest(port, {
+      path: '/',
+      headers: { Host: `evil.example:${port}` },
+    });
+    assert.equal(spoofedHostGet.status, 403);
+
+    const slashSlash = await rawRequest(port, {
+      path: '//',
+      headers: { Host: goodHost },
+    });
+    assert.equal(slashSlash.status, 400);
+    assert.equal((await fetch(url)).status, 200);
+
+    const html = await (await fetch(url)).text();
+    assert.match(html, /const KEY = "seckey"/);
+    assert.match(html, /\/answer' \+ keyQ/);
+    assert.match(html, /\/heartbeat' \+ keyQ/);
+
+    const ok = await fetch(`http://${goodHost}/answer?key=${key}`, { method: 'POST', headers: jsonHeaders, body });
+    assert.equal(ok.status, 200);
+    const collected = await run(['--wait', '--key', key, '--poll', '5']);
     assert.equal(collected.code, 0);
     assert.match(collected.out, /"optionId":"assigned"/);
   });

--- a/tests/serve-question.test.mjs
+++ b/tests/serve-question.test.mjs
@@ -334,7 +334,7 @@ describe('serve-question', () => {
     // Beat well past the 3s timeout: the timer must not fire under a live page.
     const beatUntil = Date.now() + 5500;
     while (Date.now() < beatUntil) {
-      await fetch(`${url}heartbeat`, { method: 'POST' });
+      await fetch(`${url}heartbeat?key=life`, { method: 'POST' });
       await new Promise((r) => setTimeout(r, 400));
     }
     const alive = await fetch(url);
@@ -419,7 +419,7 @@ describe('serve-question', () => {
     // One beat, then silence: the idle grace must still reclaim the daemon.
     // Before the fix, the whole lifetime check sat inside timeoutSec > 0 and
     // a closed tab leaked this daemon forever.
-    await fetch(`${url}heartbeat`, { method: 'POST' });
+    await fetch(`${url}heartbeat?key=zero`, { method: 'POST' });
     const deadline = Date.now() + 12000;
     let gone = false;
     while (Date.now() < deadline && !gone) {
@@ -444,8 +444,8 @@ describe('serve-question', () => {
     const url = started.out.match(/QUESTION URL: (\S+)/)?.[1];
     assert.ok(url, started.out);
     try {
-      await fetch(`${url}heartbeat`, { method: 'POST' });
-      await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
+      await fetch(`${url}heartbeat?key=latehand`, { method: 'POST' });
+      await fetch(`${url}answer?key=latehand`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
       // Go silent like a stalled page until just before the 3s idle
       // deadline, then deliver: the daemon used to exit before the page's
       // watch could claim the hand, orphaning a delivery --update had
@@ -490,7 +490,7 @@ describe('serve-question', () => {
       // serving decision has to live here: once a re-roll answer is collected
       // and no replacement has landed, GET / re-enters the bounded shuffle
       // wait instead of re-serving the answered cards.
-      await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
+      await fetch(`${url}answer?key=refresh`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
       const waitingPage = await (await fetch(url)).text();
       assert.ok(waitingPage.includes('awaitNextRound(false,'), 'a refresh mid re-roll re-enters the shuffle wait');
       const nextPath = path.join(dir, 'next.json');
@@ -520,7 +520,7 @@ describe('serve-question', () => {
     const url = started.out.match(/QUESTION URL: (\S+)/)?.[1];
     assert.ok(url, started.out);
     try {
-      await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
+      await fetch(`${url}answer?key=deadline`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
       const fresh = await (await fetch(url)).text();
       const budget = Number(fresh.match(/awaitNextRound\(false, (\d+)\);/)?.[1]);
       assert.ok(budget > 0 && budget <= 3000, `the waiting page carries the remaining allowance, got ${budget}`);
@@ -529,7 +529,7 @@ describe('serve-question', () => {
       // click-time disable can race a second click, so the server keeps the
       // first stamp instead of renewing the allowance.
       await new Promise((r) => setTimeout(r, 1200));
-      await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
+      await fetch(`${url}answer?key=deadline`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
       const restamped = Number((await (await fetch(url)).text()).match(/awaitNextRound\(false, (\d+)\);/)?.[1]);
       assert.ok(restamped > 0 && restamped < 2500, `a duplicate re-roll does not renew the allowance, got ${restamped}`);
       await new Promise((r) => setTimeout(r, 3500));
@@ -565,7 +565,7 @@ describe('serve-question', () => {
       // A bad file that reaches the disk anyway must not trap the page:
       // GET / discards it, so /next-status stops reporting a hand that can
       // never render and the bounded wait resumes instead of reload-looping.
-      await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
+      await fetch(`${url}answer?key=badhand`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
       writeFileSync(path.join(dir, '.impeccable', 'questions', 'badhand.next.json'), JSON.stringify({ title: 'No options' }));
       const page = await (await fetch(url)).text();
       assert.ok(page.includes('awaitNextRound(false,'), 'the round stays in the wait');
@@ -591,7 +591,7 @@ describe('serve-question', () => {
     const url = started.out.match(/QUESTION URL: (\S+)/)?.[1];
     assert.ok(url, started.out);
     try {
-      await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
+      await fetch(`${url}answer?key=silent`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
       const collected = await run(['--wait', '--key', 'silent', '--poll', '2']);
       assert.equal(collected.code, 0, collected.out);
       // The stalled page went silent by design: fake a beat older than the
@@ -644,7 +644,7 @@ describe('serve-question', () => {
     const url = started.out.match(/QUESTION URL: (\S+)/)?.[1];
     assert.ok(url, started.out);
     try {
-      await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
+      await fetch(`${url}answer?key=claimgap`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'reroll', steer: '' }) });
       const collected = await run(['--wait', '--key', 'claimgap', '--poll', '2']);
       assert.equal(collected.code, 0, collected.out);
       const statePath = path.join(dir, '.impeccable', 'questions', 'claimgap.state.json');

--- a/tests/serve-question.test.mjs
+++ b/tests/serve-question.test.mjs
@@ -1,7 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { writeFileSync, mkdtempSync } from 'node:fs';
+import http from 'node:http';
+import { writeFileSync, mkdtempSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -40,6 +41,25 @@ const PAYLOAD = {
   reroll: true,
   steer: true,
 };
+
+function rawRequest(port, { method = 'GET', path: reqPath = '/', headers = {} } = {}, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1',
+      port,
+      method,
+      path: reqPath,
+      headers,
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }));
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
 
 describe('serve-question', () => {
   it('opens Windows URLs through cmd.exe and reserves the start title argument', () => {
@@ -105,8 +125,81 @@ describe('serve-question', () => {
     assert.ok(url, started.out);
     const waiting = await run(['--wait', '--key', 'tk', '--poll', '1']);
     assert.equal(waiting.code, 3);
-    await fetch(`${url}answer`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'assigned', steer: '' }) });
+    await fetch(`${url}answer?key=tk`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ optionId: 'assigned', steer: '' }) });
     const collected = await run(['--wait', '--key', 'tk', '--poll', '5']);
+    assert.equal(collected.code, 0);
+    assert.match(collected.out, /"optionId":"assigned"/);
+  });
+
+  it('rejects detached POSTs without the session key or with bad Host/Origin', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'serve-question-'));
+    const payloadPath = path.join(dir, 'q.json');
+    const key = 'seckey';
+    const answerPath = path.join(dir, '.impeccable', 'questions', `${key}.answer.json`);
+    writeFileSync(payloadPath, JSON.stringify(PAYLOAD));
+    const run = (args) => new Promise((resolve) => {
+      const child = spawn(process.execPath, [SCRIPT, ...args], { cwd: dir, stdio: ['ignore', 'pipe', 'ignore'] });
+      let out = '';
+      child.stdout.on('data', (chunk) => { out += chunk; });
+      child.on('exit', (code) => resolve({ code, out }));
+    });
+    const started = await run(['--start', '--payload', payloadPath, '--no-open', '--key', key]);
+    assert.equal(started.code, 0);
+    const url = started.out.match(/QUESTION URL: (\S+)/)?.[1];
+    assert.ok(url, started.out);
+    const port = Number(new URL(url).port);
+    const goodHost = `127.0.0.1:${port}`;
+    const body = JSON.stringify({ optionId: 'assigned', steer: '' });
+    const jsonHeaders = { 'content-type': 'application/json', Host: goodHost };
+
+    const noKey = await fetch(`http://${goodHost}/answer`, { method: 'POST', headers: jsonHeaders, body });
+    assert.equal(noKey.status, 401);
+    assert.equal(existsSync(answerPath), false);
+    const waiting = await run(['--wait', '--key', key, '--poll', '1']);
+    assert.equal(waiting.code, 3);
+
+    const wrongKey = await fetch(`http://${goodHost}/answer?key=wrong`, { method: 'POST', headers: jsonHeaders, body });
+    assert.equal(wrongKey.status, 401);
+
+    const evilOrigin = await rawRequest(port, {
+      method: 'POST',
+      path: `/answer?key=${key}`,
+      headers: { ...jsonHeaders, Origin: 'https://evil.example' },
+    }, body);
+    assert.equal(evilOrigin.status, 403);
+    assert.equal(existsSync(answerPath), false);
+
+    const spoofedHostPost = await rawRequest(port, {
+      method: 'POST',
+      path: `/answer?key=${key}`,
+      headers: { ...jsonHeaders, Host: `evil.example:${port}` },
+    }, body);
+    assert.equal(spoofedHostPost.status, 403);
+
+    const noKeyBeat = await fetch(`http://${goodHost}/heartbeat`, { method: 'POST', headers: { Host: goodHost } });
+    assert.equal(noKeyBeat.status, 401);
+
+    const spoofedHostGet = await rawRequest(port, {
+      path: '/',
+      headers: { Host: `evil.example:${port}` },
+    });
+    assert.equal(spoofedHostGet.status, 403);
+
+    const slashSlash = await rawRequest(port, {
+      path: '//',
+      headers: { Host: goodHost },
+    });
+    assert.equal(slashSlash.status, 400);
+    assert.equal((await fetch(url)).status, 200);
+
+    const html = await (await fetch(url)).text();
+    assert.match(html, /const KEY = "seckey"/);
+    assert.match(html, /\/answer' \+ keyQ/);
+    assert.match(html, /\/heartbeat' \+ keyQ/);
+
+    const ok = await fetch(`http://${goodHost}/answer?key=${key}`, { method: 'POST', headers: jsonHeaders, body });
+    assert.equal(ok.status, 200);
+    const collected = await run(['--wait', '--key', key, '--poll', '5']);
     assert.equal(collected.code, 0);
     assert.match(collected.out, /"optionId":"assigned"/);
   });


### PR DESCRIPTION
Unauthenticated POST /answer copied free-text steer into the ANSWER line the agent reads. The handler now requires ?key= on detached /answer and /heartbeat, rejects a foreign Origin, and pins Host to 127.0.0.1/localhost so DNS rebinding cannot leak the key.
Fixes #555
Validated with tests/serve-question.test.mjs, bun run test, and bun run test:new-work-e2e.
Written with AI assistance under maintainer direction.

Made with [Cursor](https://cursor.com)