### PR TITLE
Simplify hook manifest builders

### DIFF
--- a/scripts/lib/transformers/hooks.js
+++ b/scripts/lib/transformers/hooks.js
@@ -46,6 +46,7 @@ function stopEntry(command) {
     ],
   };
 }
+
 const CLAUDE_PROJECT_HOOK = '${CLAUDE_PROJECT_DIR}/.claude/skills/impeccable/scripts/hook.mjs';
 // The Node major the hook runtime requires, kept equal to the engines floor in
 // package.json. The probe and the notice both derive from it so they cannot
@@ -85,6 +86,27 @@ const guardedNode = (hookPath, notice = '') => {
     : `! ${NODE_PROBE}`;
   return `[ ! -f "${hookPath}" ] || ${probe} || node "${hookPath}"`;
 };
+
+function buildClaudeCompatibleHooks(matcher, hookPath, notice = '') {
+  const command = guardedNode(hookPath, notice);
+  return {
+    PostToolUse: [
+      {
+        matcher,
+        hooks: [
+          {
+            type: 'command',
+            command,
+            timeout: TIMEOUT_SECONDS,
+            statusMessage: STATUS_MESSAGE,
+          },
+        ],
+      },
+    ],
+    Stop: [stopEntry(command)],
+  };
+}
+
 // The message says `on PATH` deliberately: the common cause is a hook shell
 // whose PATH misses the version manager, so a user already running Node 22
 // needs to know the hook's PATH is at issue and not their install. Apostrophes
@@ -116,22 +138,11 @@ const GROK_PROJECT_HOOK = '.grok/skills/impeccable/scripts/hook.mjs';
 export function buildClaudeSettingsManifest() {
   return {
     description: 'Impeccable design detector: immediate-tier checks after Edit/Write/MultiEdit on UI files, full-rule deep pass on Stop.',
-    hooks: {
-      PostToolUse: [
-        {
-          matcher: 'Edit|Write|MultiEdit',
-          hooks: [
-            {
-              type: 'command',
-              command: guardedNode(CLAUDE_PROJECT_HOOK, SYSTEM_MESSAGE_NOTICE),
-              timeout: TIMEOUT_SECONDS,
-              statusMessage: STATUS_MESSAGE,
-            },
-          ],
-        },
-      ],
-      Stop: [stopEntry(guardedNode(CLAUDE_PROJECT_HOOK, SYSTEM_MESSAGE_NOTICE))],
-    },
+    hooks: buildClaudeCompatibleHooks(
+      'Edit|Write|MultiEdit',
+      CLAUDE_PROJECT_HOOK,
+      SYSTEM_MESSAGE_NOTICE,
+    ),
   };
 }
 
@@ -143,22 +154,11 @@ export function buildClaudeSettingsManifest() {
 // than `hooks`, failing the whole manifest (issue #330).
 export function buildClaudePluginHooksManifest() {
   return {
-    hooks: {
-      PostToolUse: [
-        {
-          matcher: 'Edit|Write|MultiEdit',
-          hooks: [
-            {
-              type: 'command',
-              command: guardedNode(CLAUDE_PLUGIN_HOOK, SYSTEM_MESSAGE_NOTICE),
-              timeout: TIMEOUT_SECONDS,
-              statusMessage: STATUS_MESSAGE,
-            },
-          ],
-        },
-      ],
-      Stop: [stopEntry(guardedNode(CLAUDE_PLUGIN_HOOK, SYSTEM_MESSAGE_NOTICE))],
-    },
+    hooks: buildClaudeCompatibleHooks(
+      'Edit|Write|MultiEdit',
+      CLAUDE_PLUGIN_HOOK,
+      SYSTEM_MESSAGE_NOTICE,
+    ),
   };
 }
 
@@ -167,22 +167,11 @@ export function buildClaudePluginHooksManifest() {
 // instead of relying on its Claude compatibility alias.
 export function buildCodexPluginHooksManifest() {
   return {
-    hooks: {
-      PostToolUse: [
-        {
-          matcher: 'Edit|Write|apply_patch',
-          hooks: [
-            {
-              type: 'command',
-              command: guardedNode(CODEX_PLUGIN_HOOK, SYSTEM_MESSAGE_NOTICE),
-              timeout: TIMEOUT_SECONDS,
-              statusMessage: STATUS_MESSAGE,
-            },
-          ],
-        },
-      ],
-      Stop: [stopEntry(guardedNode(CODEX_PLUGIN_HOOK, SYSTEM_MESSAGE_NOTICE))],
-    },
+    hooks: buildClaudeCompatibleHooks(
+      'Edit|Write|apply_patch',
+      CODEX_PLUGIN_HOOK,
+      SYSTEM_MESSAGE_NOTICE,
+    ),
   };
 }
 
@@ -192,22 +181,11 @@ export function buildCodexPluginHooksManifest() {
 export function buildCodexHooksManifest(skillDir = '.codex') {
   const hookPath = codexProjectHook(skillDir);
   return {
-    hooks: {
-      PostToolUse: [
-        {
-          matcher: 'Edit|Write|apply_patch',
-          hooks: [
-            {
-              type: 'command',
-              command: guardedNode(hookPath, SYSTEM_MESSAGE_NOTICE),
-              timeout: TIMEOUT_SECONDS,
-              statusMessage: STATUS_MESSAGE,
-            },
-          ],
-        },
-      ],
-      Stop: [stopEntry(guardedNode(hookPath, SYSTEM_MESSAGE_NOTICE))],
-    },
+    hooks: buildClaudeCompatibleHooks(
+      'Edit|Write|apply_patch',
+      hookPath,
+      SYSTEM_MESSAGE_NOTICE,
+    ),
   };
 }
 
@@ -259,22 +237,7 @@ export function buildGitHubHooksManifest() {
 // https://docs.x.ai/build/features/hooks
 export function buildGrokHooksManifest() {
   return {
-    hooks: {
-      PostToolUse: [
-        {
-          matcher: 'Edit|Write|MultiEdit',
-          hooks: [
-            {
-              type: 'command',
-              command: guardedNode(GROK_PROJECT_HOOK),
-              timeout: TIMEOUT_SECONDS,
-              statusMessage: STATUS_MESSAGE,
-            },
-          ],
-        },
-      ],
-      Stop: [stopEntry(guardedNode(GROK_PROJECT_HOOK))],
-    },
+    hooks: buildClaudeCompatibleHooks('Edit|Write|MultiEdit', GROK_PROJECT_HOOK),
   };
 }
 


### PR DESCRIPTION
## Summary

- centralize the Claude-compatible `PostToolUse` + `Stop` hook schema in one private builder
- keep each provider's matcher, hook path, runtime notice policy, timeouts, and public builder unchanged
- avoid a new module or abstraction layer; the provider-specific builders remain the public boundary

## Hindsight architecture review

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No. Five builders hand-assembled the same durable Claude-compatible event schema. The smaller design keeps that schema in one place and leaves only provider policy at each call site.

## Before / after

- primary file: `scripts/lib/transformers/hooks.js`
- source lines: **296 → 259** (37 fewer)
- duplicated Claude-compatible manifest trees: **5 → 1**
- public exports / entry points: **9 → 9**
- files changed: **1**
- public contracts, JSON schemas, CLI output, and error behavior: unchanged

## Validation

- `node --test tests/hook-build.test.mjs` before refactor: 22 passed
- `node --test tests/hook-build.test.mjs` after refactor: 22 passed
- `bun run build`: passed across all 17 provider outputs
- `bun run test`: passed
  - core/detector suites: 381 passed
  - browser/static suites: 141 passed
  - Live suites: 837 passed, 2 provider-backed replays skipped by design
  - framework fixtures: 216 passed
  - plugin loader E2E: 4 passed

The source-first build intentionally omitted tracked generated root harness and `plugin/` churn. Existing exact-output tests confirmed the generated hook manifests still match their builders.

## Risk

Low. The only remaining coupling is intentional: the five providers share the same Claude-compatible event schema. Exact manifest-shape, provider-path, notice, timeout, and generated-artifact assertions cover that boundary.

## Authorization and AI disclosure

This PR was prepared by Codex with AI assistance under maintainer **pbakaus's** standing scheduled architecture-simplification authorization. It is ready for normal review and was not created as a draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure internal deduplication in hook manifest builders with unchanged public exports and test coverage for exact manifest output.
> 
> **Overview**
> Introduces **`buildClaudeCompatibleHooks`** in `hooks.js` so the shared **PostToolUse** + **Stop** Claude-compatible hook shape is built once instead of copied across five providers.
> 
> **Claude** (project + plugin), **Codex** (project + plugin), and **Grok** manifests now call that helper with their existing matcher, hook path, and optional Node runtime notice—timeouts, status messages, and `guardedNode` behavior stay the same. **Cursor** and **GitHub** builders are untouched.
> 
> No new modules or public API changes; generated hook JSON and tests are expected to match byte-for-byte.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e52c2cee83374cf89f14e7381097f8373431eda4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->