### PR TITLE
Add IMPECCABLE_CACHE_ROOT to relocate hook state out of project roots (#422)

### DIFF
--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -210,12 +210,29 @@ export function getLocalConfigPath(cwd) {
   return path.join(cwd, '.impeccable', 'config.local.json');
 }
 
+// Where mutable hook state (cache + pending) lives. Defaults to the
+// project-local `.impeccable/` dir. When IMPECCABLE_CACHE_ROOT is set, state
+// relocates to a per-project subdirectory of that root instead, keyed by a
+// slug of the project path (`[:\\/.]` → `-`, mirroring Claude Code's
+// `~/.claude/projects/` convention), so project roots stay free of tool
+// artifacts (issue #422). User-authored config (config.json,
+// config.local.json, design.json) deliberately stays project-local — only
+// disposable state relocates.
+function hookStateDir(cwd) {
+  const root = process.env.IMPECCABLE_CACHE_ROOT;
+  if (root && typeof root === 'string' && root.trim()) {
+    const slug = String(cwd).replace(/[:\\/.]/g, '-');
+    return path.join(root, slug);
+  }
+  return path.join(cwd, '.impeccable');
+}
+
 export function getCachePath(cwd) {
-  return path.join(cwd, '.impeccable', 'hook.cache.json');
+  return path.join(hookStateDir(cwd), 'hook.cache.json');
 }
 
 export function getPendingPath(cwd) {
-  return path.join(cwd, '.impeccable', 'hook.pending.json');
+  return path.join(hookStateDir(cwd), 'hook.pending.json');
 }
 
 export function resolveProjectCwd(event, fallback = process.cwd()) {

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -43,6 +43,7 @@
  *   `cli/engine/detect-antipatterns.mjs` (running from source).
  */
 
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -220,20 +221,29 @@ export function getLocalConfigPath(cwd) {
 // disposable state relocates.
 // Read from process.env (not runHook's injected env): the cache root is a
 // machine-scoped setting like CURSOR_PROJECT_DIR, not a per-invocation
-// switch. Trim guards against stray whitespace in env files; `~/` expands to
-// the home dir (settings/env files hand it to Node unexpanded — same
-// treatment IMPECCABLE_HOOK_LOG gets in writeAuditLog); resolving both sides
-// makes the slug deterministic when callers hand in a trailing separator or
-// unnormalized cwd.
+// switch. Trim guards against stray whitespace in env files; `~/` (or the
+// Windows `~\` spelling) expands via os.homedir(), and when no home dir can
+// be determined the expansion is rejected — state falls back to the
+// project-local default rather than anchoring under the hook process's cwd.
+// Resolving both sides makes the slug deterministic when callers hand in a
+// trailing separator or unnormalized cwd. The slug is the readable
+// separator-mapped path PLUS an 8-hex sha256 of the resolved path: the
+// readable part alone is lossy (`/x/my.app` and `/x/my-app` would both map
+// to `-x-my-app` and share state), so the digest disambiguates while keeping
+// the dir name human-scannable.
 function hookStateDir(cwd) {
   const raw = process.env.IMPECCABLE_CACHE_ROOT;
   let root = typeof raw === 'string' ? raw.trim() : '';
   if (root.startsWith('~/') || root.startsWith('~\\') || root === '~') {
-    root = path.join(process.env.HOME || process.env.USERPROFILE || '.', root.slice(2));
+    let home = '';
+    try { home = os.homedir() || ''; } catch { home = ''; }
+    root = home ? path.join(home, root.slice(2)) : '';
   }
   if (root) {
-    const slug = path.resolve(String(cwd)).replace(/[:\\/.]/g, '-');
-    return path.join(path.resolve(root), slug);
+    const resolved = path.resolve(String(cwd));
+    const slug = resolved.replace(/[:\\/.]/g, '-');
+    const digest = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 8);
+    return path.join(path.resolve(root), `${slug}-${digest}`);
   }
   return path.join(cwd, '.impeccable');
 }

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -218,11 +218,17 @@ export function getLocalConfigPath(cwd) {
 // artifacts (issue #422). User-authored config (config.json,
 // config.local.json, design.json) deliberately stays project-local — only
 // disposable state relocates.
+// Read from process.env (not runHook's injected env): the cache root is a
+// machine-scoped setting like CURSOR_PROJECT_DIR, not a per-invocation
+// switch. Trim guards against stray whitespace in env files; resolving both
+// sides makes the slug deterministic when callers hand in a trailing
+// separator or unnormalized cwd.
 function hookStateDir(cwd) {
-  const root = process.env.IMPECCABLE_CACHE_ROOT;
-  if (root && typeof root === 'string' && root.trim()) {
-    const slug = String(cwd).replace(/[:\\/.]/g, '-');
-    return path.join(root, slug);
+  const raw = process.env.IMPECCABLE_CACHE_ROOT;
+  const root = typeof raw === 'string' ? raw.trim() : '';
+  if (root) {
+    const slug = path.resolve(String(cwd)).replace(/[:\\/.]/g, '-');
+    return path.join(path.resolve(root), slug);
   }
   return path.join(cwd, '.impeccable');
 }
@@ -2072,8 +2078,13 @@ export async function runHook({ stdinJson, env = {}, cwd = process.cwd(), now = 
     // touched-file list for the Stop deep pass, and an already-present
     // `.impeccable/` dir marks a project that opted in. A non-UI edit, or a
     // clean UI edit in a project with no Impeccable footprint, must be a
-    // no-op on disk (issues #344, #305).
-    if (deferredTotal > 0 || (cacheDirty && fs.existsSync(path.join(projectCwd, '.impeccable')))) {
+    // no-op on disk (issues #344, #305). An existing cache file also counts
+    // as opted in: under IMPECCABLE_CACHE_ROOT (issue #422) state lives
+    // outside the project, so the project dir alone can't carry the marker —
+    // without this, clean-edit editCount bumps would stop persisting the
+    // moment state relocates. Under stock paths the cache sits inside
+    // `.impeccable/`, so the extra check changes nothing there.
+    if (deferredTotal > 0 || (cacheDirty && (fs.existsSync(path.join(projectCwd, '.impeccable')) || fs.existsSync(getCachePath(projectCwd))))) {
       persistCache(projectCwd, cache);
     }
 

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -220,12 +220,17 @@ export function getLocalConfigPath(cwd) {
 // disposable state relocates.
 // Read from process.env (not runHook's injected env): the cache root is a
 // machine-scoped setting like CURSOR_PROJECT_DIR, not a per-invocation
-// switch. Trim guards against stray whitespace in env files; resolving both
-// sides makes the slug deterministic when callers hand in a trailing
-// separator or unnormalized cwd.
+// switch. Trim guards against stray whitespace in env files; `~/` expands to
+// the home dir (settings/env files hand it to Node unexpanded — same
+// treatment IMPECCABLE_HOOK_LOG gets in writeAuditLog); resolving both sides
+// makes the slug deterministic when callers hand in a trailing separator or
+// unnormalized cwd.
 function hookStateDir(cwd) {
   const raw = process.env.IMPECCABLE_CACHE_ROOT;
-  const root = typeof raw === 'string' ? raw.trim() : '';
+  let root = typeof raw === 'string' ? raw.trim() : '';
+  if (root.startsWith('~/') || root.startsWith('~\\') || root === '~') {
+    root = path.join(process.env.HOME || process.env.USERPROFILE || '.', root.slice(2));
+  }
   if (root) {
     const slug = path.resolve(String(cwd)).replace(/[:\\/.]/g, '-');
     return path.join(path.resolve(root), slug);

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -456,11 +456,36 @@ describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
     assert.equal(getPendingPath(cwd), path.join(cacheRoot, slug, 'hook.pending.json'));
   });
 
-  it('slug maps colons, slashes, backslashes, and dots to hyphens', () => {
+  it('slug maps separators, colons, and dots to hyphens', () => {
     process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
-    const cachePath = getCachePath('C:\\work\\my.app/sub');
-    const slugDir = path.basename(path.dirname(cachePath));
-    assert.equal(slugDir, 'C--work-my-app-sub');
+    const proj = path.join(cwd, 'my.app', 'v2');
+    const slugDir = path.basename(path.dirname(getCachePath(proj)));
+    assert.doesNotMatch(slugDir, /[:\\/.]/, 'no path-significant chars survive');
+    assert.ok(slugDir.endsWith('my-app-v2'), `dots and separators map to hyphens (got ${slugDir})`);
+  });
+
+  it('trailing separators and relative segments slug to the same dir', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const canonical = getCachePath(cwd);
+    assert.equal(getCachePath(cwd + path.sep), canonical);
+    assert.equal(getCachePath(path.join(cwd, 'sub', '..')), canonical);
+  });
+
+  it('trims stray whitespace from the env value', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = `  ${cacheRoot}  `;
+    const slug = path.resolve(cwd).replace(/[:\\/.]/g, '-');
+    assert.equal(getCachePath(cwd), path.join(cacheRoot, slug, 'hook.cache.json'));
+  });
+
+  it('persistCache degrades gracefully when the cache root is unusable', () => {
+    // Point the root at an existing FILE so mkdir of the slug dir must fail.
+    const blocker = path.join(cacheRoot, 'not-a-dir');
+    fs.writeFileSync(blocker, 'x');
+    process.env.IMPECCABLE_CACHE_ROOT = blocker;
+    const cache = readCache(cwd);
+    bumpEditCount(cache, 'sid-1', '/x/a.tsx');
+    assert.equal(persistCache(cwd, cache), false, 'returns false instead of throwing');
+    assert.equal(fs.existsSync(path.join(cwd, '.impeccable')), false);
   });
 
   it('config paths stay project-local even when the redirect is active', () => {
@@ -481,6 +506,79 @@ describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
 
     const reloaded = readCache(cwd);
     assert.equal(reloaded.sessions['sid-1'].files['/x/a.tsx'].editCount, 1);
+  });
+
+  function redirectEventFor(file, sessionId = 'redir-sid') {
+    return {
+      session_id: sessionId,
+      cwd,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: file },
+    };
+  }
+
+  function writeProjectFile(rel, body) {
+    const abs = path.join(cwd, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+    return abs;
+  }
+
+  it('runHook end-to-end: findings persist under the redirect root, project root stays clean', async () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const file = writeProjectFile('src/Card.tsx', 'noop');
+    const det = fakeDetector([finding('text-overflow', 1)]);
+
+    const first = await runHook({
+      stdinJson: JSON.stringify(redirectEventFor(file)),
+      env: {}, cwd, detector: det,
+    });
+    assert.match(first.stdout, /Design hook findings requiring review/);
+    assert.equal(fs.existsSync(path.join(cwd, '.impeccable')), false, 'no project-local footprint');
+    assert.equal(fs.existsSync(getCachePath(cwd)), true, 'cache lands under the redirect root');
+
+    // Session dedup still works across runs through the redirected cache.
+    const second = await runHook({
+      stdinJson: JSON.stringify(redirectEventFor(file)),
+      env: {}, cwd, detector: det,
+    });
+    assert.doesNotMatch(second.stdout, /Design hook findings requiring review/);
+    assert.match(second.stdout, /flagged earlier this session/);
+  });
+
+  it('runHook end-to-end: clean edits keep persisting editCount once redirected state exists', async () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const file = writeProjectFile('src/Card.tsx', 'noop');
+
+    // Earn the footprint (in the redirect dir) with a real finding first.
+    await runHook({
+      stdinJson: JSON.stringify(redirectEventFor(file)),
+      env: {}, cwd, detector: fakeDetector([finding('text-overflow', 1)]),
+    });
+    assert.equal(fs.existsSync(getCachePath(cwd)), true);
+
+    // A clean follow-up edit must still persist its editCount bump — the
+    // opted-in check has to see the redirected cache, not just `<cwd>/.impeccable/`.
+    await runHook({
+      stdinJson: JSON.stringify(redirectEventFor(file)),
+      env: {}, cwd, detector: fakeDetector([]),
+    });
+    const cache = readCache(cwd);
+    assert.equal(cache.sessions['redir-sid'].files[file].editCount, 2);
+    assert.equal(fs.existsSync(path.join(cwd, '.impeccable')), false, 'project root still clean');
+  });
+
+  it('runHook end-to-end: a no-footprint clean edit writes nothing anywhere (gates hold under redirect)', async () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const file = writeProjectFile('src/Card.tsx', 'noop');
+    const r = await runHook({
+      stdinJson: JSON.stringify(redirectEventFor(file)),
+      env: {}, cwd, detector: fakeDetector([]),
+    });
+    assert.match(r.stdout, /No deterministic design-quality issues found/);
+    assert.equal(fs.existsSync(path.join(cwd, '.impeccable')), false);
+    assert.equal(fs.existsSync(getCachePath(cwd)), false, 'redirect root also stays empty');
   });
 });
 

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -24,6 +24,8 @@ import {
   truthy,
   getConfigPath,
   getLocalConfigPath,
+  getCachePath,
+  getPendingPath,
   ensureHookGitExcludes,
   readConfig,
   readCache,
@@ -65,6 +67,12 @@ import {
 } from '../skill/scripts/hook-lib.mjs';
 import { normalizeIgnoreValueEntries as normalizeIgnoreValueEntriesCli } from '../cli/lib/impeccable-config.mjs';
 import { detectHtml, detectText } from '../cli/engine/detect-antipatterns.mjs';
+
+// Hook state paths are env-sensitive: an ambient IMPECCABLE_CACHE_ROOT (a
+// developer using the redirect locally) would relocate cache/pending out of
+// the tmp projects and break stock-path assertions. Clear it up front; the
+// dedicated issue-#422 suite sets and restores it explicitly.
+delete process.env.IMPECCABLE_CACHE_ROOT;
 
 function mkTmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-hook-'));
@@ -411,6 +419,68 @@ describe('readCache / persistCache / bumpEditCount', () => {
     assert.equal(Object.keys(reloaded.sessions).length, 8);
     assert.ok(reloaded.sessions['sid-9'], 'newest preserved');
     assert.ok(!reloaded.sessions['sid-0'], 'oldest gc-ed');
+  });
+});
+
+describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
+  let cwd;
+  let cacheRoot;
+  let savedEnv;
+  beforeEach(() => {
+    cwd = mkTmp();
+    cacheRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-cache-root-'));
+    savedEnv = process.env.IMPECCABLE_CACHE_ROOT;
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.IMPECCABLE_CACHE_ROOT;
+    else process.env.IMPECCABLE_CACHE_ROOT = savedEnv;
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+  });
+
+  it('keeps hook state project-local when the env var is unset', () => {
+    delete process.env.IMPECCABLE_CACHE_ROOT;
+    assert.equal(getCachePath(cwd), path.join(cwd, '.impeccable', 'hook.cache.json'));
+    assert.equal(getPendingPath(cwd), path.join(cwd, '.impeccable', 'hook.pending.json'));
+  });
+
+  it('treats a blank env var as unset', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = '   ';
+    assert.equal(getCachePath(cwd), path.join(cwd, '.impeccable', 'hook.cache.json'));
+  });
+
+  it('relocates cache and pending under a per-project slug dir', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const slug = String(cwd).replace(/[:\\/.]/g, '-');
+    assert.equal(getCachePath(cwd), path.join(cacheRoot, slug, 'hook.cache.json'));
+    assert.equal(getPendingPath(cwd), path.join(cacheRoot, slug, 'hook.pending.json'));
+  });
+
+  it('slug maps colons, slashes, backslashes, and dots to hyphens', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const cachePath = getCachePath('C:\\work\\my.app/sub');
+    const slugDir = path.basename(path.dirname(cachePath));
+    assert.equal(slugDir, 'C--work-my-app-sub');
+  });
+
+  it('config paths stay project-local even when the redirect is active', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    assert.equal(getConfigPath(cwd), path.join(cwd, '.impeccable', 'config.json'));
+    assert.equal(getLocalConfigPath(cwd), path.join(cwd, '.impeccable', 'config.local.json'));
+  });
+
+  it('persistCache round-trips through the redirect dir and leaves the project root clean', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const cache = readCache(cwd);
+    bumpEditCount(cache, 'sid-1', '/x/a.tsx');
+    assert.equal(persistCache(cwd, cache), true);
+
+    assert.equal(fs.existsSync(path.join(cwd, '.impeccable')), false, 'project root untouched');
+    const slug = String(cwd).replace(/[:\\/.]/g, '-');
+    assert.equal(fs.existsSync(path.join(cacheRoot, slug, 'hook.cache.json')), true);
+
+    const reloaded = readCache(cwd);
+    assert.equal(reloaded.sessions['sid-1'].files['/x/a.tsx'].editCount, 1);
   });
 });
 

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -494,6 +494,26 @@ describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
     assert.equal(getLocalConfigPath(cwd), path.join(cwd, '.impeccable', 'config.local.json'));
   });
 
+  it('expands a leading ~/ against the home dir, like IMPECCABLE_HOOK_LOG', () => {
+    const savedHome = process.env.HOME;
+    const savedProfile = process.env.USERPROFILE;
+    try {
+      process.env.HOME = cacheRoot;
+      delete process.env.USERPROFILE;
+      process.env.IMPECCABLE_CACHE_ROOT = '~/impeccable-state';
+      const slug = path.resolve(cwd).replace(/[:\\/.]/g, '-');
+      assert.equal(
+        getCachePath(cwd),
+        path.join(cacheRoot, 'impeccable-state', slug, 'hook.cache.json'),
+      );
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      if (savedProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = savedProfile;
+    }
+  });
+
   it('persistCache round-trips through the redirect dir and leaves the project root clean', () => {
     process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
     const cache = readCache(cwd);

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -9,6 +9,7 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -449,19 +450,40 @@ describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
     assert.equal(getCachePath(cwd), path.join(cwd, '.impeccable', 'hook.cache.json'));
   });
 
+  // Mirrors hookStateDir's slug formula: readable separator-mapped path plus
+  // an 8-hex sha256 disambiguator.
+  function slugFor(p) {
+    const resolved = path.resolve(p);
+    const readable = resolved.replace(/[:\\/.]/g, '-');
+    const digest = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 8);
+    return `${readable}-${digest}`;
+  }
+
   it('relocates cache and pending under a per-project slug dir', () => {
     process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
-    const slug = String(cwd).replace(/[:\\/.]/g, '-');
-    assert.equal(getCachePath(cwd), path.join(cacheRoot, slug, 'hook.cache.json'));
-    assert.equal(getPendingPath(cwd), path.join(cacheRoot, slug, 'hook.pending.json'));
+    assert.equal(getCachePath(cwd), path.join(cacheRoot, slugFor(cwd), 'hook.cache.json'));
+    assert.equal(getPendingPath(cwd), path.join(cacheRoot, slugFor(cwd), 'hook.pending.json'));
   });
 
-  it('slug maps separators, colons, and dots to hyphens', () => {
+  it('slug maps separators, colons, and dots to hyphens, with a digest suffix', () => {
     process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
     const proj = path.join(cwd, 'my.app', 'v2');
     const slugDir = path.basename(path.dirname(getCachePath(proj)));
     assert.doesNotMatch(slugDir, /[:\\/.]/, 'no path-significant chars survive');
-    assert.ok(slugDir.endsWith('my-app-v2'), `dots and separators map to hyphens (got ${slugDir})`);
+    assert.match(slugDir, /my-app-v2-[0-9a-f]{8}$/, `readable slug + 8-hex digest (got ${slugDir})`);
+  });
+
+  it('distinct projects whose readable slugs collide get distinct state dirs', () => {
+    process.env.IMPECCABLE_CACHE_ROOT = cacheRoot;
+    const dotted = path.join(cwd, 'my.app');
+    const dashed = path.join(cwd, 'my-app');
+    // Readable part is identical for both...
+    assert.equal(
+      path.resolve(dotted).replace(/[:\\/.]/g, '-'),
+      path.resolve(dashed).replace(/[:\\/.]/g, '-'),
+    );
+    // ...but the digest keeps their hook state apart.
+    assert.notEqual(path.dirname(getCachePath(dotted)), path.dirname(getCachePath(dashed)));
   });
 
   it('trailing separators and relative segments slug to the same dir', () => {
@@ -473,8 +495,7 @@ describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
 
   it('trims stray whitespace from the env value', () => {
     process.env.IMPECCABLE_CACHE_ROOT = `  ${cacheRoot}  `;
-    const slug = path.resolve(cwd).replace(/[:\\/.]/g, '-');
-    assert.equal(getCachePath(cwd), path.join(cacheRoot, slug, 'hook.cache.json'));
+    assert.equal(getCachePath(cwd), path.join(cacheRoot, slugFor(cwd), 'hook.cache.json'));
   });
 
   it('persistCache degrades gracefully when the cache root is unusable', () => {
@@ -494,24 +515,14 @@ describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
     assert.equal(getLocalConfigPath(cwd), path.join(cwd, '.impeccable', 'config.local.json'));
   });
 
-  it('expands a leading ~/ against the home dir, like IMPECCABLE_HOOK_LOG', () => {
-    const savedHome = process.env.HOME;
-    const savedProfile = process.env.USERPROFILE;
-    try {
-      process.env.HOME = cacheRoot;
-      delete process.env.USERPROFILE;
-      process.env.IMPECCABLE_CACHE_ROOT = '~/impeccable-state';
-      const slug = path.resolve(cwd).replace(/[:\\/.]/g, '-');
-      assert.equal(
-        getCachePath(cwd),
-        path.join(cacheRoot, 'impeccable-state', slug, 'hook.cache.json'),
-      );
-    } finally {
-      if (savedHome === undefined) delete process.env.HOME;
-      else process.env.HOME = savedHome;
-      if (savedProfile === undefined) delete process.env.USERPROFILE;
-      else process.env.USERPROFILE = savedProfile;
-    }
+  it('expands a leading ~/ against os.homedir()', () => {
+    // Property check without duplicating the expansion: the tilde form must
+    // resolve identically to the explicit homedir-joined form.
+    process.env.IMPECCABLE_CACHE_ROOT = path.join(os.homedir(), 'impeccable-state');
+    const explicit = getCachePath(cwd);
+    process.env.IMPECCABLE_CACHE_ROOT = '~/impeccable-state';
+    assert.equal(getCachePath(cwd), explicit);
+    assert.ok(explicit.startsWith(os.homedir()), 'anchored under the home dir');
   });
 
   it('persistCache round-trips through the redirect dir and leaves the project root clean', () => {
@@ -521,8 +532,7 @@ describe('IMPECCABLE_CACHE_ROOT relocates hook state (issue #422)', () => {
     assert.equal(persistCache(cwd, cache), true);
 
     assert.equal(fs.existsSync(path.join(cwd, '.impeccable')), false, 'project root untouched');
-    const slug = String(cwd).replace(/[:\\/.]/g, '-');
-    assert.equal(fs.existsSync(path.join(cacheRoot, slug, 'hook.cache.json')), true);
+    assert.equal(fs.existsSync(path.join(cacheRoot, slugFor(cwd), 'hook.cache.json')), true);
 
     const reloaded = readCache(cwd);
     assert.equal(reloaded.sessions['sid-1'].files['/x/a.tsx'].editCount, 1);


### PR DESCRIPTION
Implements #422 (maintainer-approved).

## What changed

`getCachePath()` / `getPendingPath()` in `skill/scripts/hook-lib.mjs` now route through a shared `hookStateDir(cwd)` helper. When the optional `IMPECCABLE_CACHE_ROOT` env var is set, hook state lands under a per-project subdirectory of that root instead of `<project>/.impeccable/`:

```
$IMPECCABLE_CACHE_ROOT/<project-slug>/hook.cache.json
$IMPECCABLE_CACHE_ROOT/<project-slug>/hook.pending.json
```

The slug maps `[:\\/.]` to hyphens, mirroring Claude Code's `~/.claude/projects/` convention. Unset or blank env = stock behavior, byte-for-byte. Per the issue's scope, user-authored config (`config.json`, `config.local.json`, `design.json`) deliberately stays project-local — only disposable state relocates. `ensureHookGitExcludes()` is untouched since it still usefully covers `config.local.json`.

Because every consumer (persist, read, admin reset) already goes through the two getters, the redirect needs no other call-site changes; `persistCache` already creates the target's parent dir.

**Interaction with the #344/#305 persist gate.** The "project opted in" check was `fs.existsSync(<project>/.impeccable)`. Under the redirect that dir never appears, so once findings created state in the cache root, clean-edit `editCount` bumps silently stopped persisting. The gate now also treats an existing cache file (via `getCachePath()`) as the opt-in marker — a no-op under stock paths, where the cache file lives inside `.impeccable/`. Covered by an end-to-end test.

**Robustness details.** The env value is trimmed (stray whitespace in env files), and a leading `~/` (or Windows `~\`) expands against the home dir — mirroring the treatment `IMPECCABLE_HOOK_LOG` already gets in `writeAuditLog`, since settings/env files hand the value to Node unexpanded. Both the root and the cwd are `path.resolve()`d before slugging, so trailing separators and relative segments (`sub/..`) map to the same per-project dir. An unusable root (e.g. pointing at a file) degrades gracefully: `persistCache` returns `false`, nothing throws, and nothing is written into the project. The var is read from `process.env` rather than `runHook`'s injected env because it is a machine-scoped setting (same treatment as `CURSOR_PROJECT_DIR`), not a per-invocation switch.

Known property, inherited deliberately from the `~/.claude/projects/` convention: distinct paths can slug identically (`/x/my.app` and `/x/my-app` both → `-x-my-app`). Theoretical in practice, and cache contents are keyed per session/file, so a collision degrades to shared dedup state, not corruption.

## Tests

New suite in `tests/hook.test.mjs` ("IMPECCABLE_CACHE_ROOT relocates hook state"), 13 subtests: unset/blank env keeps stock paths; redirect lands under the slug dir; slug character mapping; normalization equivalences (trailing separator, `sub/..`); whitespace trim; `~/` home expansion; config paths unaffected; graceful `persistCache` failure on an unusable root; a `persistCache` round-trip asserting the project root stays clean; and three `runHook` end-to-end cases — findings persist + session dedup through the redirected cache, clean-edit `editCount` persistence once redirected state exists, and the no-footprint clean edit still writing nothing anywhere (the #344/#305 gates hold under redirect).

The file also now clears ambient `IMPECCABLE_CACHE_ROOT` at the top, so a developer running the suite with the redirect active still gets deterministic stock-path assertions (the new suite sets/restores the var explicitly).

## Validation

- `node --test tests/hook.test.mjs` — all 13 new subtests pass; no new failures vs a stock checkout on this machine (6 pre-existing local failures on Windows, identical before/after: hook-admin, renderTemplate, parseApplyPatchPaths, resolveTargetFiles, Cursor hook scripts).
- `node --test tests/live-server.test.mjs` — identical pass/fail before/after (74/20 on this Windows machine).
- Behaviorally verified for ~3 weeks as a local patch on the installed plugin: state lands in a central cache dir, project roots stay clean, and a plugin update reverting to stock degrades harmlessly.

Generated provider output intentionally omitted per the source-first policy — `skill/scripts/hook-lib.mjs` and `tests/hook.test.mjs` only. No manifest or changelog changes.

*Prepared with AI assistance under direction of @0xDarkMatter (see #422).*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is opt-in via env var with unchanged defaults; changes are localized to hook state paths and persist gating, with broad test coverage.
> 
> **Overview**
> **Optional `IMPECCABLE_CACHE_ROOT`** moves disposable hook state (`hook.cache.json`, `hook.pending.json`) out of `<project>/.impeccable/` into `$IMPECCABLE_CACHE_ROOT/<slug>-<8hex>/`, where the slug is derived from the resolved project path (with a short SHA-256 suffix to avoid collisions). Unset or blank env keeps today’s project-local layout; user config files stay under `.impeccable/` in the repo.
> 
> **Persist gate fix:** when state is redirected, the “project opted in” check for writing cache updates now also treats an existing cache file (via `getCachePath`) as opted in, so clean-edit `editCount` bumps still persist without a project-local `.impeccable/` folder.
> 
> **Tests:** `tests/hook.test.mjs` clears ambient `IMPECCABLE_CACHE_ROOT` for stock-path tests and adds a dedicated suite covering slug rules, `~/` expansion, graceful persist failure, config path locality, and `runHook` end-to-end under redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc685bbf2d8caa67f0fb37b4ec273504d8d9e9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->