### PR TITLE
Fix Windows Claude hook migration dedupe

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -1534,7 +1534,8 @@ function hookInstalledForProvider(root, provider) {
 
 function valueHasImpeccableHookMarker(value) {
   if (typeof value === 'string') {
-    return IMPECCABLE_HOOK_COMMAND_MARKERS.some(marker => value.includes(marker));
+    const normalized = value.replace(/\\/g, '/');
+    return IMPECCABLE_HOOK_COMMAND_MARKERS.some(marker => normalized.includes(marker));
   }
   if (Array.isArray(value)) return value.some(valueHasImpeccableHookMarker);
   if (value && typeof value === 'object') {

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -1649,6 +1649,35 @@ describe('hook manifest merge helpers', () => {
       'node .cursor/skills/impeccable/scripts/hook-before-edit.mjs',
     ]);
   });
+
+  test('mergeHookManifests replaces legacy Windows-path Claude hooks (#604)', () => {
+    const legacyPath = 'C:\\Users\\alice\\.claude\\skills\\impeccable\\scripts\\hook.mjs';
+    const legacyCommand = `[ ! -f "${legacyPath}" ] || node "${legacyPath}"`;
+    const freshCommand = `node -e "guard" "${legacyPath}"`;
+    const merged = mergeHookManifests(
+      {
+        hooks: {
+          PostToolUse: [{ matcher: 'Edit|Write|MultiEdit', hooks: [
+            { type: 'command', command: legacyCommand },
+          ] }],
+          Stop: [{ hooks: [{ type: 'command', command: legacyCommand }] }],
+        },
+      },
+      {
+        hooks: {
+          PostToolUse: [{ matcher: 'Edit|Write|MultiEdit', hooks: [
+            { type: 'command', command: freshCommand },
+          ] }],
+          Stop: [{ hooks: [{ type: 'command', command: freshCommand }] }],
+        },
+      },
+    );
+
+    expect(merged.hooks.PostToolUse).toHaveLength(1);
+    expect(merged.hooks.Stop).toHaveLength(1);
+    expect(merged.hooks.PostToolUse[0].hooks[0].command).toBe(freshCommand);
+    expect(merged.hooks.Stop[0].hooks[0].command).toBe(freshCommand);
+  });
 });
 
 // ─── Hook command path resolution (issue #399, part 1) ───────────────────────


### PR DESCRIPTION
Closes #604.

## Summary

- normalize hook-command path separators before identifying Impeccable-owned entries
- replace legacy Windows backslash-path `PostToolUse` and `Stop` hook groups during update instead of appending duplicates
- preserve unrelated third-party hook entries

## Validation

- `bun test tests/skills-cli.test.js --test-name-pattern "hook manifest merge helpers"` — 2 passed
- `bun test tests/skills-cli.test.js` — 83 passed, 8 skipped
- `bun run test:cli-remote-e2e` — 87 passed
- `bun run build` — passed
- `bun run test` — passed
- `git diff --check` — passed

Generated provider and root harness output was intentionally omitted per the repository source-first policy.

## AI assistance disclosure

This fix, regression test, and PR description were prepared with AI assistance from Codex under explicit maintainer authorization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to hook-manifest string matching on update/install merge; behavior on POSIX paths is unchanged and a regression test guards the Windows case.
> 
> **Overview**
> Fixes **duplicate Claude `PostToolUse` / `Stop` hooks** after `impeccable skills update` on Windows when settings still reference legacy absolute paths with `\` separators (#604).
> 
> **`valueHasImpeccableHookMarker`** now normalizes `\` to `/` before matching `IMPECCABLE_HOOK_COMMAND_MARKERS`, so existing Windows-style hook commands are recognized as Impeccable-owned. **`mergeHookManifests`** can strip those entries via **`stripImpeccableHookEntries`** and apply the fresh manifest instead of appending a second copy. Third-party hook commands are unchanged.
> 
> A regression test covers legacy `C:\Users\...\hook.mjs` commands merging to a single updated group per event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 665c51b9036d8266ae250635093688156476252c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->