### PR TITLE
Share doctor boot finding policy

### DIFF
--- a/skill/scripts/doctor.mjs
+++ b/skill/scripts/doctor.mjs
@@ -33,13 +33,8 @@ import {
   stampProductSchema,
 } from './lib/artifact-schema.mjs';
 import {
-  checkBuildPathUnset,
-  checkConfig,
-  checkDesignSidecar,
+  collectBootFindingGroups,
   checkNativePlatformEvidence,
-  checkProduct,
-  checkProjectRoots,
-  checkSurfaceBriefs,
   designSidecarCandidatesFor,
 } from './lib/staleness.mjs';
 import {
@@ -106,34 +101,30 @@ async function collect(cwd, targetOptions) {
     extractPlatform,
     readFile: safeRead,
   });
+  const bootFindings = collectBootFindingGroups(ctx, {
+    absDesignPath,
+    sidecarCandidates,
+    projectRootPatterns: readProjectRootPatterns(ctx.repoRoot),
+    targetCandidates: workspaceCandidates,
+  });
 
   const findings = [
-    ...checkProduct(ctx.product, ctx.productPath || 'PRODUCT.md'),
-    ...(ctx.product
-      ? checkNativePlatformEvidence({
-          projectRoot,
-          platform: ctx.platform,
-          product: ctx.product,
-          productPath: ctx.productPath,
-        })
-      : []),
-    ...checkDesignSidecar({ designPath: absDesignPath, sidecarCandidates, projectRoot }),
+    ...bootFindings.product,
+    ...bootFindings.nativePlatform,
+    ...bootFindings.designSidecar,
     ...checkDesignDrift({ designPath: absDesignPath, projectRoot }),
     ...checkDesignCoverage({ design: ctx.design, designPath: ctx.designPath, parseDesignMd }),
-    ...checkConfig({ projectRoot, repoRoot: ctx.repoRoot }),
-    ...checkBuildPathUnset({ projectRoot, repoRoot: ctx.repoRoot, product: ctx.product }),
+    ...bootFindings.config,
+    ...bootFindings.buildPath,
     ...checkDetectorIgnores({ projectRoot, knownRuleIds }),
-    ...checkSurfaceBriefs({ candidates: ctx.surfaceBriefCandidates, projectRoot }),
+    ...bootFindings.surfaceBriefs,
     ...checkHookInstallation({
       projectRoot,
       repoRoot: ctx.repoRoot,
       providerId: IMPECCABLE_PROVIDER_ID,
     }),
     ...checkLegacyLiveState({ projectRoot }),
-    ...checkProjectRoots({
-      patterns: readProjectRootPatterns(ctx.repoRoot),
-      candidates: workspaceCandidates,
-    }),
+    ...bootFindings.projectRoots,
     ...workspaceResult.findings,
   ];
 

--- a/skill/scripts/lib/staleness.mjs
+++ b/skill/scripts/lib/staleness.mjs
@@ -488,41 +488,46 @@ export function describeWorkspaceContext(candidates = []) {
 // ─── Tier 1 orchestration ──────────────────────────────────────────────────
 
 /**
- * Everything a boot can afford. `ctx` is the loadContext result; `extras`
- * carries values the caller already computed so nothing is recomputed here.
+ * Everything a boot can afford, grouped by artifact so deeper reports can
+ * interleave their own checks without rebuilding this policy. `ctx` is the
+ * loadContext result; `extras` carries values the caller already computed so
+ * nothing is recomputed here.
  */
-export function collectBootFindings(ctx, extras = {}) {
-  if (!ctx) return [];
+export function collectBootFindingGroups(ctx, extras = {}) {
+  if (!ctx) return {};
   const projectRoot = ctx.projectRoot || process.cwd();
-  const absProductPath = extras.absProductPath || null;
   const absDesignPath = extras.absDesignPath || null;
 
-  return [
-    ...checkProduct(ctx.product, ctx.productPath || 'PRODUCT.md'),
+  return {
+    product: checkProduct(ctx.product, ctx.productPath || 'PRODUCT.md'),
     // Only checked once a PRODUCT.md exists. Without one the boot already
     // emits NO_PRODUCT_MD and routes into init, which asks for the platform
     // directly; a second signal saying the same thing is noise.
-    ...(ctx.product
+    nativePlatform: ctx.product
       ? checkNativePlatformEvidence({
           projectRoot,
           platform: ctx.platform,
           product: ctx.product,
           productPath: ctx.productPath,
         })
-      : []),
-    ...checkDesignSidecar({
+      : [],
+    designSidecar: checkDesignSidecar({
       designPath: absDesignPath,
       sidecarCandidates: extras.sidecarCandidates || [],
       projectRoot,
     }),
-    ...checkConfig({ projectRoot, repoRoot: ctx.repoRoot }),
-    ...checkBuildPathUnset({ projectRoot, repoRoot: ctx.repoRoot, product: ctx.product }),
-    ...checkSurfaceBriefs({ candidates: ctx.surfaceBriefCandidates, projectRoot }),
-    ...(extras.projectRootPatterns
+    config: checkConfig({ projectRoot, repoRoot: ctx.repoRoot }),
+    buildPath: checkBuildPathUnset({ projectRoot, repoRoot: ctx.repoRoot, product: ctx.product }),
+    surfaceBriefs: checkSurfaceBriefs({ candidates: ctx.surfaceBriefCandidates, projectRoot }),
+    projectRoots: extras.projectRootPatterns
       ? checkProjectRoots({
           patterns: extras.projectRootPatterns,
           candidates: extras.targetCandidates || [],
         })
-      : []),
-  ];
+      : [],
+  };
+}
+
+export function collectBootFindings(ctx, extras = {}) {
+  return Object.values(collectBootFindingGroups(ctx, extras)).flat();
 }

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -634,6 +634,26 @@ describe('doctor CLI', () => {
     assert.equal(report.ruleRegistryAvailable, true);
   });
 
+  it('keeps boot and deep findings in their established artifact order', () => {
+    write('PRODUCT.md', '# Product\n\n## Register\n\nbrand\n\n## Users\nDesigners.\n');
+    write('DESIGN.md', '---\nname: Example\n---\n\n# Design System: Example\n');
+    write('.impeccable/design.json', JSON.stringify({ schemaVersion: 1 }));
+    write('.impeccable/config.json', JSON.stringify({ unknownSetting: true }));
+
+    const res = run(['--json']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(
+      JSON.parse(res.stdout).findings.map((entry) => entry.id),
+      [
+        'product-deprecated-register',
+        'product-schema-legacy',
+        'design-sidecar-schema-outdated',
+        'design-md-coverage',
+        'config-unknown-keys',
+      ],
+    );
+  });
+
   it('applies only the automatic migrations under --fix', () => {
     write('PRODUCT.md', CURRENT_PRODUCT.replace('<!-- impeccable:product-schema 1 -->\n\n', ''));
     write('DESIGN.json', JSON.stringify({ schemaVersion: 2 }));


### PR DESCRIPTION
## Summary
- centralize the seven boot-time artifact finding groups in `staleness.mjs`
- let `doctor.mjs` interleave its deeper checks with those shared groups instead of rebuilding boot policy
- characterize the established doctor finding order

## Hindsight judgment
**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No.

The doctor should own deep diagnostics, rendering, and fixes. It should not carry a second copy of the boot artifact policy already owned by the staleness layer. The smallest behavior-preserving architecture is a named-group view of that existing policy, allowing doctor to preserve its exact interleaving without duplicating guards, inputs, or check order.

## Before / after
- Primary target, `skill/scripts/doctor.mjs`: **338 → 329 lines**
- Affected production architecture, doctor + staleness: **866 → 862 lines**
- Boot-policy assemblers: **2 → 1**
- Production diff: **35 additions / 39 deletions** (net −4)
- Public CLI output, JSON schema, finding order, exports, error semantics, and fix behavior: unchanged
- Responsibilities after: staleness owns boot artifact policy; doctor owns deep checks and presentation/fixes

## Validation
- `node --test tests/staleness.test.mjs tests/doctor.test.mjs` — **105 passed**
- `bun run build` — passed
- Default-suite coverage:
  - core — **713 passed**
  - detector — all tests passed; one unrelated quick-benchmark case exceeded the 5-second limit under concurrent load, then passed alone in **863 ms**
  - live — all tests passed after an orphaned prior test server caused one `EADDRINUSE`; the affected restart test then passed alone
  - framework fixtures — **216 passed**
  - plugin loader E2E — **4 passed**

Generated provider/root harness output was intentionally omitted; the source-first build validated the distribution without syncing tracked harnesses.

## Risk
Low. The shared function groups existing results without changing any individual check. A new characterization test locks the doctor finding order.

## Authorization and AI assistance
Prepared with AI assistance by OpenAI Codex under maintainer pbakaus explicit standing authorization for the scheduled architecture-simplification automation. This PR is ready for review and is **not** authorized for automatic merge.
