### PR TITLE
Simplify manual Apply failure orchestration

### DIFF
--- a/skill/scripts/live-commit-manual-edits.mjs
+++ b/skill/scripts/live-commit-manual-edits.mjs
@@ -944,8 +944,42 @@ export async function commitManualEdits({
     };
   }
 
+  const repairContext = {
+    batch,
+    cwd,
+    pageUrl,
+    count,
+    provider,
+    env,
+    timeoutMs,
+    applyBatchToSource,
+    chatAvailable,
+    transactionId,
+  };
+
   const baseRollbackScope = collectApplyOwnedFiles(batch, cwd);
   const rollbackSnapshot = snapshotRollbackFiles(cwd, baseRollbackScope);
+  const failWithRollback = ({
+    scope = baseRollbackScope,
+    extraFiles = [],
+    failed,
+    files = [],
+    details = {},
+  }) => {
+    const rollback = rollbackChangedFiles(cwd, rollbackSnapshot, extraFiles, scope);
+    return {
+      applied: [],
+      failed,
+      files,
+      cleared: 0,
+      count,
+      pageUrl,
+      ...details,
+      rolledBackFiles: rollback.rolledBackFiles,
+      rollbackFailures: rollback.rollbackFailures,
+      ...countByPage(cwd),
+    };
+  };
   let result;
   try {
     result = repairOnly
@@ -965,42 +999,27 @@ export async function commitManualEdits({
           chatAvailable,
         });
   } catch (err) {
-    const rollback = rollbackChangedFiles(cwd, rollbackSnapshot, [], baseRollbackScope);
-    return {
-      applied: [],
+    return failWithRollback({
       failed: batch.entries.map((entry) => ({
         id: entry.id,
         reason: err.message || String(err),
         candidates: candidatesForEntry(batch, entry.id),
       })),
-      files: [],
-      cleared: 0,
-      count,
-      pageUrl,
-      rolledBackFiles: rollback.rolledBackFiles,
-      rollbackFailures: rollback.rollbackFailures,
-      ...countByPage(cwd),
-    };
+    });
   }
 
   if (result.status === 'error') {
     const rollbackScope = collectApplyOwnedFiles(batch, cwd, result.files || []);
-    const rollback = rollbackChangedFiles(cwd, rollbackSnapshot, result.files || [], rollbackScope);
     const failed = normalizeFailedEntries(batch, result, result.message || 'AI copy edit failed');
-    return {
-      applied: [],
+    return failWithRollback({
+      scope: rollbackScope,
+      extraFiles: result.files || [],
       failed: failed.length > 0
         ? failed
         : verificationFailuresForEntries(batch, batch.entries, result.message || 'AI copy edit failed'),
       files: result.files || [],
-      cleared: 0,
-      count,
-      pageUrl,
-      notes: result.notes || [],
-      rolledBackFiles: rollback.rolledBackFiles,
-      rollbackFailures: rollback.rollbackFailures,
-      ...countByPage(cwd),
-    };
+      details: { notes: result.notes || [] },
+    });
   }
 
   const reportedAppliedIds = uniqueStrings(result.appliedEntryIds || []);
@@ -1013,72 +1032,44 @@ export async function commitManualEdits({
   const conflictingAppliedIds = reportedAppliedIds.filter((id) => failedIds.has(id));
 
   if (conflictingAppliedIds.length > 0) {
-    const rollback = rollbackChangedFiles(cwd, rollbackSnapshot, result.files || [], rollbackScope);
     const conflictingEntries = batch.entries.filter((entry) => conflictingAppliedIds.includes(entry.id));
-    return {
-      applied: [],
+    return failWithRollback({
+      scope: rollbackScope,
+      extraFiles: result.files || [],
       failed: [
         ...verificationFailuresForEntries(batch, conflictingEntries, 'conflicting_apply_result'),
         ...aiFailed.filter((item) => !conflictingAppliedIds.includes(item.id)),
       ],
       files: result.files || [],
-      cleared: 0,
-      count,
-      pageUrl,
-      notes: result.notes || [],
-      rolledBackFiles: rollback.rolledBackFiles,
-      rollbackFailures: rollback.rollbackFailures,
-      ...countByPage(cwd),
-    };
+      details: { notes: result.notes || [] },
+    });
   }
 
   const unreportedFiles = unreportedChangedFiles(cwd, rollbackSnapshot, result.files || [], rollbackScope);
   if (unreportedFiles.length > 0) {
-    const rollback = rollbackChangedFiles(cwd, rollbackSnapshot, result.files || [], [...rollbackScope, ...unreportedFiles]);
-    return {
-      applied: [],
+    return failWithRollback({
+      scope: [...rollbackScope, ...unreportedFiles],
+      extraFiles: result.files || [],
       failed: verificationFailuresForEntries(batch, batch.entries, 'unreported_source_changes', { files: unreportedFiles }),
       files: result.files || [],
-      unreportedFiles,
-      cleared: 0,
-      count,
-      pageUrl,
-      notes: result.notes || [],
-      rolledBackFiles: rollback.rolledBackFiles,
-      rollbackFailures: rollback.rollbackFailures,
-      ...countByPage(cwd),
-    };
+      details: { unreportedFiles, notes: result.notes || [] },
+    });
   }
 
   if (result.status === 'done' && reportedAppliedIds.length === 0) {
-    const rollback = rollbackChangedFiles(cwd, rollbackSnapshot, result.files || [], rollbackScope);
-    return {
-      applied: [],
+    return failWithRollback({
+      scope: rollbackScope,
+      extraFiles: result.files || [],
       failed: verificationFailuresForEntries(batch, batch.entries, 'missing_applied_entry_ids'),
       files: result.files || [],
-      cleared: 0,
-      count,
-      pageUrl,
-      notes: result.notes || [],
-      rolledBackFiles: rollback.rolledBackFiles,
-      rollbackFailures: rollback.rollbackFailures,
-      ...countByPage(cwd),
-    };
+      details: { notes: result.notes || [] },
+    });
   }
 
   const reportedAppliedEntries = batch.entries.filter((entry) => reportedAppliedIds.includes(entry.id));
   if (reportedAppliedIds.length > 0 && reportedFiles.length === 0) {
     return repairPostApplyValidation({
-      batch,
-      cwd,
-      pageUrl,
-      count,
-      provider,
-      env,
-      timeoutMs,
-      applyBatchToSource,
-      chatAvailable,
-      transactionId,
+      ...repairContext,
       appliedEntryIds: reportedAppliedIds,
       files: result.files || [],
       failed: aiFailed,
@@ -1089,21 +1080,10 @@ export async function commitManualEdits({
     });
   }
 
-  const verifiedAppliedIds = [];
-  const verificationFailed = [];
-  for (const entry of reportedAppliedEntries) {
-    const failures = verifyAppliedEntry({ batch, entry, reportedFiles, cwd });
-    if (failures.length === 0) {
-      verifiedAppliedIds.push(entry.id);
-    } else {
-      verificationFailed.push({
-        id: entry.id,
-        reason: 'source_verification_failed',
-        failures,
-        candidates: candidatesForEntry(batch, entry.id),
-      });
-    }
-  }
+  const {
+    verifiedIds: verifiedAppliedIds,
+    failed: verificationFailed,
+  } = verifyEntriesAfterRepair({ batch, appliedEntryIds: reportedAppliedIds, files: reportedFiles, cwd });
   const unreportedEntries = result.status === 'done' || result.status === 'partial'
     ? batch.entries.filter((entry) => !reportedAppliedIds.includes(entry.id) && !aiFailed.some((item) => item.id === entry.id))
     : [];
@@ -1133,37 +1113,22 @@ export async function commitManualEdits({
         reason: 'rolled_back_due_to_failed_entry_source_changed',
         candidates: candidatesForEntry(batch, entry.id),
       }));
-    const rollback = rollbackChangedFiles(cwd, rollbackSnapshot, result.files || [], rollbackScope);
-    return {
-      applied: [],
+    return failWithRollback({
+      scope: rollbackScope,
+      extraFiles: result.files || [],
       failed: [
         ...leakedUnapplied,
         ...failed.filter((item) => !leakedIds.has(item.id)),
         ...rolledBackVerified,
       ],
       files: result.files || [],
-      cleared: 0,
-      count,
-      pageUrl,
-      rolledBackFiles: rollback.rolledBackFiles,
-      rollbackFailures: rollback.rollbackFailures,
-      notes: result.notes || [],
-      ...countByPage(cwd),
-    };
+      details: { notes: result.notes || [] },
+    });
   }
 
   if (verificationFailed.length > 0) {
     return repairPostApplyValidation({
-      batch,
-      cwd,
-      pageUrl,
-      count,
-      provider,
-      env,
-      timeoutMs,
-      applyBatchToSource,
-      chatAvailable,
-      transactionId,
+      ...repairContext,
       appliedEntryIds: reportedAppliedIds,
       files: result.files || [],
       failed: nonRepairFailed,
@@ -1180,16 +1145,7 @@ export async function commitManualEdits({
       ? reportedAppliedEntries.filter((entry) => verifiedAppliedIds.includes(entry.id))
       : batch.entries;
     return repairPostApplyValidation({
-      batch,
-      cwd,
-      pageUrl,
-      count,
-      provider,
-      env,
-      timeoutMs,
-      applyBatchToSource,
-      chatAvailable,
-      transactionId,
+      ...repairContext,
       appliedEntryIds: verifiedAppliedIds.length > 0
         ? verifiedAppliedIds
         : postCheckEntries.map((entry) => entry.id).filter(Boolean),


### PR DESCRIPTION
## Summary

- centralize the six rollback failure exits behind one local transaction-result boundary
- define the repeated repair invocation context once
- reuse the existing entry verifier for the initial result instead of maintaining a second verification loop

## Hindsight architecture review

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No.

The manual Apply orchestrator independently reconstructed the same rollback response contract in six branches, threaded the same repair context through three calls, and duplicated entry verification that the repair flow already owned. Those are durable rules with one reason to change, so the leanest behavior-preserving design is to define each once inside the existing module. No new framework, helper module, public API, or state was introduced.

## Before / after

- primary file: **1,244 → 1,200 lines** (-44)
- one-file diff: **68 additions / 112 deletions**
- rollback response construction: **6 branch-specific implementations → 1 local transaction boundary**
- entry verification loops: **2 → 1**
- repeated repair context: **3 call-site copies → 1 context definition**
- top-level named functions: **47 → 47**
- public contract: unchanged `commitManualEdits` export, CLI entry point, JSON result fields, rollback semantics, repair behavior, buffer clearing, logs, and exit behavior

The module retains its existing responsibilities—batch orchestration, source verification, rollback, repair, and buffer clearing—but the main control flow now delegates repeated policy instead of restating it.

## Validation

- `node --check skill/scripts/live-commit-manual-edits.mjs`
- `node --test tests/live-commit-manual-edits.test.mjs` — 41 passed
- `bun run build` — passed
- `bun run test` — full default suite passed outside the sandbox, including localhost-backed tests
- `git diff --check`

## Generated output

Generated provider and root harness output was intentionally omitted under the source-first policy. The required build regenerated and validated `dist/` without tracked harness churn.

## Remaining risk

Low. The only meaningful risk is accidental drift in a rollback result shape or verifier outcome; the existing focused suite exercises thrown runners, explicit error results, conflicting IDs, unreported source changes, leaked failed-entry writes, repair attempts, successful partial applies, and public CLI behavior.

## Authorization and AI assistance

Prepared by Codex with AI assistance under maintainer pbakaus's standing scheduled architecture-refactor authorization. This PR is ready for review and is not authorized for automatic merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in a single script with existing tests covering rollback, repair, and failure paths; risk is only accidental drift in result object shape.
> 
> **Overview**
> Refactors **`commitManualEdits`** in `live-commit-manual-edits.mjs` so failure handling is defined once instead of copied across branches.
> 
> A local **`failWithRollback`** helper now builds the standard failure payload (empty `applied`, rollback metadata, page counts) for agent throws, explicit errors, conflicting apply IDs, unreported file changes, missing applied IDs, and leaked writes from failed entries. **`repairContext`** is defined once and spread into the three **`repairPostApplyValidation`** call sites. Post-apply entry checks use **`verifyEntriesAfterRepair`** instead of an inline loop that duplicated the repair path’s verifier.
> 
> Public behavior and JSON shape are unchanged; this is structural deduplication in the manual Apply orchestrator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2c3f9d6b207ad5a7119cd38c4dfb3bc1dc4d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->