### PR TITLE
Fix stalled Tune state without params

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -4902,6 +4902,13 @@
     saveSession();
   }
 
+  function completeParameterGenerationIfReady() {
+    if (expectedVariants <= 0 || arrivedVariants < expectedVariants) return;
+    if (parameterGenerationState === 'pending' || parameterGenerationState === 'loading') {
+      completeParameterPublication();
+    }
+  }
+
   function toggleTunePopover() {
     if (pendingApplyInFlight) { showManualApplyBusyToast(); return; }
     if (tuneOpen) { closeTunePopover(); return; }
@@ -5796,7 +5803,7 @@
         setLiveState('CYCLING');
         showOrUpdateCyclingBar();
         saveSession();
-        if (parameterGenerationState === 'loading') completeParameterPublication();
+        completeParameterGenerationIfReady();
         return;
       }
 
@@ -5884,7 +5891,7 @@
       refreshParamsPanel();
       positionBar();
       saveSession();
-      if (parameterGenerationState === 'loading') completeParameterPublication();
+      completeParameterGenerationIfReady();
       console.log('[impeccable] Mounted ' + arrivedVariants + ' ' + manifest.framework + ' component variants.');
     } catch (err) {
       console.error('[impeccable] Failed to mount component-preview variants:', err);
@@ -6329,7 +6336,7 @@
         refreshParamsPanel();
         positionBar();
         saveSession();
-        if (parameterGenerationState === 'loading') completeParameterPublication();
+        completeParameterGenerationIfReady();
         console.log('[impeccable] Injected ' + arrivedVariants + ' variants from source file.');
       })
       .catch(err => {
@@ -6836,6 +6843,7 @@
 
       const expected = parseInt(wrapper.dataset.impeccableVariantCount || '0');
       if (expected > 0) expectedVariants = expected;
+      completeParameterGenerationIfReady();
 
       if (arrivedVariants > 0) {
         setLiveState('CYCLING');

--- a/tests/live-browser-regression.test.mjs
+++ b/tests/live-browser-regression.test.mjs
@@ -1032,6 +1032,15 @@ describe('live-browser.js regression guards', () => {
       /case 'variant_progress':[\s\S]{0,120}?if \(msg\.publicationKind === 'params'\) parameterGenerationState = 'loading';/,
       'a params-only publication must mark Tune controls loading even though the variant count is unchanged',
     );
+    assert.match(
+      SOURCE,
+      /function completeParameterGenerationIfReady\(\) \{[\s\S]{0,240}?arrivedVariants < expectedVariants[\s\S]{0,160}?parameterGenerationState === 'pending'[\s\S]{0,120}?completeParameterPublication\(\);/,
+      'the completed variants publication must resolve pending Tune controls even when no params publication follows',
+    );
+    assert.ok(
+      (SOURCE.match(/completeParameterGenerationIfReady\(\);/g) || []).length >= 4,
+      'every DOM, source, and component-preview completion path must resolve pending Tune controls',
+    );
     assert.match(SOURCE, /revisionDomain: 'browser'/, 'browser checkpoints must use their own revision domain');
   });
 


### PR DESCRIPTION
Closes #620.

## Summary

- resolve the pending Tune state once the full expected variant set has mounted
- treat both the initial `pending` state and deferred `loading` publications consistently
- cover DOM, source-preview, and Svelte/Vue component-preview completion paths

Before this change, knob-less variants left the Tune chip disabled and spinning forever because production code never emitted a `publicationKind: 'params'` event. The focused regression failed before the implementation and passes with the fix.

## Validation

- `node --test tests/live-browser-regression.test.mjs` — 54/54 passed
- `bun run build` — passed
- `bun run test:live-e2e` — 35 passed, 1 documented skip
- `bun run test:live-e2e-accept-cleanup` — skipped because `DEEPSEEK_API_KEY` is unavailable
- `bun run test` — passed, including browser, live, framework, and plugin suites
- `git diff --check` — passed

Generated provider and root harness output was intentionally omitted per the source-first policy.

AI assistance: implemented, tested, and submitted by OpenAI Codex under explicit maintainer authorization.
