### PR TITLE
Remove dead DESIGN.md parser paths

### DIFF
--- a/skill/scripts/lib/design-parser.mjs
+++ b/skill/scripts/lib/design-parser.mjs
@@ -196,9 +196,6 @@ function parseScalar(raw) {
 
 const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
 const OKLCH_RE = /oklch\([^)]+\)/gi;
-const RGBA_RE = /rgba?\([^)]+\)/gi;
-const BOX_SHADOW_RE = /(?:box-shadow:\s*)?((?:-?\d[\w\d\s\-.,/()#%]*)+)/;
-const NAMED_RULE_RE = /\*\*(The [^*]+?Rule)\.\*\*\s*(.+)/;
 
 // ---------- Section splitting ----------
 
@@ -548,36 +545,6 @@ function detectFormat(v) {
   if (/^oklch/i.test(v)) return 'oklch';
   if (/^rgb/i.test(v)) return 'rgb';
   return 'unknown';
-}
-
-function scanInlineColors(lines) {
-  const out = [];
-  for (const line of lines) {
-    if (!/^\s*[-*]\s/.test(line)) continue;
-    const trimmed = line.replace(/^\s*[-*]\s+/, '');
-    const color = parseColorBullet(trimmed);
-    if (color) out.push(color);
-  }
-  return out;
-}
-
-function parseStitchInlineGroups(lines) {
-  // Stitch writes: `*   **Primary (`#00478d` to `#005eb8`):** Use for "..."`
-  // Each bullet IS its own role. Group them under the spoken role name.
-  const out = [];
-  for (const line of lines) {
-    if (!/^\s*[-*]\s/.test(line)) continue;
-    const trimmed = line.replace(/^\s*[-*]\s+/, '').trim();
-    const m = trimmed.match(
-      /^\*\*([A-Z][a-zA-Z]+)\s*\(([^)]+)\):\*\*\s*(.*)$/
-    );
-    if (m) {
-      const role = m[1];
-      const color = buildColor(role, m[2], m[3]);
-      out.push({ role, colors: [color] });
-    }
-  }
-  return out;
 }
 
 function extractTypography(section) {


### PR DESCRIPTION
## Summary

Remove a disconnected, unreachable inline-color parsing path from `skill/scripts/lib/design-parser.mjs`:

- delete two private helpers that had no callers
- delete three regular expressions used by no parser path
- preserve the existing `parseDesignMd` and `assessCoverage` exports and all parsed output contracts

## Hindsight review

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No. The file had two conceptual color-parsing paths, but only `extractColors → collectBullets → parseColorBullet` was reachable. Keeping a second disconnected mechanism increased the apparent state space without providing behavior.

The leanest architecture is to retain the proven parser path and delete the unreachable one, without introducing a replacement abstraction.

## Before / after

- Primary file: 925 → 892 lines (**-33**)
- Unreachable private parsing helpers: 2 → 0
- Unused parser regular expressions: 3 → 0
- Files changed: 1
- Diff: 0 additions, 33 deletions
- Public exports, schemas, CLI output, and error behavior: unchanged

## Validation

- `node --check skill/scripts/lib/design-parser.mjs`
- `node --test tests/design-parser.test.mjs` — 10/10 passed before and after
- `bun run build` — passed; validated all 17 provider distributions and 108 script files
- `git diff --check` — passed
- Static reference scan confirmed the removed private declarations had no callers
- `bun run test` — all completed suites passed except one unrelated browser-decoration assertion in `tests/detect-antipatterns-browser.test.mjs`; the exact same isolated failure (`13 !== 0`) reproduces on an untouched `origin/main` control worktree

Generated root harness/provider output was intentionally omitted per the source-first contribution policy.

## Risk

Very low. This is deletion-only and removes declarations that were unreachable from both public entry points. The focused parser suite and distribution build are green. The only observed broader-suite failure is independently reproducible on current main and shares no code path with this file.

## Authorization and disclosure

This PR was prepared with AI assistance by Codex under pbakaus's explicit standing authorization for the scheduled architecture-simplification automation. It is ready for review and will not be merged by the automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only of unreachable private code; focused tests and public exports are unchanged.
> 
> **Overview**
> **Removes unreachable color-parsing code** from `design-parser.mjs` so only the live path remains: `extractColors` → `collectBullets` → `parseColorBullet`.
> 
> Deleted two unused helpers (`scanInlineColors`, `parseStitchInlineGroups`) and three regex constants (`RGBA_RE`, `BOX_SHADOW_RE`, `NAMED_RULE_RE`) that nothing referenced. **`parseDesignMd`**, **`assessCoverage`**, and parsed output shape are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d62b135fe25bb41ced9f49a923e0cb1a62e23ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->