### PR TITLE
Fix: strip comments in markup and stylesheets before regex matchers (#589)

### DIFF
--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -261,20 +261,115 @@ function blankHtmlComments(text) {
   return text.replace(/<!--[\s\S]*?-->/g, comment => comment.replace(/[^\n]/g, ' '));
 }
 
+function blankHtmlAndCssCommentsOutsideScripts(text) {
+  const re = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+  let output = '';
+  let lastIndex = 0;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    output += stripCssComments(blankHtmlComments(text.slice(lastIndex, match.index)));
+    output += match[0];
+    lastIndex = re.lastIndex;
+  }
+  return output + stripCssComments(blankHtmlComments(text.slice(lastIndex)));
+}
+
+function blankCssLineComments(text) {
+  let output = '';
+  let state = 'code';
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const next = text[i + 1];
+    if (state === 'line') {
+      if (char === '\n') {
+        output += '\n';
+        state = 'code';
+      } else {
+        output += ' ';
+      }
+      continue;
+    }
+    if (state === 'single' || state === 'double') {
+      output += char;
+      if (char === '\\' && next) {
+        output += next;
+        i++;
+      } else if ((state === 'single' && char === "'") || (state === 'double' && char === '"')) {
+        state = 'code';
+      }
+      continue;
+    }
+    const prev = output.length ? output[output.length - 1] : '';
+    if (char === '/' && next === '/' && prev !== ':' && prev !== '(' && prev !== '\\') {
+      output += '  ';
+      i++;
+      state = 'line';
+      continue;
+    }
+    if (char === "'") state = 'single';
+    else if (char === '"') state = 'double';
+    output += char;
+  }
+  return output;
+}
+
+function findAstroFrontmatterClose(text) {
+  if (!text.startsWith('---')) return -1;
+  let cursor = text.indexOf('\n');
+  if (cursor === -1) return -1;
+  cursor += 1;
+  while (cursor < text.length) {
+    if (text[cursor - 1] === '\n' && text.startsWith('---', cursor)) {
+      let end = cursor + 3;
+      while (text[end] === ' ' || text[end] === '\t') end++;
+      if (end >= text.length || text[end] === '\n' || text[end] === '\r') return cursor - 1;
+    }
+    const char = text[cursor];
+    const next = text[cursor + 1];
+    if (char === "'" || char === '"') {
+      const close = findQuotedStringEnd(text, cursor, char);
+      if (close === -1) return -1;
+      cursor = close + 1;
+      continue;
+    }
+    if (char === '`') {
+      const close = findTemplateLiteralEnd(text, cursor);
+      if (close === -1) return -1;
+      cursor = close + 1;
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      const lineEnd = text.indexOf('\n', cursor);
+      if (lineEnd === -1) return -1;
+      cursor = lineEnd;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      const commentEnd = text.indexOf('*/', cursor + 2);
+      if (commentEnd === -1) return -1;
+      cursor = commentEnd + 2;
+      continue;
+    }
+    cursor++;
+  }
+  return -1;
+}
+
 function blankAstroFrontmatterComments(text) {
-  if (!text.startsWith('---')) return text;
-  const close = text.indexOf('\n---', 3);
+  const close = findAstroFrontmatterClose(text);
   if (close === -1) return text;
   return stripJsComments(text.slice(0, close)) + text.slice(close);
 }
 
 function blankCommentsForMatchers(text, ext) {
   if (PAGE_ANALYZER_EXTS.has(ext)) {
-    let next = stripCssComments(blankHtmlComments(text));
-    if (ext === '.astro') next = blankAstroFrontmatterComments(next);
-    return next;
+    const withFrontmatter = ext === '.astro' ? blankAstroFrontmatterComments(text) : text;
+    return blankHtmlAndCssCommentsOutsideScripts(withFrontmatter);
   }
-  if (STYLESHEET_EXTS.has(ext)) return stripCssComments(text);
+  if (STYLESHEET_EXTS.has(ext)) {
+    const withoutBlocks = stripCssComments(text);
+    return ext === '.css' ? withoutBlocks : blankCssLineComments(withoutBlocks);
+  }
   return text;
 }
 

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -294,6 +294,7 @@ function blankHtmlAndCssCommentsOutsideScripts(text) {
 function blankCssLineComments(text) {
   let output = '';
   let state = 'code';
+  let urlDepth = 0;
   for (let i = 0; i < text.length; i++) {
     const char = text[i];
     const next = text[i + 1];
@@ -317,7 +318,7 @@ function blankCssLineComments(text) {
       continue;
     }
     const prev = output.length ? output[output.length - 1] : '';
-    if (char === '/' && next === '/' && prev !== ':' && prev !== '(' && prev !== '\\') {
+    if (char === '/' && next === '/' && urlDepth === 0 && prev !== ':' && prev !== '(' && prev !== '\\') {
       output += '  ';
       i++;
       state = 'line';
@@ -325,6 +326,12 @@ function blankCssLineComments(text) {
     }
     if (char === "'") state = 'single';
     else if (char === '"') state = 'double';
+    if (char === '(') {
+      const behind = output.replace(/\s+$/, '');
+      if (urlDepth > 0 || /url$/i.test(behind)) urlDepth++;
+    } else if (char === ')' && urlDepth) {
+      urlDepth--;
+    }
     output += char;
   }
   return output;
@@ -366,6 +373,13 @@ function findAstroFrontmatterClose(text) {
       if (commentEnd === -1) return -1;
       cursor = commentEnd + 2;
       continue;
+    }
+    if (char === '/' && next !== '/' && next !== '*') {
+      const close = findRegexLiteralEnd(text, cursor);
+      if (close !== -1) {
+        cursor = close + 1;
+        continue;
+      }
     }
     cursor++;
   }

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -261,17 +261,34 @@ function blankHtmlComments(text) {
   return text.replace(/<!--[\s\S]*?-->/g, comment => comment.replace(/[^\n]/g, ' '));
 }
 
+function blankCssLineCommentsInStyleBlocks(text) {
+  const re = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+  let output = '';
+  let lastIndex = 0;
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    const inner = match[1];
+    const openLength = match[0].length - inner.length - '</style>'.length;
+    output += text.slice(lastIndex, match.index);
+    output += match[0].slice(0, openLength);
+    output += blankCssLineComments(inner);
+    output += match[0].slice(openLength + inner.length);
+    lastIndex = re.lastIndex;
+  }
+  return output + text.slice(lastIndex);
+}
+
 function blankHtmlAndCssCommentsOutsideScripts(text) {
   const re = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
   let output = '';
   let lastIndex = 0;
   let match;
   while ((match = re.exec(text)) !== null) {
-    output += stripCssComments(blankHtmlComments(text.slice(lastIndex, match.index)));
+    output += blankCssLineCommentsInStyleBlocks(stripCssComments(blankHtmlComments(text.slice(lastIndex, match.index))));
     output += match[0];
     lastIndex = re.lastIndex;
   }
-  return output + stripCssComments(blankHtmlComments(text.slice(lastIndex)));
+  return output + blankCssLineCommentsInStyleBlocks(stripCssComments(blankHtmlComments(text.slice(lastIndex))));
 }
 
 function blankCssLineComments(text) {
@@ -1194,7 +1211,7 @@ function detectText(content, filePath, options = {}) {
     }, () => extractStyleBlocks(content, ext))
     : extractStyleBlocks(content, ext);
   for (const block of styleBlocks) {
-    const blockContent = stripCssComments(block.content);
+    const blockContent = blankCssLineComments(stripCssComments(block.content));
     const blockLines = blockContent.split('\n');
     findings.push(...runRegexMatchers(blockLines, filePath, block.startLine - 1, true, {
       profile,

--- a/cli/engine/engines/regex/detect-text.mjs
+++ b/cli/engine/engines/regex/detect-text.mjs
@@ -42,6 +42,7 @@ function shouldRunPageAnalyzers(content, filePath) {
 }
 
 const JS_SOURCE_EXTS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const STYLESHEET_EXTS = new Set(['.css', '.scss', '.sass', '.less']);
 const REGEX_PREFIX_KEYWORDS = new Set(['await', 'case', 'default', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'of', 'return', 'throw', 'typeof', 'void', 'yield']);
 const BLOCK_BRACE_PREFIX_KEYWORDS = new Set(['do', 'else', 'finally', 'try']);
 
@@ -254,6 +255,27 @@ function stripJsComments(content, options = {}) {
 
 function stripCssComments(content) {
   return content.replace(/\/\*[\s\S]*?\*\//g, comment => comment.replace(/[^\n]/g, ' '));
+}
+
+function blankHtmlComments(text) {
+  return text.replace(/<!--[\s\S]*?-->/g, comment => comment.replace(/[^\n]/g, ' '));
+}
+
+function blankAstroFrontmatterComments(text) {
+  if (!text.startsWith('---')) return text;
+  const close = text.indexOf('\n---', 3);
+  if (close === -1) return text;
+  return stripJsComments(text.slice(0, close)) + text.slice(close);
+}
+
+function blankCommentsForMatchers(text, ext) {
+  if (PAGE_ANALYZER_EXTS.has(ext)) {
+    let next = stripCssComments(blankHtmlComments(text));
+    if (ext === '.astro') next = blankAstroFrontmatterComments(next);
+    return next;
+  }
+  if (STYLESHEET_EXTS.has(ext)) return stripCssComments(text);
+  return text;
 }
 
 function firstOverusedGoogleFont(text) {
@@ -1028,14 +1050,13 @@ function detectText(content, filePath, options = {}) {
   const ext = extFromFilePath(filePath);
   const commentStrippedSource = JS_SOURCE_EXTS.has(ext) ? stripJsComments(content, {
     jsx: ext === '.js' || ext === '.jsx' || ext === '.tsx',
-  }) : content;
+  }) : blankCommentsForMatchers(content, ext);
   const source = stripCssInJsComments(commentStrippedSource, ext);
   const lines = source.split('\n');
 
   // Run regex matchers on the full file content (catches Tailwind classes, inline styles)
   // Enable block context for CSS files where related properties span multiple lines
-  const cssLike = new Set(['.css', '.scss', '.sass', '.less']);
-  findings.push(...runRegexMatchers(lines, filePath, 0, cssLike.has(ext) || null, {
+  findings.push(...runRegexMatchers(lines, filePath, 0, STYLESHEET_EXTS.has(ext) || null, {
     profile,
     phase: 'source',
   }));
@@ -1050,7 +1071,7 @@ function detectText(content, filePath, options = {}) {
     scanCssTextForPseudoStripe(text).map(hit =>
       finding(hit.id, filePath, hit.snippet, lineOffset + text.slice(0, hit.index).split('\n').length));
 
-  if (cssLike.has(ext)) {
+  if (STYLESHEET_EXTS.has(ext)) {
     findings.push(...scanInsetStripeCss(content, filePath));
     findings.push(...pseudoStripeFindings(content, 0));
   }
@@ -1078,7 +1099,8 @@ function detectText(content, filePath, options = {}) {
     }, () => extractStyleBlocks(content, ext))
     : extractStyleBlocks(content, ext);
   for (const block of styleBlocks) {
-    const blockLines = block.content.split('\n');
+    const blockContent = stripCssComments(block.content);
+    const blockLines = blockContent.split('\n');
     findings.push(...runRegexMatchers(blockLines, filePath, block.startLine - 1, true, {
       profile,
       phase: 'style-block',
@@ -1089,8 +1111,8 @@ function detectText(content, filePath, options = {}) {
     // 1-based, so the offset is startLine - 2; startLine - 1 double-counted and
     // reported every selector one line low. runRegexMatchers keeps startLine - 1
     // because it indexes its split lines from zero.
-    findings.push(...scanInsetStripeCss(block.content, filePath, block.startLine - 2));
-    findings.push(...pseudoStripeFindings(block.content, block.startLine - 2));
+    findings.push(...scanInsetStripeCss(blockContent, filePath, block.startLine - 2));
+    findings.push(...pseudoStripeFindings(blockContent, block.startLine - 2));
   }
 
   // Extract and scan CSS-in-JS template literals

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -495,6 +495,62 @@ describe('detectText — broken images in source comments', () => {
     expect(broken).toHaveLength(1);
     expect(broken[0].line).toBe(6);
   });
+
+  test('does not treat comment markers inside script strings as markup comments', () => {
+    const htmlDelimiters = [
+      '<script>const open = "<!--";</script>',
+      '<img>',
+      '<script>const close = "-->";</script>',
+    ].join('\n');
+    const cssDelimiters = [
+      '<script>const open = "/*";</script>',
+      '<img>',
+      '<script>const close = "*/";</script>',
+    ].join('\n');
+
+    for (const filePath of ['hero.astro', 'hero.vue', 'hero.svelte']) {
+      expect(detectText(htmlDelimiters, filePath).filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+      expect(detectText(cssDelimiters, filePath).filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+    }
+  });
+
+  test('ignores preprocessor line comments in stylesheets', () => {
+    const source = '// font-family: Inter\n.hero { color: red; }';
+
+    for (const filePath of ['hero.scss', 'hero.sass', 'hero.less']) {
+      expect(detectText(source, filePath).filter(r => r.antipattern === 'overused-font')).toHaveLength(0);
+    }
+  });
+
+  test('still detects live font-family after a preprocessor line comment', () => {
+    const source = '// skip this\n.hero { font-family: Inter; }';
+
+    const findings = detectText(source, 'hero.scss').filter(r => r.antipattern === 'overused-font');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].line).toBe(2);
+  });
+
+  test('does not blank https URLs in SCSS', () => {
+    const source = '.hero { background: url(https://example.com/i.png); }\n.hero { font-family: Inter; }';
+
+    const findings = detectText(source, 'hero.scss').filter(r => r.antipattern === 'overused-font');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].line).toBe(2);
+  });
+
+  test('ignores frontmatter comments after a --- line inside a template literal', () => {
+    const source = [
+      '---',
+      'const md = `',
+      '---',
+      '`;',
+      '// <img src="" alt="Comment-only image" />',
+      '---',
+      '<div>ok</div>',
+    ].join('\n');
+
+    expect(detectText(source, 'hero.astro').filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
 });
 
 describe('detectText — CSS borders', () => {

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -551,6 +551,32 @@ describe('detectText — broken images in source comments', () => {
 
     expect(detectText(source, 'hero.astro').filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
   });
+
+  test('ignores preprocessor line comments in component style blocks', () => {
+    const source = [
+      '<style lang="scss">',
+      '// font-family: Inter',
+      '.hero { color: red; }',
+      '</style>',
+    ].join('\n');
+
+    for (const filePath of ['hero.astro', 'hero.vue', 'hero.svelte']) {
+      expect(detectText(source, filePath).filter(r => r.antipattern === 'overused-font')).toHaveLength(0);
+    }
+  });
+
+  test('still detects live font-family after a style-block line comment', () => {
+    const source = [
+      '<style lang="scss">',
+      '// skip this',
+      '.hero { font-family: Inter; }',
+      '</style>',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.vue').filter(r => r.antipattern === 'overused-font');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].line).toBe(3);
+  });
 });
 
 describe('detectText — CSS borders', () => {

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -382,6 +382,119 @@ describe('detectText — broken images in source comments', () => {
 
     expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
   });
+
+  test('ignores img tags in Astro style block comments', () => {
+    const source = [
+      '---',
+      'const title = "Hero";',
+      '---',
+      '<style>',
+      '  /*',
+      '   * Example markup: <img src="">',
+      '   */',
+      '  .hero { color: red; }',
+      '</style>',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.astro');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
+  test('ignores img tags in Astro HTML comments', () => {
+    const source = [
+      '---',
+      'const title = "Hero";',
+      '---',
+      '<!-- <img src="" alt="Comment-only image" /> -->',
+      '<img src="/logo.png" alt="Logo" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.astro');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
+  test('ignores img tags in Astro frontmatter line comments', () => {
+    const source = [
+      '---',
+      '// <img src="" alt="Comment-only image" />',
+      'const site = "https://example.com";',
+      '---',
+      '<img src="/logo.png" alt="Logo" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.astro');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
+  test('ignores img tags in CSS block comments', () => {
+    const source = [
+      '/*',
+      ' * Example markup: <img src="">',
+      ' */',
+      '.hero { color: red; }',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.css');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
+  test('still detects real img tags after an HTML comment in Astro', () => {
+    const source = [
+      '---',
+      'const title = "Hero";',
+      '---',
+      '<!-- decorative only -->',
+      '<img src="" alt="Empty source" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.astro');
+
+    const broken = findings.filter(r => r.antipattern === 'broken-image');
+    expect(broken).toHaveLength(1);
+    expect(broken[0].line).toBe(5);
+  });
+
+  test('does not blank https URLs in Astro frontmatter', () => {
+    const source = [
+      '---',
+      'const site = "https://example.com/logo.png";',
+      '---',
+      '<img src="" alt="Empty source" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.astro');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
+  test('keeps same-line img visible after a bare https URL in Astro markup', () => {
+    const source = '<p>https://example.com <img src="" alt="Empty source" /></p>';
+
+    const findings = detectText(source, 'hero.astro');
+
+    expect(findings.filter(r => r.antipattern === 'broken-image')).toHaveLength(1);
+  });
+
+  test('preserves line numbers after comment blanking in Astro', () => {
+    const source = [
+      '---',
+      'const title = "Hero";',
+      '---',
+      '<!-- <img src="" alt="Comment-only image" /> -->',
+      '<p>Intro copy</p>',
+      '<img src="" alt="Empty source" />',
+    ].join('\n');
+
+    const findings = detectText(source, 'hero.astro');
+
+    const broken = findings.filter(r => r.antipattern === 'broken-image');
+    expect(broken).toHaveLength(1);
+    expect(broken[0].line).toBe(6);
+  });
 });
 
 describe('detectText — CSS borders', () => {

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -577,6 +577,33 @@ describe('detectText — broken images in source comments', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].line).toBe(3);
   });
+
+  test('ignores frontmatter comments after a regex literal that contains quotes', () => {
+    const source = [
+      '---',
+      'const re = /["\']/;',
+      '// <img src="" alt="Comment-only image" />',
+      '---',
+      '<div>ok</div>',
+    ].join('\n');
+
+    expect(detectText(source, 'hero.astro').filter(r => r.antipattern === 'broken-image')).toHaveLength(0);
+  });
+
+  test('keeps live font-family after a protocol-relative URL in SCSS', () => {
+    const sources = [
+      '.hero { background: url( //cdn.example.com/i.png); font-family: Inter; }',
+      '.hero { background: url(#{$prefix}//cdn.example.com/i.png); font-family: Inter; }',
+    ];
+
+    for (const source of sources) {
+      expect(detectText(source, 'hero.scss').filter(r => r.antipattern === 'overused-font')).toHaveLength(1);
+    }
+    expect(detectText(
+      '.hero { background: url(@{prefix}//cdn.example.com/i.png); font-family: Inter; }',
+      'hero.less',
+    ).filter(r => r.antipattern === 'overused-font')).toHaveLength(1);
+  });
 });
 
 describe('detectText — CSS borders', () => {


### PR DESCRIPTION
detectText only blanked comments for JS/TS, so broken-image still fired on <img> written inside Astro/Vue/Svelte comments, CSS comments, and extracted style blocks. Non-JS sources now get the same offset-preserving blanking, and style-block scans strip CSS comments the way the CSS-in-JS loop already did. Fixes #589

Prepared with AI assistance. Validated with bun test tests/detect-antipatterns.test.js and bun run test.

Made with [Cursor](https://cursor.com)