### PR TITLE
Bump skill-behavior test lineup: gemini-3.7-flash

### DIFF
--- a/tests/skill-behavior/README.md
+++ b/tests/skill-behavior/README.md
@@ -90,8 +90,8 @@ Against the current default lineup, two cells are the known floor:
 `redesign replaces DESIGN` is flaky on every model, and `critique closes` is
 flaky on gemini-3.6-flash. A regression is a failure beyond those two.
 
-The google slot in `DEFAULT_MODELS` moved to `gemini-3.7-flash` on 2026-08-15.
-Every gemini cell in the tables below was measured on 3.6-flash (or 3.5-flash
+The Google slot in `DEFAULT_MODELS` moved to `gemini-3.7-flash` on 2026-08-15.
+Every Gemini cell in the tables below was measured on 3.6-flash (or 3.5-flash
 where marked), and per the cross-version rule further down, those results are
 unmeasured on 3.7, not inherited. Re-run the sweep on the next Setup or routing
 change and update the tables to the new column.

--- a/tests/skill-behavior/README.md
+++ b/tests/skill-behavior/README.md
@@ -90,6 +90,12 @@ Against the current default lineup, two cells are the known floor:
 `redesign replaces DESIGN` is flaky on every model, and `critique closes` is
 flaky on gemini-3.6-flash. A regression is a failure beyond those two.
 
+The google slot in `DEFAULT_MODELS` moved to `gemini-3.7-flash` on 2026-08-15.
+Every gemini cell in the tables below was measured on 3.6-flash (or 3.5-flash
+where marked), and per the cross-version rule further down, those results are
+unmeasured on 3.7, not inherited. Re-run the sweep on the next Setup or routing
+change and update the tables to the new column.
+
 **Read any failure against the clock before calling it behavior.** The suite ran
 at a 300s per-test timeout until 2026-08-13, and for the workflow-contract
 scenarios that cap was below the runtime of a correct run. `initialized natural

--- a/tests/skill-behavior/providers.mjs
+++ b/tests/skill-behavior/providers.mjs
@@ -127,7 +127,7 @@ export function getProviderOptions(modelId) {
  * its own floor:
  *   IMPECCABLE_SKILL_BEHAVIOR_MODELS=gpt-5.6-luna,deepseek-v4-flash
  */
-export const DEFAULT_MODELS = ['claude-sonnet-5', 'gpt-5.6-terra', 'gemini-3.6-flash'];
+export const DEFAULT_MODELS = ['claude-sonnet-5', 'gpt-5.6-terra', 'gemini-3.7-flash'];
 
 export function resolveModelList() {
   const override = process.env.IMPECCABLE_SKILL_BEHAVIOR_MODELS;


### PR DESCRIPTION
Test lineup bump only, source-only, no version bump.

- `tests/skill-behavior/providers.mjs`: the google slot in `DEFAULT_MODELS` moves from `gemini-3.6-flash` to the newly released `gemini-3.7-flash`.
- `tests/skill-behavior/README.md`: notes that the recorded gemini baseline cells were measured on 3.6-flash (or 3.5-flash where marked) and, per the suite's own cross-version rule, count as unmeasured on 3.7 rather than inherited. The sweep should be re-run on the next Setup or routing change and the tables updated.

No paid suite run was performed for this bump; the suite is opt-in and billed per run.

AI-assisted: prepared by Claude (Fable 5) on maintainer instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only default model swap and documentation; no production or skill routing changes.
> 
> **Overview**
> Updates the opt-in skill-behavior suite so the **Google slot in `DEFAULT_MODELS`** runs **`gemini-3.7-flash`** instead of **`gemini-3.6-flash`**.
> 
> The README now states that existing Gemini baseline table cells were measured on 3.6 (or 3.5 where noted) and, under the suite’s cross-version rule, **do not carry over to 3.7** until the next sweep after Setup or routing changes. No scenario logic or skill text changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60160786b57c8493feed9cf96ec775539465eadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->