### PR TITLE
Centralize surface route normalization

### DIFF
--- a/skill/scripts/lib/surface-briefs.mjs
+++ b/skill/scripts/lib/surface-briefs.mjs
@@ -8,6 +8,12 @@ export function getSurfaceBriefDir(projectRoot) {
   return path.join(projectRoot, '.impeccable', 'surfaces');
 }
 
+function normalizeRouteTarget(route) {
+  if (!route.startsWith('/') || route.includes('..')) return null;
+  const normalized = route.split(/[?#]/, 1)[0].replace(/\/{2,}/g, '/').replace(/\/$/, '') || '/';
+  return `route:${normalized}`;
+}
+
 export function normalizeSurfaceTarget(target, { projectRoot = process.cwd() } = {}) {
   if (!target || typeof target !== 'string' || !target.trim()) return null;
   const trimmed = target.trim();
@@ -21,21 +27,13 @@ export function normalizeSurfaceTarget(target, { projectRoot = process.cwd() } =
       return null;
     }
   }
-  if (/^route:/i.test(trimmed)) {
-    const route = trimmed.slice(trimmed.indexOf(':') + 1).trim();
-    if (!route.startsWith('/') || route.includes('..')) return null;
-    const normalizedRoute = route.split(/[?#]/, 1)[0].replace(/\/{2,}/g, '/').replace(/\/$/, '') || '/';
-    return `route:${normalizedRoute}`;
-  }
-  if (trimmed === '/') return 'route:/';
+  if (/^route:/i.test(trimmed)) return normalizeRouteTarget(trimmed.slice(trimmed.indexOf(':') + 1).trim());
+  if (trimmed === '/') return normalizeRouteTarget(trimmed);
   if (trimmed.startsWith('/')) {
     const absolute = path.resolve(trimmed);
     const relativeToProject = path.relative(projectRoot, absolute);
     const isProjectFile = relativeToProject && !relativeToProject.startsWith('..') && !path.isAbsolute(relativeToProject);
-    if (!isProjectFile && !fs.existsSync(absolute) && !trimmed.includes('..')) {
-      const normalizedRoute = trimmed.split(/[?#]/, 1)[0].replace(/\/{2,}/g, '/').replace(/\/$/, '') || '/';
-      return `route:${normalizedRoute}`;
-    }
+    if (!isProjectFile && !fs.existsSync(absolute)) return normalizeRouteTarget(trimmed);
   }
   const abs = path.isAbsolute(trimmed) ? trimmed : path.resolve(projectRoot, trimmed);
   const rel = path.relative(projectRoot, abs);

--- a/tests/surface-brief.test.mjs
+++ b/tests/surface-brief.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import {
   listSurfaceBriefs,
+  normalizeSurfaceTarget,
   resolveSurfaceBrief,
   writeSurfaceBrief,
 } from '../skill/scripts/lib/surface-briefs.mjs';
@@ -67,6 +68,13 @@ describe('surface briefs', () => {
     const result = resolveSurfaceBrief(cwd, 'route:/pricing');
     assert.equal(result.reason, 'slug');
     assert.equal(result.brief?.primaryTarget, 'route:/pricing');
+  });
+
+  it('canonicalizes explicit and inferred route identifiers consistently', () => {
+    assert.equal(normalizeSurfaceTarget('route:/docs//intro/?from=nav#top', { projectRoot: cwd }), 'route:/docs/intro');
+    assert.equal(normalizeSurfaceTarget('/docs//intro/?from=nav#top', { projectRoot: cwd }), 'route:/docs/intro');
+    assert.equal(normalizeSurfaceTarget('route:/docs/../admin', { projectRoot: cwd }), null);
+    assert.equal(normalizeSurfaceTarget('/docs/../admin', { projectRoot: cwd }), null);
   });
 
   it('supports the root route even though the filesystem root exists', () => {


### PR DESCRIPTION
## Summary
- centralize route validation and canonicalization for explicit route identifiers and inferred absolute-style routes
- preserve existing surface-brief paths, frontmatter, resolution reasons, and public exports
- characterize equivalent query-bearing, repeated-slash, traversal, and root-route inputs

## Hindsight judgment
Hindsight is 20/20: if these requirements were implemented today, the two accepted route input forms should delegate to one durable normalization rule. The prior implementation duplicated query stripping, slash collapsing, trailing-slash handling, and traversal validation across branches. This change introduces one private helper and keeps file and URL handling separate.

## Before / after
- Primary file: 151 lines to 149 lines
- Route canonicalization implementations: 2 to 1
- Public exports and entry points: unchanged
- Responsibilities: unchanged; normalizeSurfaceTarget still classifies URL, route, and project-file targets, while the private helper now owns route syntax
- Total production source touched: one file, net minus 2 lines

## Validation
- node --test tests/surface-brief.test.mjs: 6 passed
- node --test tests/context.test.mjs tests/staleness.test.mjs: 164 passed
- bun run build: passed
- bun run test: passed, including core, detector/browser, Live, framework, and plugin E2E suites

## Delivery notes
AI assistance: OpenAI Codex prepared this PR under pbakaus scheduled architecture-simplification authorization.

Generated provider output was intentionally omitted; the source-first build completed without tracked generated churn.

Remaining risk is low and limited to route classification edge cases. Characterization covers both accepted forms and traversal rejection, and the full suite is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of route classification with characterization tests; public exports and brief paths are unchanged.
> 
> **Overview**
> **Route targets** (`route:/…` and absolute paths that are not project files) now share one private `normalizeRouteTarget` helper instead of duplicating query/hash stripping, slash collapsing, trailing-slash trimming, and `..` rejection in two branches of `normalizeSurfaceTarget`.
> 
> Explicit `route:` inputs, bare `/`, and inferred routes when the path is not a resolvable project file all delegate to that helper. The extra `!trimmed.includes('..')` guard on the inferred-route branch is dropped because traversal is rejected inside the helper.
> 
> A new test asserts that equivalent messy inputs (`route:/docs//intro/?from=nav#top` vs `/docs//intro/…`) canonicalize to `route:/docs/intro`, and that `..` segments return `null` for both forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f793678f2e3259ec4402f846cf8b6cfe486131c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->