### PR TITLE
fix: hooks reset also removes the hook manifests it installed (#512, #667)

### DIFF
--- a/skill/reference/hooks.md
+++ b/skill/reference/hooks.md
@@ -32,7 +32,7 @@ The first argument is the action. Defaults to `status`.
 | `ignore-value <id> <value> [--shared] [--reason "..."]` | Append a rule/value suppression to shared `.impeccable/config.json`. |
 | `ignore-value <id> <value> --local [--reason "..."]` | Append a private rule/value suppression to `.impeccable/config.local.json`. |
 | `ignore-value <id> "*" --file <glob> [--file <glob>...]` | Turn one rule off in matching files only, leaving it active everywhere else. Repeat `--file`, or use `--file=<glob>` / `--files=<glob>`. A bare `"*"` with no `--file` is refused: use `ignore-rule <id>` if you really mean project-wide. |
-| `reset` | Delete the project config, dedup cache, and Cursor pending queue. |
+| `reset` | Delete the project config, dedup cache, and Cursor pending queue, and remove the hook's entries from every provider manifest `on` installs, the committed Copilot file included (a team-shared `settings.json` that `on` never writes is never touched). |
 
 ## Flow
 

--- a/skill/scripts/hook-admin.mjs
+++ b/skill/scripts/hook-admin.mjs
@@ -770,9 +770,22 @@ function reset(cwd) {
       }
     } catch { /* ignore */ }
   }
-  return removed.length
-    ? `Reset design hook config and cache (removed: ${removed.join(', ')}).`
-    : 'No hook config or cache to remove. Already at defaults.';
+  // `on` writes three things: config, consent, and hook entries in the
+  // provider manifests. Reset must undo all three (issue #512): a leftover
+  // manifest entry kept invoking the hook after the config that said "off"
+  // was deleted. Local destRel only, since `on` never writes the team-shared
+  // sharedDestRel. No skill-folder gate: a reset mid-uninstall (skill files
+  // gone, manifest still wired) is the case that most needs the prune.
+  const pruned = [];
+  for (const target of HOOK_MANIFEST_TARGETS) {
+    try {
+      if (pruneImpeccableHookFromManifest(path.join(cwd, target.destRel))) pruned.push(target.provider);
+    } catch { /* ignore */ }
+  }
+  const parts = [];
+  if (removed.length) parts.push(`Reset design hook config and cache (removed: ${removed.join(', ')}).`);
+  if (pruned.length) parts.push(`Removed hook entries from: ${pruned.join(', ')}.`);
+  return parts.length ? parts.join(' ') : 'No hook config or cache to remove. Already at defaults.';
 }
 
 function main() {

--- a/tests/hook.test.mjs
+++ b/tests/hook.test.mjs
@@ -1311,6 +1311,109 @@ describe('hook-admin.mjs', () => {
     assert.equal(r.stdout, '');
     assert.equal(r.audit.skipped, 'config-ignore-file');
   });
+
+  it('reset prunes impeccable entries from an installed manifest, sibling entries survive', () => {
+    // Deliberately no .claude/skills/ folder in this fixture: the prune must
+    // not be gated on the skill install surviving (repairHookManifests()
+    // gates on it; a reset mid-uninstall most needs the prune to run anyway).
+    fs.mkdirSync(path.join(cwd, '.impeccable'), { recursive: true });
+    fs.writeFileSync(getConfigPath(cwd), JSON.stringify({ hook: { enabled: false } }));
+    fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, '.claude', 'settings.local.json'), JSON.stringify({
+      description: 'Impeccable design detector',
+      hooks: {
+        PostToolUse: [
+          { matcher: 'OtherTool', hooks: [{ type: 'command', command: 'node "./local-hook.mjs"' }] },
+          { matcher: 'Edit|Write', hooks: [{ type: 'command', command: 'node ".claude/skills/impeccable/scripts/hook.mjs"' }] },
+        ],
+        Stop: [{ hooks: [{ type: 'command', command: 'node ".claude/skills/impeccable/scripts/hook.mjs"' }] }],
+      },
+    }));
+
+    const out = runAdmin(['reset']);
+    assert.match(out, /Reset design hook config and cache \(removed:/);
+    assert.match(out, /Removed hook entries from: \.claude\./);
+
+    const claude = JSON.parse(fs.readFileSync(path.join(cwd, '.claude', 'settings.local.json'), 'utf-8'));
+    assert.equal(claude.hooks.PostToolUse.length, 1);
+    assert.match(claude.hooks.PostToolUse[0].hooks[0].command, /local-hook\.mjs/);
+    assert.equal(claude.hooks.Stop, undefined, 'the impeccable-only Stop array should be dropped entirely');
+  });
+
+  it('reset prunes all four provider manifests installed via `on`', () => {
+    for (const provider of ['.claude', '.agents', '.cursor', '.github']) {
+      fs.mkdirSync(path.join(cwd, provider, 'skills', 'impeccable', 'scripts'), { recursive: true });
+    }
+    runAdmin(['on']);
+    assert.match(fs.readFileSync(path.join(cwd, '.claude', 'settings.local.json'), 'utf-8'), /skills\/impeccable\/scripts\/hook\.mjs/);
+
+    const out = runAdmin(['reset']);
+    assert.match(out, /Reset design hook config and cache \(removed:/);
+    assert.match(out, /Removed hook entries from: \.claude, \.agents, \.cursor, \.github\./);
+
+    assert.equal(fs.existsSync(path.join(cwd, '.claude', 'settings.local.json')), false, 'nothing else was in the manifest, so it is removed entirely');
+    assert.equal(fs.existsSync(path.join(cwd, '.codex', 'hooks.json')), false);
+    assert.equal(fs.existsSync(path.join(cwd, '.cursor', 'hooks.json')), false);
+    assert.equal(fs.existsSync(path.join(cwd, '.github', 'hooks', 'impeccable.json')), false);
+  });
+
+  it('reset never touches the shared/committed manifest, only the local one', () => {
+    // .claude/settings.json is the team-shared, typically committed file;
+    // `on` only ever reads it and never writes it, so reset honors the same
+    // write-scope asymmetry.
+    const shared = JSON.stringify({
+      hooks: { PostToolUse: [{ matcher: 'Edit', hooks: [{ type: 'command', command: 'node ".claude/skills/impeccable/scripts/hook.mjs"' }] }] },
+    });
+    fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, '.claude', 'settings.json'), shared);
+    fs.writeFileSync(path.join(cwd, '.claude', 'settings.local.json'), shared);
+
+    const out = runAdmin(['reset']);
+
+    // No config existed, so the message carries only the prune half.
+    assert.match(out, /Removed hook entries from: \.claude\./);
+    assert.doesNotMatch(out, /Reset design hook config and cache/);
+    assert.equal(fs.readFileSync(path.join(cwd, '.claude', 'settings.json'), 'utf-8'), shared, 'shared settings.json must survive reset untouched');
+    assert.equal(fs.existsSync(path.join(cwd, '.claude', 'settings.local.json')), false, 'the local settings.local.json is still pruned');
+  });
+
+  it('reset with no manifests installed keeps the original config-only message', () => {
+    fs.mkdirSync(path.join(cwd, '.impeccable'), { recursive: true });
+    fs.writeFileSync(getConfigPath(cwd), JSON.stringify({ hook: { enabled: false } }));
+
+    const out = runAdmin(['reset']);
+    assert.match(out, /Reset design hook config and cache/);
+    assert.doesNotMatch(out, /Removed hook entries from/);
+    assert.equal(fs.existsSync(getConfigPath(cwd)), false);
+  });
+
+  it('reset leaves a manifest with no impeccable marker byte-for-byte unchanged', () => {
+    fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true });
+    const unrelated = JSON.stringify({
+      hooks: { PostToolUse: [{ matcher: 'OtherTool', hooks: [{ type: 'command', command: 'node "./unrelated.mjs"' }] }] },
+    });
+    fs.writeFileSync(path.join(cwd, '.claude', 'settings.local.json'), unrelated);
+
+    const out = runAdmin(['reset']);
+
+    assert.match(out, /Already at defaults/);
+    assert.equal(fs.readFileSync(path.join(cwd, '.claude', 'settings.local.json'), 'utf-8'), unrelated);
+  });
+
+  it('on, off, then reset leaves nothing armed: config gone and every manifest unwired (issue #512 repro)', () => {
+    fs.mkdirSync(path.join(cwd, '.claude', 'skills', 'impeccable', 'scripts'), { recursive: true });
+    runAdmin(['on']);
+    runAdmin(['off']);
+
+    runAdmin(['reset']);
+
+    // The harness only invokes the hook through a manifest entry, so with the
+    // config and every manifest gone the project cannot re-arm, whatever the
+    // config default says.
+    assert.equal(fs.existsSync(getConfigPath(cwd)), false);
+    assert.equal(fs.existsSync(getLocalConfigPath(cwd)), false);
+    assert.equal(fs.existsSync(path.join(cwd, '.claude', 'settings.local.json')), false);
+  });
 });
 
 describe('renderTemplate()', () => {


### PR DESCRIPTION
Fixes #512. Verified reproduction: #667. Supersedes the reset half of #551.

> **Note:** this PR was force-pushed to replace an earlier revision that also flipped `DEFAULT_CONFIG.enabled` to false and taught the skills CLI to write the explicit opt-in. The maintainer descoped that half: it changes behavior for existing installs and deserves its own issue and migration plan. This revision is the minimal fix. Two follow-up fixes from testing the earlier revision (`skills update` writing `hook.enabled` to HOME instead of the project, and a local `enabled: true` being promoted onto a shared `false`) belong to that removed machinery; they are recorded here so the follow-up issue inherits them.

## What was broken

`hooks on` sets up three things: `hook.enabled: true` in the config, the local consent record, and hook entries in each provider manifest (`.claude/settings.local.json`, `.codex/hooks.json`, `.cursor/hooks.json`, `.github/hooks/impeccable.json`). `hooks reset` deleted the config and consent but forgot the manifests. With the wiring still in place and no config on disk, the enabled-by-default config re-armed the hook: `off` then `reset` ended with the hook running again. #667 verified the full sequence on current main, including the real `hook.mjs` process scanning after a reset.

## The fix

Symmetry: `reset()` now also prunes impeccable's entries from the same manifests `on` writes, reusing the existing `pruneImpeccableHookFromManifest()` with the function's best-effort error handling. Sibling hook entries survive; a manifest without an impeccable marker stays byte-for-byte identical; a team-shared `.claude/settings.json` is never touched (`on` never writes it, so `reset` never strips it); the prune is not gated on the skill folder still existing, so a reset mid-uninstall still cleans up.

After `reset`, no manifest exists, and a harness only invokes the hook through a manifest entry, so the project cannot re-arm regardless of the config default.

**The committed Copilot manifest is pruned like the rest.** An earlier revision of this branch skipped `.github/hooks/impeccable.json` as team-shared; that was safe only alongside the default flip, where a leftover entry invoked a hook that skipped as `config-disabled`. Without the flip, skipping it would leave the reported bug alive for every Copilot repo. `on` writes the file, so `reset` removes it, and because it is tracked, git surfaces the deletion (` D .github/hooks/impeccable.json`) for the team to referee before anything is committed.

## Deliberately unchanged

- `DEFAULT_CONFIG.enabled` stays `true`: no regression for projects installed without an explicit `hook.enabled` key (externally verified: a project with manifests and a hand-deleted `.impeccable/` still scans).
- `hooks status` output is unchanged; a fresh project still prints `state: enabled` (config semantics with nothing wired). Whether absence should mean off is a real question with real migration cost; it moves to its own issue rather than riding along on this fix.
- No CLI changes.

## Testing

- Six new hook-admin tests: sibling-entry survival with the prune deliberately ungated on the skill folder, all four providers pruned after a real `on`, team-shared `settings.json` untouched with the prune-only message asserted, config-only reset message unchanged, markerless manifests byte-for-byte identical, and the named #512 repro (`on`, `off`, `reset` ends with config gone and every manifest unwired).
- Full default suite and `bun run build` green.
- External behavioral checks in a throwaway project outside the repo, mirroring #667's method: `off` still skips the runtime, reset removes all four manifests, the committed Copilot deletion shows up in `git status`, `on` after reset re-wires and fires, and the no-regression guard above.

## Relationship to #551

#551 diagnosed the same bug and proposed this prune plus the default flip. This PR lands the prune; the flip discussion moves to a follow-up issue where its migration cost can be weighed on its own. Thanks @SomSamantray for the clean diagnosis.

AI-assisted change (Claude Code), prepared and reviewed under maintainer direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hook admin behavior across multiple IDE/agent manifest files; mistakes could strip wrong entries or leave hooks armed, though pruning reuses existing marker-based logic with broad test coverage.
> 
> **Overview**
> **`hooks reset` now unwires the design hook from every local provider manifest that `hooks on` installs**, fixing the case where config was deleted but manifests still invoked the hook (e.g. `on` → `off` → `reset` left scanning active).
> 
> `reset()` in `hook-admin.mjs` still clears `.impeccable` hook/detector config, cache, and Cursor pending queue, and **additionally** runs `pruneImpeccableHookFromManifest` across `HOOK_MANIFEST_TARGETS` (`.claude`, `.agents`/Codex, `.cursor`, `.github` Copilot file). Pruning is **not** gated on the skill folder still being present (mid-uninstall cleanup). **Team-shared** `.claude/settings.json` is **never** modified—only the same `destRel` paths `on` writes. Non-Impeccable hook entries in a manifest are preserved; empty manifests are removed.
> 
> Reference docs for the `reset` action and CLI output now mention manifest removal. **Six new tests** cover sibling-hook survival, all four providers after a real `on`, shared vs local Claude settings, unchanged unrelated manifests, and the #512 repro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62d4bd1fd949082fd3490365825a961ea7858f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->