### PR TITLE
Simplify design rule extraction

### DIFF
--- a/skill/scripts/lib/design-parser.mjs
+++ b/skill/scripts/lib/design-parser.mjs
@@ -329,47 +329,37 @@ function stripBold(s) {
 function extractNamedRules(lines) {
   const rules = [];
   const seen = new Set();
+  const addRule = (name, body, { allowDuplicate = false } = {}) => {
+    const key = name.toLowerCase();
+    if (!allowDuplicate && seen.has(key)) return;
+    seen.add(key);
+    rules.push({ name, body });
+  };
 
   // Style A (Impeccable): "**The X Rule.** body body body" — can span lines.
   const joined = lines.join('\n');
-  const inlineStart = /\*\*(The [^*]+?Rule)\.\*\*/g;
-  const inlineMatches = [];
-  let m;
-  while ((m = inlineStart.exec(joined)) !== null) {
-    inlineMatches.push({ name: m[1], start: m.index, end: inlineStart.lastIndex });
-  }
+  const inlineMatches = [...joined.matchAll(/\*\*(The [^*]+?Rule)\.\*\*/g)];
   for (let i = 0; i < inlineMatches.length; i++) {
-    const mm = inlineMatches[i];
-    const bodyEnd = i + 1 < inlineMatches.length ? inlineMatches[i + 1].start : joined.length;
+    const match = inlineMatches[i];
+    const bodyEnd = inlineMatches[i + 1]?.index ?? joined.length;
     const body = joined
-      .slice(mm.end, bodyEnd)
+      .slice(match.index + match[0].length, bodyEnd)
       .replace(/\n##[^\n]*$/s, '')
       .replace(/\n###[^\n]*$/s, '')
       .trim();
-    const name = stripBold(mm.name).trim();
-    seen.add(name.toLowerCase());
-    rules.push({ name, body: stripBold(body) });
+    // Preserve the inline format's historical behavior: repeated inline rules
+    // remain visible, while the later heading and bullet formats dedupe.
+    addRule(stripBold(match[1]).trim(), stripBold(body), { allowDuplicate: true });
   }
 
   // Style B (Stitch): `### The "X" Rule` or `### The X Fallback`, body is the
   // bullets/paragraphs until the next heading. Accept Rule / Fallback / Principle.
-  for (let i = 0; i < lines.length; i++) {
-    const h3 = lines[i].match(/^###\s+(.+?)\s*$/);
-    if (!h3) continue;
-    const headerName = stripBold(h3[1]).replace(/["“”]/g, '').trim();
+  for (const subsection of splitSubsections(lines).slice(1)) {
+    const headerName = stripBold(subsection.name).replace(/["“”]/g, '').trim();
     if (!/^The\b.*\b(Rule|Fallback|Principle)\b/i.test(headerName)) continue;
-    if (seen.has(headerName.toLowerCase())) continue;
 
-    const bodyLines = [];
-    for (let j = i + 1; j < lines.length; j++) {
-      if (/^##\s|^###\s/.test(lines[j])) break;
-      bodyLines.push(lines[j]);
-    }
-    const body = stripBold(bodyLines.join('\n').replace(/\n+/g, ' ')).trim();
-    if (body) {
-      seen.add(headerName.toLowerCase());
-      rules.push({ name: headerName, body });
-    }
+    const body = stripBold(subsection.lines.join('\n').replace(/\n+/g, ' ')).trim();
+    if (body) addRule(headerName, body);
   }
 
   // Style C (Stitch bullet form): "*   **The Layering Principle:** body"
@@ -379,9 +369,7 @@ function extractNamedRules(lines) {
     if (!mm) continue;
     const nameRaw = mm[1].replace(/[.:]\s*$/, '').replace(/["“”]/g, '').trim();
     if (!/^The\b.+\b(Rule|Fallback|Principle)$/i.test(nameRaw)) continue;
-    if (seen.has(nameRaw.toLowerCase())) continue;
-    seen.add(nameRaw.toLowerCase());
-    rules.push({ name: nameRaw, body: stripBold(mm[2]).trim() });
+    addRule(nameRaw, stripBold(mm[2]).trim());
   }
 
   return rules;

--- a/tests/design-parser.test.mjs
+++ b/tests/design-parser.test.mjs
@@ -228,6 +228,33 @@ describe('parseDesignMd overview branch', () => {
   });
 });
 
+describe('parseDesignMd named rules', () => {
+  it('preserves format precedence while deduplicating later definitions', () => {
+    const md = `# Design System: Rules
+
+## Layout
+
+### The "Rhythm" Rule
+Ignore this duplicate heading definition.
+
+### The Fallback Principle
+Use the heading definition.
+
+### Named Rules
+- **The Fallback Principle:** Ignore this duplicate bullet definition.
+- **The Layering Principle:** Use the bullet definition.
+
+**The Rhythm Rule.** Keep the first definition.
+`;
+
+    assert.deepEqual(parseDesignMd(md).layout.rules, [
+      { name: 'The Rhythm Rule', body: 'Keep the first definition.' },
+      { name: 'The Fallback Principle', body: 'Use the heading definition.' },
+      { name: 'The Layering Principle', body: 'Use the bullet definition.' },
+    ]);
+  });
+});
+
 describe('parseDesignMd canonical sections', () => {
   it('preserves content and named rules from all eight canonical sections', () => {
     const md = `# Design System: Complete


### PR DESCRIPTION
## Summary

- centralize named-rule insertion and deduplication in the design document parser
- reuse the existing subsection parser for H3 rule bodies instead of rescanning every line
- characterize precedence across inline, heading, and bullet rule formats

## Hindsight judgment

**Hindsight is 20/20: if we were implementing these requirements today, would we design this file this way?** No.

The parser had three independent paths for storing and deduplicating the same named-rule concept, while the heading path also rebuilt subsection boundaries with a nested line scan. The smallest cleaner architecture keeps the public parser in one file, gives rule insertion one owner, and reuses the subsection structure the module already computes.

## Before / after

- Primary target, `skill/scripts/lib/design-parser.mjs`: **892 → 880 lines**
- Rule insertion/deduplication mechanisms: **3 → 1**
- H3 rule-body traversal: nested rescan of the section → existing `splitSubsections` result
- Public exports: unchanged (`parseDesignMd`, `assessCoverage`)
- Parsed schema, rule precedence, duplicate handling, consumers, and error behavior: unchanged
- Supporting characterization coverage: **+27 test lines**
- Total production source reduction: **12 lines**

## Validation

- `node --test tests/design-parser.test.mjs` — **11 passed**
- `node --check skill/scripts/lib/design-parser.mjs` — passed
- `git diff --check` — passed
- `bun run build` — passed; all provider/build validators green
- `bun run test` — passed outside the desktop sandbox:
  - core: **809 passed**
  - detector (Bun): **420 passed**
  - detector (Node): **177 passed**
  - framework fixtures: **216 passed**
  - plugin loader E2E: **4 passed**
  - remaining live suites also passed with zero failures

The initial sandboxed full-suite attempt hit the repository's documented localhost `listen EPERM` restriction; the required outside-sandbox rerun was green.

## Generated output

Generated provider/root harness output was intentionally omitted. `bun run build` validated the source-first distribution without staging generated artifacts.

## Risk

Low. The residual risk is unusual malformed rule markup around headings; existing canonical-section coverage plus the new cross-format precedence characterization bound the behavior being preserved.

## Authorization and AI assistance

Prepared with AI assistance by OpenAI Codex under maintainer pbakaus's explicit standing authorization for the scheduled architecture-simplification automation. This PR is ready for review and is **not authorized for automatic merge**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser-only refactor with preserved precedence and new test coverage; residual risk is odd malformed rule markup around headings.
> 
> **Overview**
> Refactors **`extractNamedRules`** in `design-parser.mjs` so inline, H3 heading, and bullet rule formats share one **`addRule`** path for deduplication instead of three separate `seen`/`push` blocks.
> 
> **Heading-style rules** now take bodies from existing **`splitSubsections`** output instead of scanning lines again until the next `##`/`###`. Inline rules still use **`matchAll`** on the joined section text; repeated inline definitions can still appear (**`allowDuplicate: true`**), while later heading and bullet definitions for the same name are skipped when a name was already recorded.
> 
> Adds a characterization test that locks **format precedence**: inline rhythm text wins over a duplicate H3, heading text wins over a duplicate bullet for the same principle, and distinct bullet rules still surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1e8d4e70e2e224381c2d54feaa400fd686a5e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->