### PR TITLE
Fix Codex Stop hook output

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -1424,8 +1424,11 @@ function shSingleQuote(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`;
 }
 
-function windowsHookCommand(quotedPath) {
-  return `if exist ${quotedPath} (node ${quotedPath} & exit /b)`;
+function windowsHookCommand(quotedPath, provider) {
+  const harnessEnv = provider === '.agents'
+    ? 'set "IMPECCABLE_HOOK_HARNESS=codex" & '
+    : '';
+  return `if exist ${quotedPath} (${harnessEnv}node ${quotedPath} & exit /b)`;
 }
 
 // `quotedPath` carries one pre-quoted form per target shell: { posix, win32 }.
@@ -1435,7 +1438,8 @@ function guardHookCommand(quotedPath, provider) {
   if (provider !== '.agents' && process.platform === 'win32') {
     return `node -e "${WIN32_HOOK_GUARD_SCRIPT}" ${quotedPath.win32}`;
   }
-  return `[ ! -f ${quotedPath.posix} ] || node ${quotedPath.posix}`;
+  const harnessEnv = provider === '.agents' ? 'IMPECCABLE_HOOK_HARNESS=codex ' : '';
+  return `[ ! -f ${quotedPath.posix} ] || ${harnessEnv}node ${quotedPath.posix}`;
 }
 
 // Transform bundled hook commands for the actual install target:
@@ -1480,7 +1484,7 @@ function rewriteHookCommandsForSkillRoot(value, provider, { skillRoot, absolute 
       next[key] = rewriteHookCommandsForSkillRoot(child, provider, { skillRoot, absolute });
     }
     if (provider === '.agents' && typeof value.command === 'string' && valueHasImpeccableHookMarker(value.command)) {
-      next.commandWindows = windowsHookCommand(quotedPath.win32);
+      next.commandWindows = windowsHookCommand(quotedPath.win32, provider);
     }
     return next;
   }

--- a/scripts/lib/transformers/hooks.js
+++ b/scripts/lib/transformers/hooks.js
@@ -80,15 +80,16 @@ const NODE_MAJOR_FLOOR = 22;
 // a machine that had a supported one (volta-cli/volta#1791). Newlines break the
 // same way, so this payload also has to stay on one line.
 const NODE_PROBE = `node -e "process.exit(Math.min(parseInt(process.versions.node,10),${NODE_MAJOR_FLOOR})===${NODE_MAJOR_FLOOR}?0:1)" 2>/dev/null`;
-const guardedNode = (hookPath, notice = '') => {
+const guardedNode = (hookPath, notice = '', harness = '') => {
   const probe = notice
     ? `! { ${NODE_PROBE} || { ${notice}; exit 0; }; }`
     : `! ${NODE_PROBE}`;
-  return `[ ! -f "${hookPath}" ] || ${probe} || node "${hookPath}"`;
+  const harnessEnv = harness ? `IMPECCABLE_HOOK_HARNESS=${harness} ` : '';
+  return `[ ! -f "${hookPath}" ] || ${probe} || ${harnessEnv}node "${hookPath}"`;
 };
 
-function buildClaudeCompatibleHooks(matcher, hookPath, notice = '') {
-  const command = guardedNode(hookPath, notice);
+function buildClaudeCompatibleHooks(matcher, hookPath, notice = '', harness = '') {
+  const command = guardedNode(hookPath, notice, harness);
   return {
     PostToolUse: [
       {
@@ -171,6 +172,7 @@ export function buildCodexPluginHooksManifest() {
       'Edit|Write|apply_patch',
       CODEX_PLUGIN_HOOK,
       SYSTEM_MESSAGE_NOTICE,
+      'codex',
     ),
   };
 }
@@ -185,6 +187,7 @@ export function buildCodexHooksManifest(skillDir = '.codex') {
       'Edit|Write|apply_patch',
       hookPath,
       SYSTEM_MESSAGE_NOTICE,
+      'codex',
     ),
   };
 }

--- a/skill/scripts/hook-admin.mjs
+++ b/skill/scripts/hook-admin.mjs
@@ -106,14 +106,14 @@ const HOOK_MANIFEST_TARGETS = [
             hooks: [
               {
                 type: 'command',
-                command: 'node ".agents/skills/impeccable/scripts/hook.mjs"',
+                command: 'IMPECCABLE_HOOK_HARNESS=codex node ".agents/skills/impeccable/scripts/hook.mjs"',
                 timeout: TIMEOUT_SECONDS,
                 statusMessage: STATUS_MESSAGE,
               },
             ],
           },
         ],
-        Stop: [stopManifestEntry('node ".agents/skills/impeccable/scripts/hook.mjs"')],
+        Stop: [stopManifestEntry('IMPECCABLE_HOOK_HARNESS=codex node ".agents/skills/impeccable/scripts/hook.mjs"')],
       },
     }),
   },

--- a/skill/scripts/hook-admin.mjs
+++ b/skill/scripts/hook-admin.mjs
@@ -55,12 +55,13 @@ const STATUS_MESSAGE = 'Checking UI changes';
 const STOP_TIMEOUT_SECONDS = 30;
 const STOP_STATUS_MESSAGE = 'Design deep pass';
 
-function stopManifestEntry(command) {
+function stopManifestEntry(command, commandWindows) {
   return {
     hooks: [
       {
         type: 'command',
         command,
+        ...(commandWindows ? { commandWindows } : {}),
         timeout: STOP_TIMEOUT_SECONDS,
         statusMessage: STOP_STATUS_MESSAGE,
       },
@@ -107,13 +108,17 @@ const HOOK_MANIFEST_TARGETS = [
               {
                 type: 'command',
                 command: 'IMPECCABLE_HOOK_HARNESS=codex node ".agents/skills/impeccable/scripts/hook.mjs"',
+                commandWindows: 'set "IMPECCABLE_HOOK_HARNESS=codex" & node ".agents/skills/impeccable/scripts/hook.mjs"',
                 timeout: TIMEOUT_SECONDS,
                 statusMessage: STATUS_MESSAGE,
               },
             ],
           },
         ],
-        Stop: [stopManifestEntry('IMPECCABLE_HOOK_HARNESS=codex node ".agents/skills/impeccable/scripts/hook.mjs"')],
+        Stop: [stopManifestEntry(
+          'IMPECCABLE_HOOK_HARNESS=codex node ".agents/skills/impeccable/scripts/hook.mjs"',
+          'set "IMPECCABLE_HOOK_HARNESS=codex" & node ".agents/skills/impeccable/scripts/hook.mjs"',
+        )],
       },
     }),
   },

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -1251,7 +1251,8 @@ export function resolveHarness(env = {}, event = null) {
   const explicit = env?.IMPECCABLE_HOOK_HARNESS;
   if (explicit === 'cursor') return 'cursor';
   if (explicit === 'github') return 'github';
-  if (explicit === 'claude' || explicit === 'codex') return explicit;
+  if (explicit === 'claude') return 'claude';
+  if (explicit === 'codex') return 'codex';
   // GitHub Copilot's postToolUse event uses camelCase `toolName`/`toolArgs` and
   // has no `tool_name`/`tool_input`. That shape is the discriminator.
   if (event && typeof event === 'object'

--- a/skill/scripts/hook-lib.mjs
+++ b/skill/scripts/hook-lib.mjs
@@ -1251,7 +1251,7 @@ export function resolveHarness(env = {}, event = null) {
   const explicit = env?.IMPECCABLE_HOOK_HARNESS;
   if (explicit === 'cursor') return 'cursor';
   if (explicit === 'github') return 'github';
-  if (explicit === 'claude' || explicit === 'codex') return 'claude';
+  if (explicit === 'claude' || explicit === 'codex') return explicit;
   // GitHub Copilot's postToolUse event uses camelCase `toolName`/`toolArgs` and
   // has no `tool_name`/`tool_input`. That shape is the discriminator.
   if (event && typeof event === 'object'
@@ -2163,8 +2163,8 @@ export const STOP_MAX_FILES = 20;
  *   { exitCode, stdout, audit, emission? }
  *
  * Never throws; exits silent (and fast) when the session touched no UI
- * files. Output uses the Stop hookSpecificOutput channel: additionalContext
- * is delivered to the model and the conversation continues so it can act.
+ * files. Output uses the active harness's Stop continuation channel so the
+ * findings are delivered to the model and the conversation continues.
  */
 export async function runStopHook({ stdinJson, env = {}, cwd = process.cwd(), now = Date.now, detector } = {}) {
   const audit = { ts: new Date(now()).toISOString(), event: 'Stop' };
@@ -2336,6 +2336,11 @@ export function payload(text, eventName = 'PostToolUse', harness = 'claude') {
   // `additionalContext` string (alongside an optional `modifiedResult`).
   if (harness === 'github') {
     return JSON.stringify({ additionalContext: text });
+  }
+  // Codex shares Claude Code's PostToolUse additional-context shape, but its
+  // Stop contract requires a top-level blocking decision and reason.
+  if (harness === 'codex' && eventName === 'Stop') {
+    return JSON.stringify({ decision: 'block', reason: text });
   }
   return JSON.stringify({
     hookSpecificOutput: { hookEventName: eventName, additionalContext: text },

--- a/skill/scripts/hook.mjs
+++ b/skill/scripts/hook.mjs
@@ -10,7 +10,7 @@
  *     `hookSpecificOutput.additionalContext` when findings exist.
  *   - Stop: runs the FULL detector rule set over every UI file touched this
  *     session (the deep pass), deduped against what the per-edit pass already
- *     surfaced, and emits once via the Stop additionalContext channel.
+ *     surfaced, and emits once via the harness-specific continuation channel.
  *
  * Contract: never break a turn. Always exit 0. Clean files emit a small ack
  * unless quiet mode is enabled; a clean Stop pass is silent.

--- a/tests/hook-build.test.mjs
+++ b/tests/hook-build.test.mjs
@@ -43,7 +43,7 @@ function expectCommand(command, expectedPath) {
   // probe. GitHub's portable `$(git rev-parse)` form is guarded too, so it
   // lands in the same branch.
   if (command.startsWith('[ ! -f "')) {
-    assert.match(command, /\|\| node "/);
+    assert.match(command, /\|\| (?:IMPECCABLE_HOOK_HARNESS=codex )?node "/);
     assert.ok(command.includes(NODE_PROBE), `missing runtime probe in ${command}`);
   } else {
     assert.match(command, /^node "|^bash -c|\$\(git rev-parse/);
@@ -103,6 +103,7 @@ describe('hook manifest builders', () => {
     assert.equal(handler.timeout, 5);
     assert.equal(handler.statusMessage, 'Checking UI changes');
     expectCommand(handler.command, '.codex/skills/impeccable/scripts/hook.mjs');
+    assert.ok(handler.command.includes('IMPECCABLE_HOOK_HARNESS=codex'));
     assert.ok(!handler.command.includes('git rev-parse --show-toplevel'));
     assert.ok(!handler.command.includes('${PLUGIN_ROOT}'));
     assert.equal(manifest.hooks.SessionStart, undefined);
@@ -112,6 +113,7 @@ describe('hook manifest builders', () => {
     const stop = manifest.hooks.Stop[0].hooks[0];
     assert.equal(stop.timeout, 30);
     expectCommand(stop.command, '.codex/skills/impeccable/scripts/hook.mjs');
+    assert.ok(stop.command.includes('IMPECCABLE_HOOK_HARNESS=codex'));
   });
 
   it('derives the Codex hook payload path from the install dir', () => {
@@ -222,6 +224,19 @@ describe('hook manifest builders', () => {
     for (const manifest of probeOnly) {
       for (const command of manifestCommands(manifest)) {
         assert.ok(!command.includes('systemMessage'), `unexpected notice in ${command}`);
+      }
+    }
+  });
+
+  it('marks only Codex hook commands with the Codex harness', () => {
+    for (const manifest of [buildCodexHooksManifest(), buildCodexPluginHooksManifest()]) {
+      for (const command of manifestCommands(manifest)) {
+        assert.ok(command.includes('IMPECCABLE_HOOK_HARNESS=codex'));
+      }
+    }
+    for (const manifest of [buildClaudeSettingsManifest(), buildClaudePluginHooksManifest()]) {
+      for (const command of manifestCommands(manifest)) {
+        assert.ok(!command.includes('IMPECCABLE_HOOK_HARNESS=codex'));
       }
     }
   });

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -950,6 +950,7 @@ describe('hook-admin.mjs', () => {
 
     const codex = fs.readFileSync(path.join(cwd, '.codex', 'hooks.json'), 'utf-8');
     assert.match(codex, /\.agents\/skills\/impeccable\/scripts\/hook\.mjs/);
+    assert.equal(codex.split('IMPECCABLE_HOOK_HARNESS=codex').length - 1, 2);
     const cursor = fs.readFileSync(path.join(cwd, '.cursor', 'hooks.json'), 'utf-8');
     assert.match(cursor, /\.cursor\/skills\/impeccable\/scripts\/hook-before-edit\.mjs/);
     const github = JSON.parse(fs.readFileSync(path.join(cwd, '.github', 'hooks', 'impeccable.json'), 'utf-8'));

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -948,9 +948,21 @@ describe('hook-admin.mjs', () => {
     assert.equal(claude.split('skills/impeccable/scripts/hook.mjs').length - 1, 2);
     assert.match(claude, /"Stop"/);
 
-    const codex = fs.readFileSync(path.join(cwd, '.codex', 'hooks.json'), 'utf-8');
-    assert.match(codex, /\.agents\/skills\/impeccable\/scripts\/hook\.mjs/);
-    assert.equal(codex.split('IMPECCABLE_HOOK_HARNESS=codex').length - 1, 2);
+    const codex = JSON.parse(fs.readFileSync(path.join(cwd, '.codex', 'hooks.json'), 'utf-8'));
+    const codexHooks = [
+      codex.hooks.PostToolUse[0].hooks[0],
+      codex.hooks.Stop[0].hooks[0],
+    ];
+    for (const hook of codexHooks) {
+      assert.equal(
+        hook.command,
+        'IMPECCABLE_HOOK_HARNESS=codex node ".agents/skills/impeccable/scripts/hook.mjs"',
+      );
+      assert.equal(
+        hook.commandWindows,
+        'set "IMPECCABLE_HOOK_HARNESS=codex" & node ".agents/skills/impeccable/scripts/hook.mjs"',
+      );
+    }
     const cursor = fs.readFileSync(path.join(cwd, '.cursor', 'hooks.json'), 'utf-8');
     assert.match(cursor, /\.cursor\/skills\/impeccable\/scripts\/hook-before-edit\.mjs/);
     const github = JSON.parse(fs.readFileSync(path.join(cwd, '.github', 'hooks', 'impeccable.json'), 'utf-8'));

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -1360,9 +1360,26 @@ describe('writeAuditLog()', () => {
 });
 
 describe('payload()', () => {
-  it('produces hookSpecificOutput for Claude/Codex', () => {
+  it('produces hookSpecificOutput for Claude PostToolUse', () => {
     const obj = JSON.parse(payload('hello'));
     assert.equal(obj.hookSpecificOutput.hookEventName, 'PostToolUse');
+    assert.equal(obj.hookSpecificOutput.additionalContext, 'hello');
+  });
+
+  it('keeps Codex PostToolUse on the Claude-compatible context channel', () => {
+    const obj = JSON.parse(payload('hello', 'PostToolUse', 'codex'));
+    assert.equal(obj.hookSpecificOutput.hookEventName, 'PostToolUse');
+    assert.equal(obj.hookSpecificOutput.additionalContext, 'hello');
+  });
+
+  it('produces a blocking decision for Codex Stop', () => {
+    const obj = JSON.parse(payload('hello', 'Stop', 'codex'));
+    assert.deepEqual(obj, { decision: 'block', reason: 'hello' });
+  });
+
+  it('keeps Claude Stop on the additional-context channel', () => {
+    const obj = JSON.parse(payload('hello', 'Stop', 'claude'));
+    assert.equal(obj.hookSpecificOutput.hookEventName, 'Stop');
     assert.equal(obj.hookSpecificOutput.additionalContext, 'hello');
   });
 
@@ -2707,6 +2724,7 @@ describe('resolveTargetFiles()', () => {
 describe('resolveHarness() / normalizeHookEvent()', () => {
   it('routes explicit env and Cursor conversation_id to cursor harness', () => {
     assert.equal(resolveHarness({ IMPECCABLE_HOOK_HARNESS: 'cursor' }), 'cursor');
+    assert.equal(resolveHarness({ IMPECCABLE_HOOK_HARNESS: 'codex' }), 'codex');
     assert.equal(resolveHarness({}, { conversation_id: 'c1' }), 'cursor');
     assert.equal(resolveHarness({}), 'claude');
   });
@@ -3811,6 +3829,28 @@ describe('runStopHook()', () => {
     assert.match(out.hookSpecificOutput.additionalContext, /side-tab/);
     assert.doesNotMatch(out.hookSpecificOutput.additionalContext, /dark-glow/);
     assert.equal(stop.emission.kind, 'stop-deep-pass');
+  });
+
+  it('emits Codex Stop findings as a blocking decision', async () => {
+    const sid = 'stop-codex';
+    write('package.json', '{}');
+    const file = write('src/Card.tsx', 'noop');
+    const det = fakeDetector([finding('marketing-buzzword', 3)]);
+    const env = { IMPECCABLE_HOOK_HARNESS: 'codex' };
+
+    const edit = await runHook({ stdinJson: JSON.stringify(editEvent(file, sid)), env, cwd, detector: det });
+    assert.equal(edit.audit.harness, 'codex');
+    assert.equal(edit.audit.cwd, cwd);
+    assert.equal(edit.audit.deferred, 1);
+    const stop = await runStopHook({ stdinJson: JSON.stringify(stopEvent(sid)), env, cwd, detector: det });
+
+    assert.equal(stop.exitCode, 0);
+    assert.equal(stop.audit.harness, 'codex');
+    assert.equal(stop.audit.emitted, true, JSON.stringify(stop.audit));
+    const out = JSON.parse(stop.stdout);
+    assert.equal(out.decision, 'block');
+    assert.match(out.reason, /marketing-buzzword/);
+    assert.equal(out.hookSpecificOutput, undefined);
   });
 
   it('keeps a policy footer when the grouped Stop render is clamped to the minimum budget', async () => {

--- a/tests/openai-plugin.test.mjs
+++ b/tests/openai-plugin.test.mjs
@@ -89,6 +89,8 @@ describe('OpenAI plugin staging', () => {
     assert.equal(manifest.interface.category, 'Creativity');
     assert.deepEqual(hooks, buildCodexPluginHooksManifest());
     assert.match(hooks.hooks.PostToolUse[0].hooks[0].command, /\$\{PLUGIN_ROOT\}/);
+    assert.match(hooks.hooks.PostToolUse[0].hooks[0].command, /IMPECCABLE_HOOK_HARNESS=codex/);
+    assert.match(hooks.hooks.Stop[0].hooks[0].command, /IMPECCABLE_HOOK_HARNESS=codex/);
     assert.doesNotMatch(hooks.hooks.PostToolUse[0].hooks[0].command, /CLAUDE_PLUGIN_ROOT/);
   });
 });

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -101,9 +101,19 @@ function createFakeUniversalBundle(root, providers = ['.claude', '.agents', '.cu
     mkdirSync(join(bundleRoot, '.codex'), { recursive: true });
     // Mirror production: the Codex bundle's `.codex/hooks.json` targets its own
     // `.codex/skills` payload. The CLI installs the skill at `.agents/skills`, so
-    // the installer must rewrite this command to `.agents/skills` (see below).
+    // the installer must rewrite this command to `.agents/skills` while retaining
+    // the explicit Codex harness selector (see below).
     writeFileSync(join(bundleRoot, '.codex', 'hooks.json'), JSON.stringify({
-      hooks: { PostToolUse: [{ matcher: 'apply_patch', hooks: [{ type: 'command', command: 'node ".codex/skills/impeccable/scripts/hook.mjs"' }] }] },
+      hooks: {
+        PostToolUse: [{ matcher: 'apply_patch', hooks: [{
+          type: 'command',
+          command: 'IMPECCABLE_HOOK_HARNESS=codex node ".codex/skills/impeccable/scripts/hook.mjs"',
+        }] }],
+        Stop: [{ hooks: [{
+          type: 'command',
+          command: 'IMPECCABLE_HOOK_HARNESS=codex node ".codex/skills/impeccable/scripts/hook.mjs"',
+        }] }],
+      },
     }, null, 2));
   }
   // Native subagent definitions, mirroring the build's provider agents output.
@@ -120,6 +130,19 @@ function createFakeUniversalBundle(root, providers = ['.claude', '.agents', '.cu
       '---\nname: impeccable-finish-reviewer\ndescription: Reviews a finished build.\nmodel: inherit\nreadonly: true\nis_background: false\n---\nCursor reviewer body.\n');
   }
   return bundleRoot;
+}
+
+function expectCodexHookCommands(manifestPath, expectedSkillPath) {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const handlers = Object.values(manifest.hooks).flatMap(entries =>
+    entries.flatMap(entry => entry.hooks || []));
+  expect(handlers.length).toBeGreaterThan(0);
+  for (const handler of handlers) {
+    expect(handler.command).toContain('IMPECCABLE_HOOK_HARNESS=codex');
+    expect(handler.command).toContain(expectedSkillPath);
+    expect(handler.commandWindows).toContain('set "IMPECCABLE_HOOK_HARNESS=codex"');
+    expect(handler.commandWindows).toContain(expectedSkillPath);
+  }
 }
 
 /**
@@ -390,6 +413,27 @@ describe('skills install: already-installed detection', () => {
     expect(output).toContain('already installed');
     expect(output).toContain('Installed hooks into: .claude');
     expect(existsSync(join(tmp, '.claude', 'settings.local.json'))).toBe(true);
+
+    rmSync(tmp, { recursive: true, force: true });
+  }, 15000);
+
+  test('repairs missing Codex hooks without dropping the harness selector', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-repair-codex-hooks-'));
+    execSync('git init', { cwd: tmp });
+    createFakeSkills(tmp, ['impeccable'], ['.agents']);
+    const bundleRoot = createFakeUniversalBundle(tmp, ['.agents']);
+
+    const output = run('skills install -y --providers=codex', {
+      cwd: tmp,
+      env: { ...process.env, IMPECCABLE_BUNDLE_PATH: bundleRoot },
+    });
+
+    expect(output).toContain('already installed');
+    expect(output).toContain('Installed hooks into: .agents');
+    expectCodexHookCommands(
+      join(tmp, '.codex', 'hooks.json'),
+      '.agents/skills/impeccable/scripts/hook.mjs',
+    );
 
     rmSync(tmp, { recursive: true, force: true });
   }, 15000);
@@ -842,6 +886,10 @@ describe('skills install/update: local universal bundle e2e', () => {
     const codexHooks = readFileSync(join(tmp, '.codex', 'hooks.json'), 'utf8');
     expect(codexHooks).toContain('.agents/skills/impeccable/scripts/hook.mjs');
     expect(codexHooks).not.toContain('.codex/skills/impeccable/scripts/hook.mjs');
+    expectCodexHookCommands(
+      join(tmp, '.codex', 'hooks.json'),
+      '.agents/skills/impeccable/scripts/hook.mjs',
+    );
 
     rmSync(tmp, { recursive: true, force: true });
   }, 15000);
@@ -1054,6 +1102,10 @@ describe('skills install/update: local universal bundle e2e', () => {
     expect(readFileSync(join(tmp, '.claude', 'settings.local.json'), 'utf8')).toContain(join(home, '.claude', 'skills', 'impeccable', 'scripts', 'hook.mjs'));
     expect(readFileSync(join(tmp, '.codex', 'hooks.json'), 'utf8')).toContain(join(home, '.agents', 'skills', 'impeccable', 'scripts', 'hook.mjs'));
     expect(readFileSync(join(tmp, '.cursor', 'hooks.json'), 'utf8')).toContain(join(home, '.cursor', 'skills', 'impeccable', 'scripts', 'hook-before-edit.mjs'));
+    expectCodexHookCommands(
+      join(tmp, '.codex', 'hooks.json'),
+      join(home, '.agents', 'skills', 'impeccable', 'scripts', 'hook.mjs'),
+    );
 
     rmSync(tmp, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
@@ -1425,6 +1477,31 @@ describe('skills install/update: local universal bundle e2e', () => {
     expect(content).toContain('version: 9.9.9-local');
     expect(existsSync(join(skillDir, 'scripts', 'context.mjs'))).toBe(true);
     expect(existsSync(join(tmp, '.claude', 'settings.local.json'))).toBe(true);
+
+    rmSync(tmp, { recursive: true, force: true });
+  }, 15000);
+
+  test('skills update preserves the Codex harness selector in rewritten hooks', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'imp-test-codex-update-hooks-'));
+    execSync('git init', { cwd: tmp });
+    const bundleRoot = createFakeUniversalBundle(tmp, ['.agents']);
+    const env = { ...process.env, IMPECCABLE_BUNDLE_PATH: bundleRoot };
+
+    run('skills install -y --providers=codex', { cwd: tmp, env });
+    writeFileSync(join(tmp, '.agents', 'skills', 'impeccable', 'SKILL.md'), [
+      '---',
+      'name: impeccable',
+      'version: 0.0.1-stale',
+      '---',
+      'stale',
+    ].join('\n'));
+
+    const output = run('skills update -y', { cwd: tmp, env });
+    expect(output).toContain('Updated 1 skill(s) to v9.9.9-local.');
+    expectCodexHookCommands(
+      join(tmp, '.codex', 'hooks.json'),
+      '.agents/skills/impeccable/scripts/hook.mjs',
+    );
 
     rmSync(tmp, { recursive: true, force: true });
   }, 15000);


### PR DESCRIPTION
## Summary

- preserve Codex as a distinct runtime harness in the hook pipeline
- emit Codex Stop findings as a top-level `decision: "block"` with `reason`
- keep Codex PostToolUse and all non-Codex payload formats unchanged
- mark project and OpenAI plugin hook commands with `IMPECCABLE_HOOK_HARNESS=codex`

## Root cause

Codex was intentionally mapped to Claude when the shared PostToolUse payload was introduced. The later Stop integration reused that mapping, even though Codex and Claude have different Stop output contracts. As a result, a Stop pass with fresh findings emitted Claude's nested `hookSpecificOutput` object, which Codex rejected as invalid JSON output for that event.

## User impact

Codex users now receive the deferred design findings and the turn continues for the agent to address them, instead of ending with `hook returned invalid stop hook JSON output`.

Fixes #603.

## Validation

- `node --test --test-name-pattern='payload\\(\\)' tests/hook.test.mjs`
- `node --test --test-name-pattern='resolveHarness\\(\\) / normalizeHookEvent\\(\\)' tests/hook.test.mjs`
- `node --test --test-name-pattern='emits Codex Stop findings as a blocking decision' tests/hook.test.mjs`
- `node --test --test-name-pattern='hook manifest builders' tests/hook-build.test.mjs`
- `node --test tests/openai-plugin.test.mjs`
- `npx -y bun@1.3.14 run build`

The default full suite was also attempted. Its relevant new regression passes, but the checkout has unrelated local-environment failures: `/tmp/.git` changes temporary project-root discovery in existing hook tests, the source-first policy intentionally leaves the tracked root Codex manifest unsynced, and `zip.test.mjs` cannot resolve the existing `readable-stream/passthrough` transitive dependency.

Generated root harness files and release versions are intentionally omitted; the source-first build completed successfully with root synchronization skipped.

## AI assistance

Codex implemented and tested this fix after maintainer approval in issue #603. The contributor reviewed the proposed diagnosis and implementation plan before authorizing the changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hook stdout contracts and every Codex hook install path; behavior is well-tested but affects all Codex users’ Stop and manifest wiring.
> 
> **Overview**
> Fixes Codex **Stop** hook failures caused by reusing Claude’s nested `hookSpecificOutput` shape when Codex expects a different contract.
> 
> **Runtime:** `resolveHarness()` now maps `IMPECCABLE_HOOK_HARNESS=codex` to a distinct `codex` harness (no longer folded into `claude`). For **Stop** only, `payload()` returns `{ decision: 'block', reason: text }`; Codex **PostToolUse** and Claude/GitHub/Cursor formats are unchanged.
> 
> **Install/manifests:** Codex hook commands (CLI rewrite, bundled transformers, `.agents` admin manifests, OpenAI plugin) prefix execution with `IMPECCABLE_HOOK_HARNESS=codex` on POSIX and `set "IMPECCABLE_HOOK_HARNESS=codex" &` on Windows, including **commandWindows** for Stop entries.
> 
> Tests cover payload shapes, manifest builders, install/update/repair paths, and an integration Stop pass under the Codex harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e9be8f1978968ce6e99069a3b4bbccf7d24ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->