### PR TITLE
Centralize live adapter detection probes

### DIFF
--- a/skill/scripts/live/sveltekit-adapter.mjs
+++ b/skill/scripts/live/sveltekit-adapter.mjs
@@ -11,6 +11,8 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { firstExistingFile, hasAnyDependency } from './frameworks/detect-utils.mjs';
+
 export const SVELTE_LIVE_ROOT_COMPONENT = 'src/lib/impeccable/ImpeccableLiveRoot.svelte';
 export const SVELTE_LAYOUT_MARKER_OPEN = '<!-- impeccable-live-svelte-start -->';
 export const SVELTE_LAYOUT_MARKER_CLOSE = '<!-- impeccable-live-svelte-end -->';
@@ -45,11 +47,17 @@ export function detectSvelteKitProject(cwd = process.cwd(), config = null) {
     && fileIncludes(path.join(cwd, appHtml), '%sveltekit.head%');
   if (!hasTemplateMarkers) return null;
 
-  const hasSvelteConfig = fs.existsSync(path.join(cwd, 'svelte.config.js'))
-    || fs.existsSync(path.join(cwd, 'svelte.config.mjs'))
-    || fs.existsSync(path.join(cwd, 'svelte.config.cjs'))
-    || fs.existsSync(path.join(cwd, 'svelte.config.ts'));
-  const hasKitPackage = packageHasSvelteKit(cwd);
+  const hasSvelteConfig = Boolean(firstExistingFile(cwd, [
+    'svelte.config.js',
+    'svelte.config.mjs',
+    'svelte.config.cjs',
+    'svelte.config.ts',
+  ]));
+  const hasKitPackage = hasAnyDependency(cwd, [
+    '@sveltejs/kit',
+    '@sveltejs/vite-plugin-svelte',
+    'svelte',
+  ]);
   if (!hasSvelteConfig && !hasKitPackage) return null;
 
   return {
@@ -260,34 +268,14 @@ function findSvelteKitAppHtml(cwd, config) {
 }
 
 function findSvelteKitLayout(cwd) {
-  const candidates = [
+  return firstExistingFile(cwd, [
     'src/routes/+layout.svelte',
     'src/routes/(app)/+layout.svelte',
-  ];
-  for (const rel of candidates) {
-    if (fs.existsSync(path.join(cwd, rel))) return rel;
-  }
-  return 'src/routes/+layout.svelte';
+  ]) || 'src/routes/+layout.svelte';
 }
 
 function defaultSvelteLayout() {
   return `<script>\n  let { children } = $props();\n</script>\n\n{@render children?.()}\n`;
-}
-
-function packageHasSvelteKit(cwd) {
-  const file = path.join(cwd, 'package.json');
-  if (!fs.existsSync(file)) return false;
-  try {
-    const pkg = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    const deps = {
-      ...(pkg.dependencies || {}),
-      ...(pkg.devDependencies || {}),
-      ...(pkg.peerDependencies || {}),
-    };
-    return Boolean(deps['@sveltejs/kit'] || deps['@sveltejs/vite-plugin-svelte'] || deps.svelte);
-  } catch {
-    return false;
-  }
 }
 
 function fileIncludes(file, text) {

--- a/skill/scripts/live/tanstack-adapter.mjs
+++ b/skill/scripts/live/tanstack-adapter.mjs
@@ -19,6 +19,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+
+import { firstExistingFile, hasAnyDependency } from './frameworks/detect-utils.mjs';
 import { buildLiveScriptSrc } from './frameworks/script-src.mjs';
 
 export const TANSTACK_MARKER_OPEN = '{/* impeccable-live-tanstack-start */}';
@@ -42,8 +44,8 @@ const START_PACKAGES = [
 ];
 
 export function detectTanStackStartProject(cwd = process.cwd()) {
-  if (!packageHasTanStackStart(cwd)) return null;
-  const rootRoute = findRootRouteFile(cwd);
+  if (!hasAnyDependency(cwd, START_PACKAGES)) return null;
+  const rootRoute = firstExistingFile(cwd, ROOT_ROUTE_CANDIDATES);
   if (!rootRoute) return null;
 
   const ext = path.extname(rootRoute);
@@ -216,29 +218,6 @@ export default function ImpeccableLiveRoot() {
 // its leading comment and its script data-attribute; user files never do.
 function isManagedComponent(content) {
   return String(content || '').includes('impeccable-live-tanstack');
-}
-
-function findRootRouteFile(cwd) {
-  for (const rel of ROOT_ROUTE_CANDIDATES) {
-    if (fs.existsSync(path.join(cwd, rel))) return rel;
-  }
-  return null;
-}
-
-function packageHasTanStackStart(cwd) {
-  const file = path.join(cwd, 'package.json');
-  if (!fs.existsSync(file)) return false;
-  try {
-    const pkg = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    const deps = {
-      ...(pkg.dependencies || {}),
-      ...(pkg.devDependencies || {}),
-      ...(pkg.peerDependencies || {}),
-    };
-    return START_PACKAGES.some((name) => Boolean(deps[name]));
-  } catch {
-    return false;
-  }
 }
 
 function relativeImportSpecifier(fromFile, toFile) {


### PR DESCRIPTION
## Summary

- reuse the framework layer's existing dependency probe in the SvelteKit and TanStack Start live adapters
- reuse its ordered file probe for Svelte config, Svelte layout, and TanStack root-route discovery
- delete the adapters' duplicate package parsing and path-search helpers

## Hindsight architecture review

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No.

The adapters should own framework-specific detection decisions and patch/apply/remove behavior. Generic failure-tolerant package parsing and ordered file existence checks already have a stable responsibility boundary in `live/frameworks/detect-utils.mjs`. Reimplementing those mechanisms inside each adapter created multiple copies of the same durable rule.

The leanest behavior-preserving architecture is to call that existing boundary. This adds no module, abstraction, state, or public API.

## Before / after

- Primary file, `skill/scripts/live/sveltekit-adapter.mjs`: **316 → 304 lines** (-12)
- Supporting consumer, `skill/scripts/live/tanstack-adapter.mjs`: **280 → 259 lines** (-21)
- Adapter architecture total: **596 → 563 lines** (-33)
- Diff: **19 additions / 52 deletions**
- Private package parsers: **2 → 0**
- Private ordered file-search loops: **2 → 0**
- Public exports, detection priority, project descriptors, CLI output, error semantics, patching, and removal behavior: unchanged

## Validation

- `node --test tests/live-tanstack-adapter.test.mjs tests/live-frameworks.test.mjs` — 77/77 passed
- `bun run build` — passed; validated 17 provider distributions and 108 script files
- `bun run test` — full default suite passed outside the sandbox, including core, detector/browser, live, framework fixtures, and plugin E2E; 2 documented skips
- `git diff --check` — passed

Generated provider and root harness output was intentionally omitted per the source-first policy.

## Risk

Low. The shared helpers implement the same dependency merge and ordered `existsSync` semantics that the deleted private helpers used. Existing focused tests exercise package variants, malformed detection outcomes, root-route ordering, SvelteKit fixtures, registry priority, apply/remove round trips, and public adapter behavior.

## Authorization and AI assistance

Prepared by OpenAI Codex with AI assistance under maintainer pbakaus's explicit standing authorization for the scheduled architecture-simplification automation. This PR is ready for review and is not authorized for automatic merge.
