### PR TITLE
Give Hermes Agent parity in README harness listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ cp -r dist/opencode/.opencode your-project/
 
 **Hermes Agent:**
 ```bash
-# Global (applies to all projects; honors $HERMES_HOME for profiles)
-cp -r dist/hermes/.hermes/skills/* ~/.hermes/skills/
+# Global (applies to all projects; uses the active profile, or ~/.hermes by default)
+cp -r dist/hermes/.hermes/skills/* "${HERMES_HOME:-$HOME/.hermes}/skills/"
 
 # Or project-specific
 cp -r dist/hermes/.hermes your-project/
@@ -194,8 +194,9 @@ cp -r dist/hermes/.hermes your-project/
 > **Note:** Hermes gates project-local skills behind a per-repo trust decision
 > (they are procedure documents, so auto-loading them from any cloned repo is
 > treated as a prompt-injection vector). After a project-scoped install, run
-> `hermes skills trust` once from the project root. Global installs into
-> `~/.hermes/skills/` load without a trust step. `/impeccable <command>` then
+> `hermes skills trust` once from the project root. Global installs into the
+> active `$HERMES_HOME/skills/` (or `~/.hermes/skills/` when unset) load without
+> a trust step. `/impeccable <command>` then
 > routes through the skill's Commands table; the design hook does not install
 > on Hermes (no hook surface).
 >

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ From the root of your project, run:
 npx impeccable install
 ```
 
-This shows the harness folders it detected (for example `~/.claude`, `~/.codex`, `~/.grok`, or project-local `.cursor`), lets you keep the detected set or customize providers, then asks whether to install into the current project or globally. Use `--providers=claude,codex,cursor,grok` and `--scope=project|global` to skip those choices in scripts. On Claude Code, Cursor, Codex, GitHub Copilot, and Grok Build, it also installs the provider-native hook manifest for the current project. Works with Cursor, Claude Code, Gemini CLI, Codex CLI, Grok Build, and every other supported tool. Reload your harness afterward.
+This shows the harness folders it detected (for example `~/.claude`, `~/.codex`, `~/.grok`, `~/.hermes`, or project-local `.cursor`), lets you keep the detected set or customize providers, then asks whether to install into the current project or globally. Use `--providers=claude,codex,cursor,grok` and `--scope=project|global` to skip those choices in scripts. On Claude Code, Cursor, Codex, GitHub Copilot, and Grok Build, it also installs the provider-native hook manifest for the current project. Works with Cursor, Claude Code, Gemini CLI, Codex CLI, Grok Build, and every other supported tool. Reload your harness afterward.
 
 To refresh an existing install, run:
 
@@ -126,7 +126,7 @@ git add .gitmodules .impeccable .claude .cursor
 git commit -m "Add Impeccable skills"
 ```
 
-Use the providers your project needs, for example `claude`, `cursor`, `gemini`, `codex`, `github`, `grok`, `opencode`, `pi`, `qoder`, `trae`, `trae-cn`, `rovo-dev`, or `vibe`. The command links individual skill folders from `.impeccable/dist/universal/` and leaves existing real skill directories untouched unless you pass `--force`.
+Use the providers your project needs, for example `claude`, `cursor`, `gemini`, `codex`, `github`, `grok`, `hermes`, `opencode`, `pi`, `qoder`, `trae`, `trae-cn`, `rovo-dev`, or `vibe`. The command links individual skill folders from `.impeccable/dist/universal/` and leaves existing real skill directories untouched unless you pass `--force`.
 
 To update later:
 
@@ -181,6 +181,25 @@ cp -r dist/claude-code/.claude/* ~/.claude/
 ```bash
 cp -r dist/opencode/.opencode your-project/
 ```
+
+**Hermes Agent:**
+```bash
+# Global (applies to all projects; honors $HERMES_HOME for profiles)
+cp -r dist/hermes/.hermes/skills/* ~/.hermes/skills/
+
+# Or project-specific
+cp -r dist/hermes/.hermes your-project/
+```
+
+> **Note:** Hermes gates project-local skills behind a per-repo trust decision
+> (they are procedure documents, so auto-loading them from any cloned repo is
+> treated as a prompt-injection vector). After a project-scoped install, run
+> `hermes skills trust` once from the project root. Global installs into
+> `~/.hermes/skills/` load without a trust step. `/impeccable <command>` then
+> routes through the skill's Commands table; the design hook does not install
+> on Hermes (no hook surface).
+>
+> [Learn more about Hermes skills](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
 
 **Pi:**
 ```bash
@@ -418,6 +437,7 @@ Full detector docs: [impeccable.style/docs/detector](https://impeccable.style/do
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [Codex CLI](https://github.com/openai/codex)
 - [Grok Build](https://x.ai/cli)
+- [Hermes Agent](https://hermes-agent.nousresearch.com)
 - [OpenCode](https://opencode.ai)
 - [Pi](https://pi.dev)
 - [Kiro](https://kiro.dev)

--- a/README.npm.md
+++ b/README.npm.md
@@ -81,7 +81,7 @@ impeccable detect [options] [file-or-dir-or-url...]
 
 ## Part of Impeccable
 
-This CLI is part of [Impeccable](https://impeccable.style), a cross-provider design skill pack for AI-powered development tools. The full suite includes 23 commands for Claude, Cursor, GitHub Copilot, Gemini, Codex, and more.
+This CLI is part of [Impeccable](https://impeccable.style), a cross-provider design skill pack for AI-powered development tools. The full suite includes 23 commands for Claude, Cursor, GitHub Copilot, Gemini, Codex, Hermes Agent, and more.
 
 ## License
 


### PR DESCRIPTION
## Summary

Hermes Agent is already a supported provider end to end — the installer detects `~/.hermes`, `--providers=hermes` works for both scopes, and the repo tracks a generated `.hermes/skills/impeccable/` bundle — but the README never mentions it. This brings the user-facing listings to parity (same shape as #280 did for GitHub Copilot).

## Changes

- **Supported Tools**: add Hermes Agent (https://hermes-agent.nousresearch.com)
- **Option 5 (copy from repository)**: add a Hermes entry — global copy into `~/.hermes/skills/` (honors `HERMES_HOME` profiles) or project-local `.hermes/`, plus a note that project-local skills need a one-time `hermes skills trust` from the repo root, and that no hook manifest installs on Hermes (no hook surface — matches what AGENTS.md documents)
- **Option 2 (submodule)**: add `hermes` to the provider list
- **CLI installer prose**: include `~/.hermes` among detected harness folder examples
- **README.npm.md**: include Hermes Agent in the suite description

Docs link verified live: https://hermes-agent.nousresearch.com/docs/user-guide/features/skills

No behavior changes; docs only. (Disclosure: I maintain Hermes Agent — happy to adjust wording or trim the trust note if you'd rather keep provider notes shorter.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, installer, or hook behavior modifications.
> 
> **Overview**
> **Documentation-only** update so README matches existing Hermes Agent support in the installer and `dist/hermes` bundle.
> 
> Adds **Hermes Agent** to **Supported Tools** and mentions `~/.hermes` in the CLI installer harness-folder examples. **Option 2 (submodule/link)** now lists `hermes` among `--providers` values. **Option 5 (manual copy)** adds Hermes instructions for global (`$HERMES_HOME` / `~/.hermes/skills/`) and project-local `.hermes/` installs, plus a note on one-time `hermes skills trust` for repo-local skills and that Impeccable’s design hook is not installed on Hermes. **README.npm.md** names Hermes Agent in the cross-provider suite blurb.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f56c3e3851e538e28dee60972ca671ea531e31e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->