### PR TITLE
Centralize live path glob matching

### DIFF
--- a/skill/scripts/lib/live-path-globs.mjs
+++ b/skill/scripts/lib/live-path-globs.mjs
@@ -1,0 +1,37 @@
+/**
+ * Convert a live-config glob pattern to a RegExp.
+ *
+ * Supports `**` across path segments, `*` within one segment, and `?` for one
+ * character. Callers normalize project-relative paths to forward slashes.
+ */
+export function livePathGlobToRegex(pattern) {
+  let re = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === '*') {
+      if (pattern[i + 1] === '*') {
+        if (pattern[i + 2] === '/') {
+          re += '(?:.*/)?';
+          i += 3;
+        } else {
+          re += '.*';
+          i += 2;
+        }
+      } else {
+        re += '[^/]*';
+        i += 1;
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+      i += 1;
+    } else if (/[.+^${}()|[\]\\]/.test(c)) {
+      re += `\\${c}`;
+      i += 1;
+    } else {
+      re += c;
+      i += 1;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}

--- a/skill/scripts/live-inject.mjs
+++ b/skill/scripts/live-inject.mjs
@@ -27,6 +27,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveLiveConfigPath } from './lib/impeccable-paths.mjs';
+import { livePathGlobToRegex } from './lib/live-path-globs.mjs';
 import {
   describeInjectArtifacts,
   frameworkIgnorePatterns,
@@ -364,7 +365,7 @@ export function resolveFiles(rootDir, config) {
   const patterns = config.files;
   const userExcludes = Array.isArray(config.exclude) ? config.exclude : [];
   const allExcludes = [...HARD_EXCLUDES, ...userExcludes];
-  const excludeRegexes = allExcludes.map(globToRegex);
+  const excludeRegexes = allExcludes.map(livePathGlobToRegex);
 
   const isExcluded = (relPath) => excludeRegexes.some((re) => re.test(relPath));
   const isGlob = (s) => /[*?[]/.test(s);
@@ -399,47 +400,6 @@ export function resolveFiles(rootDir, config) {
     }
   }
   return out;
-}
-
-/**
- * Convert a glob pattern to a RegExp. Supports:
- *   **  → any number of path segments (including zero)
- *   *   → any chars except `/`
- *   ?   → any single char except `/`
- * Paths are normalized to forward slashes before matching.
- */
-function globToRegex(pattern) {
-  let re = '';
-  let i = 0;
-  while (i < pattern.length) {
-    const c = pattern[i];
-    if (c === '*') {
-      if (pattern[i + 1] === '*') {
-        // ** — any number of segments, including zero. Handle the common
-        // **/ and /** forms so `a/**/b` matches `a/b` as well as `a/x/y/b`.
-        if (pattern[i + 2] === '/') {
-          re += '(?:.*/)?';
-          i += 3;
-        } else {
-          re += '.*';
-          i += 2;
-        }
-      } else {
-        re += '[^/]*';
-        i += 1;
-      }
-    } else if (c === '?') {
-      re += '[^/]';
-      i += 1;
-    } else if (/[.+^${}()|[\]\\]/.test(c)) {
-      re += '\\' + c;
-      i += 1;
-    } else {
-      re += c;
-      i += 1;
-    }
-  }
-  return new RegExp('^' + re + '$');
 }
 
 // ---------------------------------------------------------------------------

--- a/skill/scripts/live.mjs
+++ b/skill/scripts/live.mjs
@@ -24,6 +24,7 @@ import { fileURLToPath } from 'node:url';
 import { resolveTargetSelection } from './context.mjs';
 import { resolveFiles } from './live-inject.mjs';
 import { readLiveServerInfo } from './lib/impeccable-paths.mjs';
+import { livePathGlobToRegex } from './lib/live-path-globs.mjs';
 import { resolveSurfaceBrief } from './lib/surface-briefs.mjs';
 import { resolveLiveTarget } from './live-target.mjs';
 import { bootInstructions } from './live/instructions.mjs';
@@ -240,7 +241,7 @@ function scanForDrift(rootDir, resolvedFiles, config) {
   // Files matching the user's `exclude` globs are intentional omissions,
   // not drift. Compile them to regexes so the orphan list stays signal.
   const userExcludeRegexes = (Array.isArray(config.exclude) ? config.exclude : [])
-    .map((p) => globToRegex(p));
+    .map(livePathGlobToRegex);
   const isUserExcluded = (rel) => userExcludeRegexes.some((re) => re.test(rel));
 
   const orphans = [];
@@ -276,38 +277,6 @@ function scanForDrift(rootDir, resolvedFiles, config) {
     orphanCount: orphans.length,
     hint: `${orphans.length} HTML file(s) exist but aren't in config.files. Consider adding them, or use a glob pattern like "public/**/*.html".`,
   };
-}
-
-/**
- * Same glob-to-regex mapping used by live-inject.mjs. Kept inline here
- * to avoid a circular import (live-inject.mjs already imports nothing
- * from live.mjs). The two must stay in sync.
- */
-function globToRegex(pattern) {
-  let re = '';
-  let i = 0;
-  while (i < pattern.length) {
-    const c = pattern[i];
-    if (c === '*') {
-      if (pattern[i + 1] === '*') {
-        if (pattern[i + 2] === '/') { re += '(?:.*/)?'; i += 3; }
-        else { re += '.*'; i += 2; }
-      } else {
-        re += '[^/]*';
-        i += 1;
-      }
-    } else if (c === '?') {
-      re += '[^/]';
-      i += 1;
-    } else if (/[.+^${}()|[\]\\]/.test(c)) {
-      re += '\\' + c;
-      i += 1;
-    } else {
-      re += c;
-      i += 1;
-    }
-  }
-  return new RegExp('^' + re + '$');
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/live-inject.test.mjs
+++ b/tests/live-inject.test.mjs
@@ -10,9 +10,37 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+import { livePathGlobToRegex } from '../skill/scripts/lib/live-path-globs.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INJECT = resolve(__dirname, '..', 'skill/scripts/live-inject.mjs');
+
+describe('live path globs', () => {
+  it('matches recursive segments, including zero segments', () => {
+    const anywhere = livePathGlobToRegex('**/index.html');
+    assert.equal(anywhere.test('index.html'), true);
+    assert.equal(anywhere.test('public/index.html'), true);
+    assert.equal(anywhere.test('apps/web/public/index.html'), true);
+
+    const underPublic = livePathGlobToRegex('public/**/*.html');
+    assert.equal(underPublic.test('public/index.html'), true);
+    assert.equal(underPublic.test('public/docs/index.html'), true);
+    assert.equal(underPublic.test('src/index.html'), false);
+  });
+
+  it('keeps single-star and question-mark matches inside one segment', () => {
+    const pattern = livePathGlobToRegex('pages/*/item?.html');
+    assert.equal(pattern.test('pages/docs/item1.html'), true);
+    assert.equal(pattern.test('pages/docs/deep/item1.html'), false);
+    assert.equal(pattern.test('pages/docs/item12.html'), false);
+  });
+
+  it('treats regular-expression punctuation as literal path text', () => {
+    const pattern = livePathGlobToRegex('pages/[draft]/item+.html');
+    assert.equal(pattern.test('pages/[draft]/item+.html'), true);
+    assert.equal(pattern.test('pages/d/itemm.html'), false);
+  });
+});
 
 function runInject(cwd, configPath, args) {
   try {


### PR DESCRIPTION
## Summary
- Move the live-config path glob matcher into one dependency-free helper shared by live injection and drift reporting.
- Delete the two byte-equivalent implementations and add direct characterization coverage for recursive, segment-local, single-character, and literal-regex matching.

## Hindsight judgment
Hindsight is 20/20: if these requirements were implemented today, the boot and injection paths would not each carry a private copy accompanied by a “must stay in sync” comment. The glob syntax is one durable live-config contract, so it now has one implementation.

## Architecture evidence
- Primary target: `skill/scripts/live.mjs`
- Primary file: 365 → 334 lines
- Affected live architecture: 868 lines across `live.mjs` + `live-inject.mjs` → 834 lines across those files plus the shared helper (−34)
- Duplicate mechanisms: 2 → 1
- Responsibilities: boot/drift orchestration and injection/file resolution retain their existing roles; glob translation moves to a focused dependency-free leaf module
- Public contract: unchanged CLI entry points, config schema, glob syntax, output, and error behavior

## Validation
- `node --test tests/live-inject.test.mjs` — 23 passed
- `node --test tests/live-target-context.test.mjs tests/framework-fixtures.test.mjs` — 229 passed
- `bun run build` — passed
- `bun run test` — all relevant suites passed; one unrelated detector CLI case exceeded Bun’s 5-second timeout under full concurrent load, then passed alone in 234 ms with `bun test tests/detect-antipatterns.test.js --test-name-pattern 'local DESIGN.md enables design-system rules by default and --no-design-system disables them'`

Generated provider/root harness output was intentionally omitted; the source-first build validated the generated distribution without syncing tracked harnesses.

## Risk
Low. The shared helper is a direct lift of the two identical implementations, and both consuming flows plus the matcher itself are covered. CI should independently exercise the full suite.

AI-assisted change prepared by Codex under maintainer pbakaus’s standing scheduled-refactor authorization.
