### PR TITLE
Docs: Link harness trust guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ npx impeccable update
 
 Codex users should open `/hooks` after install or update and approve the project hook when prompted. Codex tracks trust by hook definition, so updates that change `.codex/hooks.json` can require approval again. Grok Build users need project folder trust (`/hooks-trust` or launch with `--trust`) before `.grok/hooks/` scripts run.
 
+See [Allow the hook in your harness](https://impeccable.style/docs/hooks#allow-the-hook-in-your-harness) for harness-specific trust and verification steps.
+
 ### Option 2: Git Submodule
 
 For teams that want to keep Impeccable vendored and updated through Git, add this repo as a submodule and link the compiled provider build into your harness folders:


### PR DESCRIPTION

## Summary

Adds a README link from the installer trust guidance to the new harness-specific approval and verification section on impeccable.style.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation link; no runtime, security, or installer logic is changed.
> 
> **Overview**
> Adds a README link after the CLI installer trust notes so users can jump to harness-specific hook approval and verification on impeccable.style.
> 
> The destination is `https://impeccable.style/docs/hooks#allow-the-hook-in-your-harness`. No code or installer behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21510c3632332c750a235c3bc1785c9a3352159c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->