### PR TITLE
Fix: parse oklch in visual-contrast and neon-text (#592)

### DIFF
--- a/cli/engine/browser/injected/index.mjs
+++ b/cli/engine/browser/injected/index.mjs
@@ -626,7 +626,7 @@ if (IS_BROWSER) {
       if (currentStyle.filter && currentStyle.filter !== 'none') reasons.add('filter');
       if (currentStyle.backdropFilter && currentStyle.backdropFilter !== 'none') reasons.add('backdrop filter');
 
-      const solidBg = parseRgb(currentStyle.backgroundColor);
+      const solidBg = parseRgb(currentStyle.backgroundColor) || parseAnyColor(currentStyle.backgroundColor);
       if (solidBg && solidBg.a >= 0.95 && (!bgImage || bgImage === 'none')) break;
       current = current.parentElement;
     }
@@ -688,7 +688,7 @@ if (IS_BROWSER) {
       // starve the url()-backed texts this mode exists to sample.
       if (options.imageOnly && !reasons.includes('image background')) continue;
 
-      const textColor = parseRgb(style.color);
+      const textColor = parseRgb(style.color) || parseAnyColor(style.color);
       const fontSize = parseFloat(style.fontSize) || 16;
       const fontWeight = parseInt(style.fontWeight) || 400;
       const isLargeText = fontSize >= WCAG_LARGE_TEXT_PX || (fontSize >= WCAG_LARGE_BOLD_TEXT_PX && fontWeight >= 700);
@@ -985,7 +985,7 @@ if (IS_BROWSER) {
         return sample;
       }
     }
-    const bg = parseRgb(style.backgroundColor);
+    const bg = parseRgb(style.backgroundColor) || parseAnyColor(style.backgroundColor);
     if (bg && bg.a > 0.05) return { status: 'sampled', color: bg, method: 'solid-background' };
     return { status: 'unresolved', reason: 'no readable background' };
   }
@@ -1115,7 +1115,7 @@ if (IS_BROWSER) {
     }
 
     const style = getComputedStyle(el);
-    const textColor = parseRgb(style.color) || candidate.textColor;
+    const textColor = parseRgb(style.color) || parseAnyColor(style.color) || candidate.textColor;
     if (!textColor) return { ...candidate, status: 'unresolved', confidence: 'none', reason: 'unreadable text color' };
 
     const rect = getDirectTextRect(el) || el.getBoundingClientRect();

--- a/cli/engine/detect-antipatterns-browser.js
+++ b/cli/engine/detect-antipatterns-browser.js
@@ -3986,7 +3986,7 @@ function checkElementAIPaletteDOM(el) {
   }
 
   // Check for neon text (vivid cyan/purple color on dark background)
-  const textColor = parseRgb(style.color);
+  const textColor = parseRgb(style.color) || parseAnyColor(style.color);
   if (textColor && hasChroma(textColor, 80)) {
     const hue = getHue(textColor);
     const isAIPalette = (hue >= 160 && hue <= 200) || (hue >= 260 && hue <= 310);
@@ -7281,7 +7281,7 @@ if (IS_BROWSER) {
       if (currentStyle.filter && currentStyle.filter !== 'none') reasons.add('filter');
       if (currentStyle.backdropFilter && currentStyle.backdropFilter !== 'none') reasons.add('backdrop filter');
 
-      const solidBg = parseRgb(currentStyle.backgroundColor);
+      const solidBg = parseRgb(currentStyle.backgroundColor) || parseAnyColor(currentStyle.backgroundColor);
       if (solidBg && solidBg.a >= 0.95 && (!bgImage || bgImage === 'none')) break;
       current = current.parentElement;
     }
@@ -7343,7 +7343,7 @@ if (IS_BROWSER) {
       // starve the url()-backed texts this mode exists to sample.
       if (options.imageOnly && !reasons.includes('image background')) continue;
 
-      const textColor = parseRgb(style.color);
+      const textColor = parseRgb(style.color) || parseAnyColor(style.color);
       const fontSize = parseFloat(style.fontSize) || 16;
       const fontWeight = parseInt(style.fontWeight) || 400;
       const isLargeText = fontSize >= WCAG_LARGE_TEXT_PX || (fontSize >= WCAG_LARGE_BOLD_TEXT_PX && fontWeight >= 700);
@@ -7640,7 +7640,7 @@ if (IS_BROWSER) {
         return sample;
       }
     }
-    const bg = parseRgb(style.backgroundColor);
+    const bg = parseRgb(style.backgroundColor) || parseAnyColor(style.backgroundColor);
     if (bg && bg.a > 0.05) return { status: 'sampled', color: bg, method: 'solid-background' };
     return { status: 'unresolved', reason: 'no readable background' };
   }
@@ -7770,7 +7770,7 @@ if (IS_BROWSER) {
     }
 
     const style = getComputedStyle(el);
-    const textColor = parseRgb(style.color) || candidate.textColor;
+    const textColor = parseRgb(style.color) || parseAnyColor(style.color) || candidate.textColor;
     if (!textColor) return { ...candidate, status: 'unresolved', confidence: 'none', reason: 'unreadable text color' };
 
     const rect = getDirectTextRect(el) || el.getBoundingClientRect();

--- a/cli/engine/rules/checks.mjs
+++ b/cli/engine/rules/checks.mjs
@@ -2752,7 +2752,7 @@ function checkElementAIPaletteDOM(el) {
   }
 
   // Check for neon text (vivid cyan/purple color on dark background)
-  const textColor = parseRgb(style.color);
+  const textColor = parseRgb(style.color) || parseAnyColor(style.color);
   if (textColor && hasChroma(textColor, 80)) {
     const hue = getHue(textColor);
     const isAIPalette = (hue >= 160 && hue <= 200) || (hue >= 260 && hue <= 310);

--- a/tests/detect-antipatterns-browser.test.mjs
+++ b/tests/detect-antipatterns-browser.test.mjs
@@ -221,12 +221,17 @@ describe('detectUrl — browser-only fixtures', () => {
     assert.equal(contrast.length, 3, `expected exactly the 3 flag-column cases, got ${contrast.length}:\n${snippets}`);
   });
 
-  it('ai-color-palette: oklch neon text on a dark ground is flagged', async () => {
+  it('ai-color-palette: oklch neon text flags the should-flag column only', async () => {
     const f = await detectUrl(`${baseUrl}/fixtures/antipatterns/oklch-neon-text.html`, { visualContrast: false });
-    assert.ok(
-      f.some(r => r.antipattern === 'ai-color-palette' && /Cyan neon text on dark background/i.test(r.snippet || '')),
-      `expected cyan neon-text finding from oklch color, got: ${JSON.stringify(f.map(r => r.snippet))}`,
+    const neon = f.filter(r =>
+      r.antipattern === 'ai-color-palette' && /neon text on dark background/i.test(r.snippet || '')
     );
+    assert.equal(
+      neon.length,
+      1,
+      `expected exactly 1 oklch neon-text finding, got ${neon.length}: ${JSON.stringify(f.map(r => r.snippet))}`,
+    );
+    assert.match(neon[0].snippet || '', /Cyan neon text on dark background/i);
   });
 
   it('shadowed form.id: a <form> with <input name="id"> does not crash the scan (issue #407)', async () => {

--- a/tests/detect-antipatterns-browser.test.mjs
+++ b/tests/detect-antipatterns-browser.test.mjs
@@ -221,6 +221,14 @@ describe('detectUrl — browser-only fixtures', () => {
     assert.equal(contrast.length, 3, `expected exactly the 3 flag-column cases, got ${contrast.length}:\n${snippets}`);
   });
 
+  it('ai-color-palette: oklch neon text on a dark ground is flagged', async () => {
+    const f = await detectUrl(`${baseUrl}/fixtures/antipatterns/oklch-neon-text.html`, { visualContrast: false });
+    assert.ok(
+      f.some(r => r.antipattern === 'ai-color-palette' && /Cyan neon text on dark background/i.test(r.snippet || '')),
+      `expected cyan neon-text finding from oklch color, got: ${JSON.stringify(f.map(r => r.snippet))}`,
+    );
+  });
+
   it('shadowed form.id: a <form> with <input name="id"> does not crash the scan (issue #407)', async () => {
     // HTMLFormElement named-property shadowing makes form.id / form.className
     // return the child input element, whose .startsWith throws. Every Shopify

--- a/tests/fixtures/antipatterns/oklch-neon-text.html
+++ b/tests/fixtures/antipatterns/oklch-neon-text.html
@@ -7,23 +7,71 @@
   <style>
     :root {
       --neon: oklch(0.85 0.2 195);
+      --muted: oklch(0.85 0.04 195);
+      --paper: oklch(0.9 0 0);
+      --ground: #050505;
+      --light: #f5f5f5;
     }
 
     body {
       margin: 0;
       padding: 32px;
-      background: #050505;
+      background: var(--ground);
       font-family: system-ui, sans-serif;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 24px;
+      max-width: 980px;
+      margin: 0 auto;
+    }
+
+    .column {
+      display: grid;
+      gap: 14px;
+    }
+
+    .column > h2 {
+      margin: 0 0 2px;
+      color: var(--paper);
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      line-height: 1.4;
+      text-transform: uppercase;
     }
 
     p {
       margin: 0;
-      color: var(--neon);
       font-size: 18px;
+    }
+
+    .neon-cyan { color: var(--neon); }
+    .muted-cyan { color: var(--muted); }
+    .oklch-paper { color: var(--paper); }
+
+    .light-shell {
+      background: var(--light);
+      padding: 12px;
     }
   </style>
 </head>
 <body>
-  <p>Cyan neon token</p>
+  <main class="grid">
+    <section class="column" data-col="flag">
+      <h2>Should flag</h2>
+      <p class="neon-cyan">Cyan neon token</p>
+    </section>
+    <section class="column" data-col="pass">
+      <h2>Should pass</h2>
+      <p class="oklch-paper">Achromatic oklch on dark should pass</p>
+      <p class="muted-cyan">Muted cyan oklch on dark should pass</p>
+      <div class="light-shell">
+        <p class="neon-cyan">Cyan oklch on light ground should pass</p>
+      </div>
+    </section>
+  </main>
 </body>
 </html>

--- a/tests/fixtures/antipatterns/oklch-neon-text.html
+++ b/tests/fixtures/antipatterns/oklch-neon-text.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OKLCH Neon Text Fixture</title>
+  <style>
+    :root {
+      --neon: oklch(0.85 0.2 195);
+    }
+
+    body {
+      margin: 0;
+      padding: 32px;
+      background: #050505;
+      font-family: system-ui, sans-serif;
+    }
+
+    p {
+      margin: 0;
+      color: var(--neon);
+      font-size: 18px;
+    }
+  </style>
+</head>
+<body>
+  <p>Cyan neon token</p>
+</body>
+</html>

--- a/tests/fixtures/antipatterns/visual-contrast.html
+++ b/tests/fixtures/antipatterns/visual-contrast.html
@@ -9,6 +9,7 @@
       --paper: #f7f3ee;
       --ink: #171717;
       --muted: #566174;
+      --flag-white: oklch(1 0 0);
     }
 
     body {
@@ -110,7 +111,7 @@
       <h2>Should flag after pixel sampling</h2>
 
       <article class="image-card light-image">
-        <p style="color: rgb(255, 255, 255);">White text on light image should be sampled by pixel contrast.</p>
+        <p style="color: var(--flag-white);">White text on light image should be sampled by pixel contrast.</p>
       </article>
 
       <article class="image-card dark-image">


### PR DESCRIPTION
Visual-contrast and neon-text called parseRgb() alone, so Chrome-preserved oklch() (Tailwind v4) became null and those checks skipped or mis-scored. Added the existing parseRgb() || parseAnyColor() fallback at the five sites.

Fixes #592

Validation: bun run test (default suite, fail 0). AI-assisted (Cursor agent).

Made with [Cursor](https://cursor.com)