### PR TITLE
Fix grammar: "an award-winning" in skill intro

### DIFF
--- a/skill/SKILL.src.md
+++ b/skill/SKILL.src.md
@@ -9,7 +9,7 @@ allowed-tools:
 license: Apache 2.0
 ---
 
-This skill gives you the tools and permission to create design that earns to be called out-of-distribution craft: Whereas before, your design work would have been safe, timid and measured, you now approach every design task as a award-winning design director with impeccable understanding for what makes exceptional design work: production-grade code, peak creativity, a clear POV, deep understanding of the needs of the client and users, and exceptional craft.
+This skill gives you the tools and permission to create design that earns to be called out-of-distribution craft: Whereas before, your design work would have been safe, timid and measured, you now approach every design task as an award-winning design director with impeccable understanding for what makes exceptional design work: production-grade code, peak creativity, a clear POV, deep understanding of the needs of the client and users, and exceptional craft.
 
 Core principles:
 - Go all out. No hedging, no shortcuts. The deliverable must be complete (except assets the user must provide).


### PR DESCRIPTION
The opening paragraph of skill/SKILL.src.md read "as a award-winning design director". "Award" takes "an" (vowel sound), so this should be "an award-winning". Provider SKILL.md files are generated from this source, so the fix propagates on the next build.

## Before opening

This repo is issue-first for outside contributions. If you are not `pbakaus` or `abdulwahabone`, please link the issue where a maintainer approved or requested this PR. Unsolicited PRs may be closed without review.

- Linked issue: #680
- Contributor status:
  - [ ] I am `pbakaus` or `abdulwahabone`
  - [ ] A maintainer approved this PR in the linked issue

## Summary

<!-- What does this PR change and why? -->
One-word grammar fix in `skill/SKILL.src.md`: "a award-winning" → "an award-winning".
Opened alongside issue #680.
## Type of change

- [ ] New command
- [ ] New / updated skill reference
- [ ] New anti-pattern guidance
- [ ] Bug fix
- [x] Documentation update
- [ ] Build system / tooling
- [ ] Other: 

## Checklist

- [x] Source files updated in `source/`
- [x] `bun run build` ran successfully
- [ ] `bun test` passes
- [ ] Tested with at least one provider (Cursor / Claude Code / Gemini CLI / Codex / Copilot / Grok Build / Kiro / OpenCode / Qoder / Mistral Vibe)
- [ ] README / DEVELOP.md updated if needed
- [x] I reviewed the full diff myself before requesting human review
- [x] I disclosed any AI assistance in this PR and related commits/comments, or no AI assistance was used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-word documentation fix in skill prose with no runtime, security, or logic impact.
> 
> **Overview**
> Corrects a grammar error in the opening paragraph of **`skill/SKILL.src.md`**: **"as a award-winning"** → **"as an award-winning"** design director.
> 
> No behavior or routing changes—only copy in the skill source. Provider **`SKILL.md`** files still show the old wording until **`bun run build`** regenerates them from this source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c957cf2a6dd210397c3c5e020bfd238c3b4a54b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->