### PR TITLE
Fix concept seed under symlinked installs (#640)

### DIFF
--- a/skill/scripts/concept-seed.mjs
+++ b/skill/scripts/concept-seed.mjs
@@ -91,7 +91,7 @@
 
 import crypto from 'node:crypto';
 import { dirname, join, relative, resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
   approvedPoolRevision,
@@ -703,7 +703,28 @@ export function nextStepAfterChoice({ key, scope, cwd = process.cwd(), env = pro
   return `NEXT (comp-led, ${why}): the world is chosen; the composition is not. Run: node ${scripts}/build-phase.mjs start${seed} and follow its NEXT lines: it opens the comps phase (three comps under .impeccable/mocks/, one approved by the user through the decision page or structured question, sidecar "approved": true), then spec, plates, hero, sections, motion, responsive, review. Do not write page code before those gates close. Reference: reference/visualize.md for the comp round.\n`;
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+export function sameMainModulePath(left, right, platform = process.platform) {
+  if (platform !== 'win32') return left === right;
+  const normalizeDriveLetter = (value) => value.replace(/^([a-z]):/i, (_, drive) => `${drive.toUpperCase()}:`);
+  return normalizeDriveLetter(left) === normalizeDriveLetter(right);
+}
+
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    // Node resolves import.meta.url through symlinks but leaves argv[1] as the
+    // invoked path. Compare real paths so a linked skill still runs its CLI,
+    // normalizing the drive-letter casing that Windows junctions can change.
+    return sameMainModulePath(
+      realpathSync(process.argv[1]),
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
   const args = process.argv.slice(2);
   const fromIdx = args.indexOf('--from');
   const scopeIdx = args.indexOf('--scope');

--- a/tests/concept-seed.test.mjs
+++ b/tests/concept-seed.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -12,7 +12,7 @@ import {
   validateConceptEntry,
 } from '../skill/scripts/lib/concept-catalog.mjs';
 import { readCompositionCatalog } from '../skill/scripts/lib/composition-catalog.mjs';
-import { dealCompositions, pingChosen, renderChallenger, selectApprovedChallengers, selectApprovedComposition, selectApprovedCompositions } from '../skill/scripts/concept-seed.mjs';
+import { dealCompositions, pingChosen, renderChallenger, sameMainModulePath, selectApprovedChallengers, selectApprovedComposition, selectApprovedCompositions } from '../skill/scripts/concept-seed.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = path.join(ROOT, 'skill', 'scripts', 'concept-seed.mjs');
@@ -40,6 +40,37 @@ function run(scope, extraArgs = [], env = {}) {
 }
 
 describe('concept seed scopes', () => {
+  it('normalizes Windows drive-letter casing for linked entry paths', () => {
+    assert.equal(
+      sameMainModulePath('C:\\repo\\skill\\scripts\\concept-seed.mjs', 'c:\\repo\\skill\\scripts\\concept-seed.mjs', 'win32'),
+      true
+    );
+    assert.equal(
+      sameMainModulePath('/repo/Skill/scripts/concept-seed.mjs', '/repo/skill/scripts/concept-seed.mjs', 'linux'),
+      false
+    );
+  });
+
+  it('runs through a symlinked skill directory', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'concept-seed-symlink-'));
+    const linkedSkill = path.join(dir, 'skill');
+    try {
+      symlinkSync(path.join(ROOT, 'skill'), linkedSkill, process.platform === 'win32' ? 'junction' : 'dir');
+      const result = spawnSync(process.execPath, [
+        path.join(linkedSkill, 'scripts', 'concept-seed.mjs'),
+        '--scope', 'surface', '--mode', 'persuade', '--from', 'symlink-test',
+      ], {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        env: { ...process.env, IMPECCABLE_CATALOG_DIR: FIXTURE_DIR },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /SURFACE CONCEPT SEED/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps complete-direction and established-world surface rolls reproducible but independent', () => {
     const directionA = run('direction');
     const directionB = run('direction');


### PR DESCRIPTION
## Summary

- resolve the concept-seed CLI entry path through realpath before comparing it with the module path
- preserve import-only behavior while allowing documented symlinked and Windows-junction skill installs to execute normally
- add a cross-platform regression that invokes the CLI through a linked skill directory

Fixes #640.

## Validation

- node --test tests/concept-seed.test.mjs — 33 passed
- bun run test:new-work-e2e — 21 passed
- bun run build — all 18 providers and validators passed
- git diff --check

Generated provider output is intentionally omitted under the source-first policy.

## AI assistance

Implemented and reviewed with Codex under @pbakaus direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI bootstrap change with targeted tests; no changes to seed logic, catalog handling, or telemetry.
> 
> **Overview**
> Fixes **concept-seed** silently skipping its CLI when the skill is invoked through a **symlink or Windows junction**, because Node resolves `import.meta.url` to the real file while `process.argv[1]` stays on the link path.
> 
> The entry guard now compares **`realpathSync`** paths via exported **`sameMainModulePath`**, with **Windows drive-letter normalization** for junction quirks. **Import-only** use of the module is unchanged.
> 
> Tests cover **`sameMainModulePath`** on Windows vs Linux and an end-to-end spawn through a **symlinked `skill` directory**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a59d51660079e74c9b05f1a258beb9002ea5017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->