### PR TITLE
Simplify CI test plan routing

### DIFF
--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -12,32 +12,20 @@ const localNoChanges = !eventName && !process.env.CI_CHANGED_FILES;
 // (skill-behavior, accept-cleanup, deepseek), every single night.
 const isSchedule = eventName === 'schedule';
 const changedFiles = localNoChanges || isSchedule ? [] : getChangedFiles();
-const forceDeterministic = localNoChanges || eventName === 'push' || eventName === 'workflow_dispatch';
+const forceDeterministic = localNoChanges || isSchedule || eventName === 'push' || eventName === 'workflow_dispatch';
 const forceOptIn = eventName === 'workflow_dispatch';
 
-const plan = isSchedule
-  ? {
-    core: true,
-    detector: true,
-    live: true,
-    framework: true,
-    cli_remote_e2e: false,
-    live_e2e: true,
-    live_e2e_accept_cleanup: false,
-    skill_behavior: false,
-    live_svelte_adapter_deepseek: false,
-  }
-  : {
-    core: true,
-    detector: forceDeterministic || matchesSuiteTriggers('detector', changedFiles),
-    live: forceDeterministic || matchesSuiteTriggers('live', changedFiles),
-    framework: forceDeterministic || matchesSuiteTriggers('framework', changedFiles),
-    cli_remote_e2e: forceOptIn,
-    live_e2e: forceOptIn || matchesSuiteTriggers('live-e2e', changedFiles),
-    live_e2e_accept_cleanup: forceOptIn || matchesSuiteTriggers('live-e2e-accept-cleanup', changedFiles),
-    skill_behavior: forceOptIn || matchesSuiteTriggers('skill-behavior', changedFiles),
-    live_svelte_adapter_deepseek: forceOptIn || matchesSuiteTriggers('live-svelte-adapter-deepseek', changedFiles),
-  };
+const plan = {
+  core: true,
+  detector: forceDeterministic || matchesSuiteTriggers('detector', changedFiles),
+  live: forceDeterministic || matchesSuiteTriggers('live', changedFiles),
+  framework: forceDeterministic || matchesSuiteTriggers('framework', changedFiles),
+  cli_remote_e2e: forceOptIn,
+  live_e2e: isSchedule || forceOptIn || matchesSuiteTriggers('live-e2e', changedFiles),
+  live_e2e_accept_cleanup: forceOptIn || matchesSuiteTriggers('live-e2e-accept-cleanup', changedFiles),
+  skill_behavior: forceOptIn || matchesSuiteTriggers('skill-behavior', changedFiles),
+  live_svelte_adapter_deepseek: forceOptIn || matchesSuiteTriggers('live-svelte-adapter-deepseek', changedFiles),
+};
 
 writeGithubOutputs(plan);
 printSummary(plan, changedFiles);

--- a/tests/ci-test-plan.test.mjs
+++ b/tests/ci-test-plan.test.mjs
@@ -103,7 +103,9 @@ describe('ci-test-plan', () => {
     assert.equal(outputs.live_svelte_adapter_deepseek, 'false');
     assert.equal(outputs.cli_remote_e2e, 'false');
     assert.equal(outputs.core, 'true');
+    assert.equal(outputs.detector, 'true');
     assert.equal(outputs.live, 'true');
+    assert.equal(outputs.framework, 'true');
   });
 
 });


### PR DESCRIPTION
## Summary

- collapse the nightly CI test plan into the same event-routing object used by pull requests, pushes, and manual runs
- keep schedule behavior as two explicit conditions: deterministic suites are forced and only the full live E2E opt-in is enabled
- strengthen nightly characterization for every deterministic suite

## Hindsight judgment

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No.

A schedule event differs from normal routing in only two decisions, so it should not own a second complete nine-output plan. The smallest cleaner architecture keeps one plan and folds those decisions into the existing booleans—without a new helper module, configuration table, or abstraction layer.

## Before / after

- Primary target, `scripts/ci-test-plan.mjs`: **109 → 97 lines**
- CI plan definitions: **2 → 1**
- GitHub output schemas expressed in planning logic: **2 → 1**
- Schedule-only branch: complete alternate plan → two local conditions
- Responsibilities remain: discover changed files, select suites, write GitHub outputs, print the summary
- Public contract unchanged: event handling, changed-file discovery, nine output names/values, and stdout summary

Supporting test file: **135 → 137 lines** to pin all four deterministic nightly outputs. Total changed source and test architecture: **244 → 234 lines**.

## Validation

- `node --test tests/ci-test-plan.test.mjs` — **8 passed**
- `node --check scripts/ci-test-plan.mjs` — passed
- `git diff --check` — passed
- `bun run build` — passed
- `bun run test` outside the sandbox — **731/732 passed**; the unrelated `serve-question` claim-window timing case exceeded its deadline under the concurrent full run, then passed alone (**1/1**, 8.3s). This PR changes no question server or timing code.

Generated provider/root harness output was intentionally omitted; this is CI orchestration source only.

## Risk

Low. The schedule, pull-request, push, manual-dispatch, and changed-file paths retain direct characterization. The residual risk is limited to event-environment combinations not represented in the tests; the PR's own CI plan and required checks independently exercise the result.

## Authorization and AI assistance

Prepared with AI assistance by OpenAI Codex under maintainer pbakaus's explicit standing authorization for the scheduled architecture-simplification automation. This PR is ready for review and is **not** authorized for automatic merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI orchestration only; schedule behavior is explicitly characterized in tests and matches the intended “full live-e2e matrix without nightly API billing suites” policy.
> 
> **Overview**
> **Collapses duplicate nightly routing** in `ci-test-plan.mjs` into the same plan object used for PRs, pushes, and manual runs. Schedule-specific behavior is now two flags: `isSchedule` joins `forceDeterministic` so **detector, live, and framework** run nightly (not only `core`), and `live_e2e` is enabled via `isSchedule || …` while **LLM-billing opt-in lanes** (accept-cleanup, skill-behavior, deepseek, cli-remote) stay off unless manually dispatched or file-triggered.
> 
> Tests pin **detector** and **framework** as `true` on `schedule` events alongside the existing live-e2e vs opt-in expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75cabbdf451157879e4f26457865456d80ccb565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->