### PR TITLE
Lock down the scroll-clip case for text-occlusion

### DIFF
--- a/tests/fixtures/antipatterns/text-occlusion.html
+++ b/tests/fixtures/antipatterns/text-occlusion.html
@@ -47,9 +47,33 @@
   .pass-scrubber-input { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; z-index: 5; margin: 0; }
   .pass-fixedbar { position: fixed; left: 0; right: 0; bottom: 0; height: 40px; background: #b22;
     color: #fff; display: flex; align-items: center; padding: 0 16px; }
+  /* ── PASS: text clipped by a scroll region, with an opaque bar right below it ──
+     getBoundingClientRect reports where a box would be if nothing cut it off, so
+     the lines that have scrolled past this panel's bottom edge still report
+     their full rects, and those rects land on the bar. Nothing overlaps: those
+     lines are clipped away, and scrolling brings them into the panel rather than
+     out from under anything. Any sticky footer or toolbar under a scroll region
+     has this shape, which is why it has to probe only where the text paints. */
+  .pass-scrollbox { width: 420px; height: 90px; overflow-y: auto;
+    background: #fff; border: 1px solid #ccd; }
+  .pass-scrollbox p { margin: 0 0 10px; padding: 0 12px; font-size: 16px; color: #222; }
+  .pass-scrollbox p:first-child { padding-top: 12px; }
+  .pass-underbar { width: 420px; height: 64px; background: #223; color: #fff;
+    display: flex; align-items: center; padding: 0 12px; font-size: 16px; }
 </style>
 </head>
 <body>
+  <!-- First in the document on purpose: the probe only samples text in the
+       first viewport, and this case is about geometry rather than about where
+       on the page it sits. -->
+  <div class="pass-scrollbox">
+    <p>Palette and material, warm cream ground with hairline sepia rules</p>
+    <p>Type and composition, engraved italic names over small-caps labels</p>
+    <p>Topology and navigation, move by life stage rather than by index</p>
+    <p>Controls and state, align and overlay and compare and annotate</p>
+  </div>
+  <div class="pass-underbar">Scrolled-out lines report rects that land here</div>
+
   <section>
     <div class="flag-box-wrap">
       <p class="flag-box-text">Root cause identified in four minutes</p>


### PR DESCRIPTION
Adds the regression fixture for the `paintedRect` clamp that landed in 9d2b0556 without one.

## The shape

`text-occlusion` probes with `elementFromPoint`, which is the right call — it hit-tests the real painted stack. The bug was where the probe coordinates came from: `getBoundingClientRect()` reports where a box *would* be if nothing clipped it. Text half-scrolled out of a panel still reports its full height, so the clipped part's coordinates land wherever the page continues below, and the probe finds whatever genuinely is painted there.

Any sticky footer or toolbar beneath a scroll region produces this. It is also the shape most likely to be waved off as noise, which costs the rule its credibility on the findings that are real.

## What this adds

A pass case in `text-occlusion.html`: a 90px scroll region holding four paragraphs, with an opaque bar directly beneath it. The two paragraphs below the fold report rects that land squarely on the bar.

It sits first in the document because the probe only samples text in the first viewport, and this case is about geometry rather than about where on the page it lives.

## Verification

Red then green, both measured rather than assumed:

- with `checks.mjs` and the browser bundle reverted to `main`'s version, the fixture produces a fourth finding and the `expected exactly 3 text-occlusion findings` assertion fails
- with the clamp in place, the count holds at three

Full suites: `detect-antipatterns-browser` + `detect-antipatterns-fixtures` 113 pass / 0 fail, `detect-antipatterns.test.js` 355 pass / 0 fail.

## Base

Targets `feat/comp-fidelity` rather than `main`, because that is where the clamp lives — the test would fail on `main`. No code change here, only the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> HTML fixture-only change for antipattern regression coverage; no runtime logic modified in this PR.
> 
> **Overview**
> Adds a **pass** regression scenario to `text-occlusion.html` for clipped text in a scroll panel with an opaque bar directly underneath.
> 
> The fixture is a 90px `overflow-y: auto` box (four paragraphs) plus a dark bar below it. Off-screen lines still report full `getBoundingClientRect()` coordinates on the bar even though they are not painted—matching sticky footers/toolbars under scroll regions. With the `paintedRect` clamp on the target branch, this must **not** count as occlusion (fixture stays at three flags).
> 
> The scroll case is placed **first in the document** so it sits in the first viewport, where the rule samples text. **No production or test-runner code changes** in this diff—fixture and comments only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f1a47c5a13bf9865e658580aaba06148df1532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->