### PR TITLE
Fix PRODUCT schema drift (#427)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,8 +1,10 @@
 # Product
 
-## Register
+<!-- impeccable:product-schema 1 -->
 
-brand
+## Platform
+
+web
 
 ## Users
 
@@ -12,13 +14,26 @@ Designers, product managers, and engineers who use AI coding tools (Cursor, Clau
 
 Impeccable gives builders a shared design vocabulary with their AI, delivered as a plug-and-play skill that works in every major AI coding harness. Success is measured in two ways: (1) the user can steer AI output with design precision instead of vague prose, and (2) the AI produces interfaces that pass professional design review, not "looks like an AI made it" output.
 
-## Brand Personality
+## Positioning
+
+Impeccable combines an opinionated design skill, live browser iteration, and deterministic anti-pattern detection in one source-first system that is transformed for supported AI coding harnesses. The repository ships the same design vocabulary through harness-native distributions instead of maintaining unrelated prompts for each tool.
+
+## Operating Context
+
+Builders install Impeccable from the repository or package, run `/impeccable init` once to record product truth, then direct design work through the shared command vocabulary. They may iterate against a runnable interface in live mode and use the CLI or browser extension for deterministic checks. Maintainers author the canonical skill under `skill/`; build scripts derive provider distributions, site assets, and validation output.
+
+## Capabilities and Constraints
+
+- The skill exposes 23 design commands covering new work, critique, technical audit, refinement, hardening, adaptation, and live iteration.
+- The CLI and browser extension run deterministic detector rules without an LLM or API key; LLM critique remains a separate judgment layer.
+- Provider-specific root harness folders and `plugin/` are generated distribution artifacts. Source changes belong in `skill/`, `scripts/`, `cli/`, `site/`, `extension/`, `functions/`, or `tests/`.
+- Product claims, testimonials, customers, benchmarks, pricing, licensing, and deployment facts must not be invented when evidence is absent.
+
+## Brand Commitments
 
 Expert, opinionated, refined. Impeccable speaks with an authoritative design voice: confident taste, editorial quality, zero hedging. It's the design director in the room who knows exactly what's wrong and how to fix it. The tone is **direct** (no "maybe consider"), **specific** (no "improve the vibe"), and **rooted in craft** (no hype, no hedging).
 
 Three-word personality: **expert, decisive, editorial**.
-
-## Anti-references
 
 The site and brand must be the antithesis of everything Impeccable critiques. Specifically, avoid:
 
@@ -28,7 +43,15 @@ The site and brand must be the antithesis of everything Impeccable critiques. Sp
 - **Educational framing**: this product is for people who already know they have a problem; we solve it, we don't teach it.
 - **Over-decoration**: every visual element must earn its place. No ornament for ornament's sake.
 
-## Design Principles
+## Evidence on Hand
+
+- `README.md` documents the public command set, supported installation paths, and deterministic detector behavior.
+- `skill/` contains the canonical guidance and command references; `tests/` contains regression coverage for its build and runtime behavior.
+- `site/` is the public product surface and a direct demonstration of the design standard Impeccable advocates.
+- `cli/` and `extension/` are working detector implementations, not roadmap claims.
+- The existing product record names no customer testimonials or quantified outcome studies. Future surfaces must not fabricate them.
+
+## Product Principles
 
 1. **Practice what you preach.** The site must pass its own anti-pattern tests with flying colors. If we ship anything we'd flag in an audit, we've lost.
 2. **Show, don't tell.** Demonstrate design quality through execution, not through words about design quality. The site IS the demo.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Anthropic's [frontend-design](https://github.com/anthropics/skills/tree/main/ski
 Every model trained on the same SaaS templates. Skip the guidance and you get the same handful of tells on every project: Inter for everything, purple-to-blue gradients, cards nested in cards, gray text on colored backgrounds, the rounded-square icon tile above every heading.
 
 Impeccable adds:
-- **One setup flow.** `/impeccable init` writes `PRODUCT.md` and offers `DESIGN.md`, so later commands know the audience, brand/product lane, voice, anti-references, colors, type, and components.
+- **One setup flow.** `/impeccable init` records durable product truth in `PRODUCT.md`, so later commands know the audience, purpose, operating context, constraints, voice, and evidence without confusing those facts with surface-level visual direction.
 - **23 commands.** A shared design vocabulary with your AI: `polish`, `audit`, `critique`, `distill`, `animate`, `bolder`, `quieter`, and more.
 - **61 deterministic detector rules** plus LLM-only critique checks. The CLI and browser extension run the deterministic rules with no LLM and no API key.
 
@@ -31,7 +31,7 @@ Start every new project with:
 /impeccable init
 ```
 
-`init` asks whether the surface is brand (marketing, landing, portfolio) or product (app UI, dashboard, tool), then writes design context that every later command reads.
+`init` inspects the project, asks only for material gaps in durable product truth, and writes `PRODUCT.md`. Visitor mode and visual direction are chosen later for each surface; incumbent or newly built visual systems are recorded separately in `DESIGN.md`.
 
 ### 23 Commands
 
@@ -40,7 +40,7 @@ All commands are accessed through `/impeccable`:
 | Command | What it does |
 |---------|--------------|
 | `/impeccable craft` | Full shape-then-build flow with visual iteration |
-| `/impeccable init` | One-time setup: gather design context, write PRODUCT.md and DESIGN.md, configure live mode, recommend next steps |
+| `/impeccable init` | One-time setup: gather durable product context, write PRODUCT.md, configure live mode when applicable, recommend next steps |
 | `/impeccable document` | Generate root DESIGN.md from existing project code |
 | `/impeccable extract` | Pull reusable components and tokens into the design system |
 | `/impeccable shape` | Plan UX/UI before writing code |


### PR DESCRIPTION
## Summary

- update README descriptions of init to match the current product-truth-only flow
- remove the retired brand/product register description and clarify that visitor mode is chosen per surface
- migrate the repository PRODUCT.md to the current stamped schema while preserving its established users, purpose, brand commitments, principles, and accessibility requirements

This addresses the internal documentation drift identified in #427. It intentionally leaves the proposed external product.md interoperability and marker policy open for a separate maintainer decision.

## Validation

- node --test tests/staleness.test.mjs — 58 passed
- direct checkProduct validation of the repository PRODUCT.md — current schema, no findings
- git diff --check

## AI assistance

Prepared and reviewed with Codex under @pbakaus direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `PRODUCT.md` and `README.md`; no runtime, auth, or product logic paths are modified.
> 
> **Overview**
> **Aligns internal product documentation with the current `impeccable:product-schema` flow** so `/impeccable init` and the repo’s own `PRODUCT.md` no longer describe the retired brand/product register model.
> 
> `PRODUCT.md` is **migrated to schema v1**: adds the schema stamp, replaces **Register** with **Platform**, and expands durable product truth with **Positioning**, **Operating Context**, **Capabilities and Constraints**, and **Evidence on Hand**. **Brand Personality** / **Anti-references** / **Design Principles** are reframed as **Brand Commitments** (anti-patterns folded in) and **Product Principles** without changing the underlying voice and a11y commitments.
> 
> `README.md` **updates init copy** to state that setup writes **product truth only** to `PRODUCT.md`, that visitor mode and visual direction are chosen per surface later, and that **`DESIGN.md`** holds visual systems—the command table row for `/impeccable init` matches that narrower scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817d7f505a7937a2015e85f70decad8c5b1cd111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->