### PR TITLE
Fix radius var fallback detection (#656)

### DIFF
--- a/cli/engine/design-system.mjs
+++ b/cli/engine/design-system.mjs
@@ -995,7 +995,9 @@ function extractRadiusTokens(value) {
   return String(value || '')
     .replace(/\s*\/\s*/g, ' ')
     .split(/\s+/)
-    .map(token => token.trim())
+    // var() fallbacks leave the closing parenthesis on the final token. Strip
+    // it before length resolution so `8px)` is not treated as unitless 8rem.
+    .map(token => token.trim().replace(/\)+$/, ''))
     .filter(Boolean);
 }
 

--- a/tests/design-system.test.mjs
+++ b/tests/design-system.test.mjs
@@ -389,6 +389,25 @@ describe('checkSourceDesignSystem()', () => {
     );
   });
 
+  it('judges var() radius fallbacks without keeping the closing parenthesis', () => {
+    const designSystem = normalizeDesignSystem({
+      frontmatter: { rounded: { md: '8px' } },
+    });
+    const findings = checkSourceDesignSystem(`
+.good {
+  border-radius: var(--radius-md, 8px);
+}
+.bad {
+  border-radius: var(--radius-custom, 18px);
+}
+`, '/tmp/radius-fallbacks.css', { designSystem });
+
+    assert.deepEqual(
+      findings.map((item) => [item.antipattern, item.ignoreValue]),
+      [['design-system-radius', '18px']],
+    );
+  });
+
   it('strips CSS priority markers before checking font-family declarations', () => {
     const designSystem = sampleDesignSystem();
     const findings = checkSourceDesignSystem(`


### PR DESCRIPTION
## Summary

- strip closing var() parentheses from individual border-radius tokens before length resolution
- keep documented fallbacks such as 8px on-scale instead of misreading 8px) as a unitless 128px value
- continue reporting genuinely off-scale fallbacks with a clean, actionable ignore value

Fixes #656.

## Validation

- node --test tests/design-system.test.mjs — 22 passed
- bun run test:detector — 601 passed
- bun run build:browser
- bun run build:extension
- bun run build — all 18 providers and validators passed
- bun run test — full default suite passed
- git diff --check

Generated provider and extension output was verified but remains unchanged and unstaged.

## AI assistance

Implemented and reviewed with Codex under @pbakaus direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to radius token parsing in the design-system linter; no auth, data, or runtime behavior outside design drift detection.
> 
> **Overview**
> Fixes **false positives** when `border-radius` uses CSS `var()` with a length fallback (e.g. `var(--radius-md, 8px)`).
> 
> Tokenization in `extractRadiusTokens` left the closing `)` on the fallback (`8px)`), so length resolution did not see a `px` suffix and treated the value as **unitless rem** (8×16px). On-scale fallbacks could be flagged; `ignoreValue` could be wrong. Tokens now have trailing `)` stripped before the rounded-scale check.
> 
> A regression test asserts documented fallbacks pass and off-scale ones (e.g. `18px`) still report `design-system-radius` with a clean `ignoreValue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bacc2503a319eb6241e6567472fa2fafa05bd94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->