### PR TITLE
Fix: ignore review and questions dirs in README gitignore (#669)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ As you run commands, Impeccable writes working files under `.impeccable/`: criti
 .impeccable/hook.cache.json
 .impeccable/hook.pending.json
 .impeccable/*.png
+.impeccable/review/
+.impeccable/questions/
 .impeccable/live/server.json
 .impeccable/live/sessions/
 .impeccable/live/previews/

--- a/scripts/test-suites.mjs
+++ b/scripts/test-suites.mjs
@@ -73,6 +73,7 @@ export const SUITES = {
           'tests/doctor.test.mjs',
           'tests/staleness.test.mjs',
           'tests/skill-reference.test.mjs',
+          'tests/readme-gitignore.test.mjs',
           'tests/target-args.test.mjs',
           'tests/surface-brief.test.mjs',
           'tests/template-extensions.test.mjs',

--- a/tests/readme-gitignore.test.mjs
+++ b/tests/readme-gitignore.test.mjs
@@ -16,7 +16,7 @@ describe('README gitignore block', () => {
   });
 
   it('ignores ephemeral review and questions dirs while keeping shared artifacts tracked', () => {
-    const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8');
+    const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8').replace(/\r\n?/g, '\n');
     const match = readme.match(/```gitignore\n([\s\S]*?)```/);
     assert.ok(match, 'README.md should contain a fenced gitignore block');
     const block = match[1];

--- a/tests/readme-gitignore.test.mjs
+++ b/tests/readme-gitignore.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+describe('README gitignore block', () => {
+  let tmp;
+
+  after(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('ignores ephemeral review and questions dirs while keeping shared artifacts tracked', () => {
+    const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8');
+    const match = readme.match(/```gitignore\n([\s\S]*?)```/);
+    assert.ok(match, 'README.md should contain a fenced gitignore block');
+    const block = match[1];
+    assert.match(block, /# impeccable-ignore-start/);
+
+    tmp = mkdtempSync(join(tmpdir(), 'impeccable-readme-gitignore-'));
+    writeFileSync(join(tmp, '.gitignore'), block);
+    execFileSync('git', ['init'], { cwd: tmp });
+
+    const ignored = execFileSync('git', [
+      'check-ignore',
+      '.impeccable/review/desktop.png',
+      '.impeccable/questions/fb63f8a6.log',
+    ], { cwd: tmp, encoding: 'utf-8' });
+    assert.match(ignored, /\.impeccable\/review\/desktop\.png/);
+    assert.match(ignored, /\.impeccable\/questions\/fb63f8a6\.log/);
+
+    for (const rel of ['.impeccable/config.json', '.impeccable/critique/report.md']) {
+      const result = spawnSync('git', ['check-ignore', rel], { cwd: tmp });
+      assert.notEqual(result.status, 0, `${rel} should not be ignored`);
+    }
+  });
+});


### PR DESCRIPTION
The copy-paste gitignore block missed `.impeccable/review/` and `.impeccable/questions/`, so users following the docs committed finish-review PNGs and question-server logs. Adds those two patterns and a git check-ignore regression. Fixes #669.

Validated with `bun run test` and `bun run build`.

AI-assisted change: implemented with Cursor under maintainer direction.

Made with [Cursor](https://cursor.com)