### PR TITLE
Fix live script response encoding (#539)

### DIFF
--- a/skill/scripts/live-server.mjs
+++ b/skill/scripts/live-server.mjs
@@ -768,7 +768,7 @@ function createRequestHandler({ detectScript, liveScriptParts }) {
         }),
       });
       res.writeHead(200, {
-        'Content-Type': 'application/javascript',
+        'Content-Type': 'application/javascript; charset=utf-8',
         'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
         'Pragma': 'no-cache',
       });
@@ -777,7 +777,7 @@ function createRequestHandler({ detectScript, liveScriptParts }) {
     }
     if (p === '/detect.js' || p === '/') {
       if (!detectScript) { res.writeHead(404); res.end('Not available'); return; }
-      res.writeHead(200, { 'Content-Type': 'application/javascript' });
+      res.writeHead(200, { 'Content-Type': 'application/javascript; charset=utf-8' });
       res.end(detectScript);
       return;
     }

--- a/tests/live-server.test.mjs
+++ b/tests/live-server.test.mjs
@@ -350,7 +350,7 @@ describe('live-server integration', () => {
   it('/live.js serves script with token injected', async () => {
     const res = await fetch(`http://localhost:${server.port}/live.js?token=${server.token}`);
     assert.equal(res.status, 200);
-    assert.equal(res.headers.get('content-type'), 'application/javascript');
+    assert.equal(res.headers.get('content-type'), 'application/javascript; charset=utf-8');
     const text = await res.text();
     assert.ok(text.includes('__IMPECCABLE_TOKEN__'));
     assert.ok(text.includes(server.token));
@@ -545,6 +545,9 @@ colors: {}
     const res = await fetch(`http://localhost:${server.port}/detect.js`);
     // May 404 if detect-antipatterns-browser.js hasn't been built
     assert.ok(res.status === 200 || res.status === 404);
+    if (res.status === 200) {
+      assert.equal(res.headers.get('content-type'), 'application/javascript; charset=utf-8');
+    }
   });
 
   it('/manual-edit-commit runs the batched AI apply path and clears successful entries', async () => {


### PR DESCRIPTION
## Summary

- serve generated /live.js with an explicit UTF-8 JavaScript content type
- serve /detect.js with the same explicit charset
- assert both response headers in the live-server integration suite

Addresses the response-encoding half of #539. The HTTPS-production mixed-content question intentionally remains open: adding self-signed TLS or declaring remote-production injection supported requires a separate product and security decision.

## Validation

- focused response-header tests: 2 failed before the implementation, 2 passed after
- node --test tests/live-server.test.mjs — 101 passed
- bun run build — all 18 providers and validators passed
- bun run test:live-e2e-accept-cleanup — invoked as required; skipped because DEEPSEEK_API_KEY is absent
- git diff --check

Generated provider output was validated through the source-first build and remains unstaged.

## AI assistance

Prepared and reviewed with Codex under @pbakaus direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only change on local dev script routes with matching test updates; no auth or data-path changes.
> 
> **Overview**
> Sets **`Content-Type`** to **`application/javascript; charset=utf-8`** for **`/live.js`** and **`/detect.js`** so browsers treat the served scripts as UTF-8 instead of relying on a charset-less JavaScript MIME type.
> 
> The live-server integration tests now expect that header on **`/live.js`** and, when the detector bundle is present, on **`/detect.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd177b65529599bef2871e769c7f02c2a0d12857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->