### PR TITLE
Remove stale Claude MultiEdit matcher

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,9 @@
 {
-  "description": "Impeccable design detector: immediate-tier checks after Edit/Write/MultiEdit on UI files, full-rule deep pass on Stop.",
+  "description": "Impeccable design detector: immediate-tier checks after Edit/Write on UI files, full-rule deep pass on Stop.",
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/plugin/skills/impeccable/reference/hooks.md
+++ b/plugin/skills/impeccable/reference/hooks.md
@@ -44,7 +44,7 @@ The first argument is the action. Defaults to `status`.
    ```
 
 3. If `<action>` is `off`, follow up with a one-line note: "Done. New edits will not trigger the design hook in this project until you run `/impeccable hooks on`."
-4. If `<action>` is `on`, follow up with: "Done. The design hook will fire after the next Edit/Write/MultiEdit on a UI file."
+4. If `<action>` is `on`, follow up with: "Done. The design hook will fire after the next Edit/Write on a UI file."
 5. If `<action>` is `ignore-value`, `ignore-file`, or `ignore-rule`, just print the script output. The default scope is shared `.impeccable/config.json`; add `--local` only when the user explicitly asks for a private exception.
 6. If `<action>` is `status`, just print the script output. Do not add commentary unless the user asked a follow-up question.
 

--- a/plugin/skills/impeccable/scripts/hook-admin.mjs
+++ b/plugin/skills/impeccable/scripts/hook-admin.mjs
@@ -75,11 +75,11 @@ const HOOK_MANIFEST_TARGETS = [
     destRel: '.claude/settings.local.json',
     sharedDestRel: '.claude/settings.json',
     manifest: () => ({
-      description: 'Impeccable design detector: immediate-tier checks after Edit/Write/MultiEdit on UI files, full-rule deep pass on Stop.',
+      description: 'Impeccable design detector: immediate-tier checks after Edit/Write on UI files, full-rule deep pass on Stop.',
       hooks: {
         PostToolUse: [
           {
-            matcher: 'Edit|Write|MultiEdit',
+            matcher: 'Edit|Write',
             hooks: [
               {
                 type: 'command',

--- a/scripts/lib/transformers/hooks.js
+++ b/scripts/lib/transformers/hooks.js
@@ -137,9 +137,9 @@ const GROK_PROJECT_HOOK = '.grok/skills/impeccable/scripts/hook.mjs';
 
 export function buildClaudeSettingsManifest() {
   return {
-    description: 'Impeccable design detector: immediate-tier checks after Edit/Write/MultiEdit on UI files, full-rule deep pass on Stop.',
+    description: 'Impeccable design detector: immediate-tier checks after Edit/Write on UI files, full-rule deep pass on Stop.',
     hooks: buildClaudeCompatibleHooks(
-      'Edit|Write|MultiEdit',
+      'Edit|Write',
       CLAUDE_PROJECT_HOOK,
       SYSTEM_MESSAGE_NOTICE,
     ),
@@ -155,7 +155,7 @@ export function buildClaudeSettingsManifest() {
 export function buildClaudePluginHooksManifest() {
   return {
     hooks: buildClaudeCompatibleHooks(
-      'Edit|Write|MultiEdit',
+      'Edit|Write',
       CLAUDE_PLUGIN_HOOK,
       SYSTEM_MESSAGE_NOTICE,
     ),

--- a/skill/reference/hooks.md
+++ b/skill/reference/hooks.md
@@ -44,7 +44,7 @@ The first argument is the action. Defaults to `status`.
    ```
 
 3. If `<action>` is `off`, follow up with a one-line note: "Done. New edits will not trigger the design hook in this project until you run `{{command_prefix}}impeccable hooks on`."
-4. If `<action>` is `on`, follow up with: "Done. The design hook will fire after the next Edit/Write/MultiEdit on a UI file."
+4. If `<action>` is `on`, follow up with: "Done. The design hook will fire after the next Edit/Write on a UI file."
 5. If `<action>` is `ignore-value`, `ignore-file`, or `ignore-rule`, just print the script output. The default scope is shared `.impeccable/config.json`; add `--local` only when the user explicitly asks for a private exception.
 6. If `<action>` is `status`, just print the script output. Do not add commentary unless the user asked a follow-up question.
 

--- a/skill/scripts/hook-admin.mjs
+++ b/skill/scripts/hook-admin.mjs
@@ -75,11 +75,11 @@ const HOOK_MANIFEST_TARGETS = [
     destRel: '.claude/settings.local.json',
     sharedDestRel: '.claude/settings.json',
     manifest: () => ({
-      description: 'Impeccable design detector: immediate-tier checks after Edit/Write/MultiEdit on UI files, full-rule deep pass on Stop.',
+      description: 'Impeccable design detector: immediate-tier checks after Edit/Write on UI files, full-rule deep pass on Stop.',
       hooks: {
         PostToolUse: [
           {
-            matcher: 'Edit|Write|MultiEdit',
+            matcher: 'Edit|Write',
             hooks: [
               {
                 type: 'command',

--- a/tests/hook-build.test.mjs
+++ b/tests/hook-build.test.mjs
@@ -376,6 +376,15 @@ describe('generated hook artifacts in repo', () => {
     assert.ok(fs.existsSync(path.join(REPO_ROOT, 'plugin/skills/impeccable/scripts/hook-lib.mjs')));
   });
 
+  it('keeps the marketplace hook repair matcher aligned with Claude Code', () => {
+    const hookAdmin = fs.readFileSync(
+      path.join(REPO_ROOT, 'plugin/skills/impeccable/scripts/hook-admin.mjs'),
+      'utf8',
+    );
+    assert.match(hookAdmin, /matcher: 'Edit\|Write'/);
+    assert.doesNotMatch(hookAdmin, /matcher: 'Edit\|Write\|MultiEdit'/);
+  });
+
   it('generated hook runtime can import the bundled detector', async () => {
     for (const scriptDir of [
       '.claude/skills/impeccable/scripts',

--- a/tests/hook-build.test.mjs
+++ b/tests/hook-build.test.mjs
@@ -72,7 +72,8 @@ describe('hook manifest builders', () => {
     const group = manifest.hooks.PostToolUse[0];
     const handler = group.hooks[0];
 
-    assert.equal(group.matcher, 'Edit|Write|MultiEdit');
+    assert.equal(group.matcher, 'Edit|Write');
+    assert.doesNotMatch(manifest.description, /MultiEdit/);
     assert.equal(handler.type, 'command');
     assert.equal(handler.timeout, 5);
     assert.equal(handler.statusMessage, 'Checking UI changes');
@@ -356,7 +357,7 @@ describe('generated hook artifacts in repo', () => {
     assert.equal(manifest.description, undefined);
 
     const handler = manifest.hooks.PostToolUse[0].hooks[0];
-    assert.equal(manifest.hooks.PostToolUse[0].matcher, 'Edit|Write|MultiEdit');
+    assert.equal(manifest.hooks.PostToolUse[0].matcher, 'Edit|Write');
     expectCommand(handler.command, 'skills/impeccable/scripts/hook.mjs');
     // Resolves relative to the installed plugin, not a `.claude/skills/` layout.
     assert.ok(handler.command.includes('${CLAUDE_PLUGIN_ROOT}'),

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -947,6 +947,10 @@ describe('hook-admin.mjs', () => {
     // impeccable entry must have been stripped, not accumulated.
     assert.equal(claude.split('skills/impeccable/scripts/hook.mjs').length - 1, 2);
     assert.match(claude, /"Stop"/);
+    const claudeManifest = JSON.parse(claude);
+    const impeccableGroup = claudeManifest.hooks.PostToolUse.find((group) =>
+      group.hooks?.some((hook) => hook.command?.includes('skills/impeccable/scripts/hook.mjs')));
+    assert.equal(impeccableGroup.matcher, 'Edit|Write');
 
     const codex = fs.readFileSync(path.join(cwd, '.codex', 'hooks.json'), 'utf-8');
     assert.match(codex, /\.agents\/skills\/impeccable\/scripts\/hook\.mjs/);

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -950,6 +950,7 @@ describe('hook-admin.mjs', () => {
     const claudeManifest = JSON.parse(claude);
     const impeccableGroup = claudeManifest.hooks.PostToolUse.find((group) =>
       group.hooks?.some((hook) => hook.command?.includes('skills/impeccable/scripts/hook.mjs')));
+    assert.ok(impeccableGroup, 'repaired Claude settings should contain the Impeccable PostToolUse group');
     assert.equal(impeccableGroup.matcher, 'Edit|Write');
 
     const codex = fs.readFileSync(path.join(cwd, '.codex', 'hooks.json'), 'utf-8');


### PR DESCRIPTION
Closes #614.

## Summary

- remove the retired `MultiEdit` token from Claude Code project and plugin hook matchers
- keep the hook self-repair manifest and user-facing hook guidance aligned
- preserve Grok Build's `Edit|Write|MultiEdit` compatibility matcher, which Grok still aliases to its own tools
- add focused regressions for generated and repaired Claude manifests

## Reproduction

Before the fix, the new assertions showed both generated Claude manifests and `impeccable hooks on` producing `Edit|Write|MultiEdit`. They now produce `Edit|Write`.

## Validation

- `node --test tests/hook-build.test.mjs` — 23/23 passed
- `node --test tests/hook.test.mjs` — 229/229 passed
- `bun run test:plugin-e2e` — 4/4 passed
- `bun run build` — passed
- `bun run build:release` — passed; unrelated pre-existing generated drift was excluded
- `git diff --check` — passed
- `node --test tests/zip.test.mjs` — 5/5 passed after one full-suite Node IPC serialization failure
- `bun run test` — changed-area/core phases passed; the integrated rerun stopped in an unrelated browser-only assertion at `tests/detect-antipatterns-browser.test.mjs:990` (`pure.before` was 13 instead of 0). The exact test reproduced in isolation. This branch does not touch detector/browser code; GitHub CI is the authoritative follow-up.

## Generated output

Included intentionally: `.claude/settings.json`, `plugin/hooks/hooks.json`, and the marketplace copies of `hook-admin.mjs` and `reference/hooks.md`, because this issue is specifically about generated hook manifests and repaired marketplace installations. Other provider/root harness copies are intentionally omitted.

## AI assistance disclosure

This change, commit, validation, and PR description were prepared with AI assistance under maintainer pbakaus's standing authorization.
