### PR TITLE
Simplify detector profiling

### DIFF
--- a/cli/engine/profile/profiler.mjs
+++ b/cli/engine/profile/profiler.mjs
@@ -8,20 +8,24 @@ function createDetectorProfile() {
   return { events: [] };
 }
 
-function recordProfileEvent(profile, event) {
-  if (!profile) return;
-  const normalized = {
+function normalizeProfileEvent(event) {
+  return {
     engine: event.engine || 'unknown',
     phase: event.phase || 'unknown',
     ruleId: event.ruleId || 'unknown',
     target: event.target || '',
     ms: Number.isFinite(event.ms) ? event.ms : 0,
     findings: Number.isFinite(event.findings) ? event.findings : 0,
+    ...(event.detail ? { detail: event.detail } : {}),
+    ...(Array.isArray(event.findingIds) && event.findingIds.length
+      ? { findingIds: event.findingIds }
+      : {}),
   };
-  if (event.detail) normalized.detail = event.detail;
-  if (Array.isArray(event.findingIds) && event.findingIds.length) {
-    normalized.findingIds = event.findingIds;
-  }
+}
+
+function recordProfileEvent(profile, event) {
+  if (!profile) return;
+  const normalized = normalizeProfileEvent(event);
   if (typeof profile === 'function') {
     profile(normalized);
   } else if (typeof profile.record === 'function') {
@@ -38,10 +42,7 @@ function extractFindingIds(findings) {
   return [...new Set(findings.map(f => f?.id || f?.type || f?.antipattern).filter(Boolean))];
 }
 
-function profileFindings(profile, meta, callback) {
-  if (!profile) return callback();
-  const started = profileNow();
-  const findings = callback();
+function recordDuration(profile, meta, started, findings) {
   recordProfileEvent(profile, {
     ...meta,
     ms: profileNow() - started,
@@ -49,6 +50,12 @@ function profileFindings(profile, meta, callback) {
     findingIds: extractFindingIds(findings),
   });
   return findings;
+}
+
+function profileFindings(profile, meta, callback) {
+  if (!profile) return callback();
+  const started = profileNow();
+  return recordDuration(profile, meta, started, callback());
 }
 
 function profileStep(profile, meta, callback) {
@@ -57,25 +64,14 @@ function profileStep(profile, meta, callback) {
   try {
     return callback();
   } finally {
-    recordProfileEvent(profile, {
-      ...meta,
-      ms: profileNow() - started,
-      findings: 0,
-    });
+    recordDuration(profile, meta, started);
   }
 }
 
 async function profileFindingsAsync(profile, meta, callback) {
   if (!profile) return callback();
   const started = profileNow();
-  const findings = await callback();
-  recordProfileEvent(profile, {
-    ...meta,
-    ms: profileNow() - started,
-    findings: Array.isArray(findings) ? findings.length : 0,
-    findingIds: extractFindingIds(findings),
-  });
-  return findings;
+  return recordDuration(profile, meta, started, await callback());
 }
 
 async function profileStepAsync(profile, meta, callback) {
@@ -84,11 +80,7 @@ async function profileStepAsync(profile, meta, callback) {
   try {
     return await callback();
   } finally {
-    recordProfileEvent(profile, {
-      ...meta,
-      ms: profileNow() - started,
-      findings: 0,
-    });
+    recordDuration(profile, meta, started);
   }
 }
 
@@ -107,19 +99,15 @@ function summarizeDetectorProfile(profile) {
     : (Array.isArray(profile?.events) ? profile.events : []);
   const groups = new Map();
   for (const event of events) {
-    const key = [
-      event.engine || 'unknown',
-      event.phase || 'unknown',
-      event.ruleId || 'unknown',
-      event.target || '',
-    ].join('\u0000');
+    const { engine, phase, ruleId, target, ms, findings } = normalizeProfileEvent(event);
+    const key = [engine, phase, ruleId, target].join('\u0000');
     let group = groups.get(key);
     if (!group) {
       group = {
-        engine: event.engine || 'unknown',
-        phase: event.phase || 'unknown',
-        ruleId: event.ruleId || 'unknown',
-        target: event.target || '',
+        engine,
+        phase,
+        ruleId,
+        target,
         calls: 0,
         totalMs: 0,
         findings: 0,
@@ -127,10 +115,9 @@ function summarizeDetectorProfile(profile) {
       };
       groups.set(key, group);
     }
-    const ms = Number.isFinite(event.ms) ? event.ms : 0;
     group.calls += 1;
     group.totalMs += ms;
-    group.findings += Number.isFinite(event.findings) ? event.findings : 0;
+    group.findings += findings;
     group.samples.push(ms);
   }
   return [...groups.values()]

--- a/tests/detect-antipatterns.test.js
+++ b/tests/detect-antipatterns.test.js
@@ -35,6 +35,15 @@ import {
   scanHtmlForShapeAssembledIllustration,
 } from '../cli/engine/rules/checks.mjs';
 import { parseGradientColors } from '../cli/engine/shared/color.mjs';
+import {
+  createDetectorProfile,
+  profileFindings,
+  profileFindingsAsync,
+  profileStep,
+  profileStepAsync,
+  recordProfileEvent,
+  summarizeDetectorProfile,
+} from '../cli/engine/profile/profiler.mjs';
 
 const FIXTURES = path.join(import.meta.dir, 'fixtures', 'antipatterns');
 const SCRIPT = path.join(import.meta.dir, '..', 'cli', 'engine', 'detect-antipatterns.mjs');
@@ -96,6 +105,53 @@ function pageTypographyForGoogleFonts(href) {
   };
   return checkPageTypography(doc, win);
 }
+
+describe('detector profiler', () => {
+  test('normalizes recorded events before summarizing them', () => {
+    const profile = createDetectorProfile();
+    recordProfileEvent(profile, {
+      engine: 'regex',
+      ms: Number.NaN,
+      findings: Number.POSITIVE_INFINITY,
+      detail: 'source scan',
+      findingIds: ['side-tab'],
+    });
+    recordProfileEvent(profile, { phase: 'parse', ms: 2, findings: 1 });
+
+    expect(profile.events[0]).toEqual({
+      engine: 'regex', phase: 'unknown', ruleId: 'unknown', target: '', ms: 0, findings: 0,
+      detail: 'source scan', findingIds: ['side-tab'],
+    });
+    expect(summarizeDetectorProfile(profile).map(({ phase, totalMs, findings }) => (
+      { phase, totalMs, findings }
+    ))).toEqual([
+      { phase: 'parse', totalMs: 2, findings: 1 },
+      { phase: 'unknown', totalMs: 0, findings: 0 },
+    ]);
+  });
+
+  test('preserves sync and async result and error contracts', async () => {
+    const profile = [];
+    const findings = [{ id: 'side-tab' }, { type: 'side-tab' }, { antipattern: 'dark-glow' }];
+
+    expect(profileFindings(profile, { phase: 'sync-findings' }, () => findings)).toBe(findings);
+    expect(await profileFindingsAsync(profile, { phase: 'async-findings' }, async () => findings)).toBe(findings);
+    expect(() => profileStep(profile, { phase: 'sync-step' }, () => {
+      throw new Error('sync failure');
+    })).toThrow('sync failure');
+    await expect(profileStepAsync(profile, { phase: 'async-step' }, async () => {
+      throw new Error('async failure');
+    })).rejects.toThrow('async failure');
+
+    expect(profile.map(({ phase, findings: count, findingIds }) => ({ phase, count, findingIds }))).toEqual([
+      { phase: 'sync-findings', count: 3, findingIds: ['side-tab', 'dark-glow'] },
+      { phase: 'async-findings', count: 3, findingIds: ['side-tab', 'dark-glow'] },
+      { phase: 'sync-step', count: 0, findingIds: undefined },
+      { phase: 'async-step', count: 0, findingIds: undefined },
+    ]);
+    expect(profile.every(event => Number.isFinite(event.ms) && event.ms >= 0)).toBe(true);
+  });
+});
 
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This scheduled architecture pass simplifies `cli/engine/profile/profiler.mjs` without changing its public API or profiling schema.

**Hindsight is 20/20:** if these requirements were implemented today, I would not duplicate event normalization in recording and summarization or assemble the same duration event in four wrappers. The leanest design is one private normalizer and one private duration recorder, while keeping the sync and async wrappers distinct so their result, throw, rejection, and timing contracts remain explicit.

## Before / after

- Primary file: **166 → 153 lines** (-13, 7.8%)
- Repeated policy implementations: **6 → 2 private owners**
  - event defaults and numeric normalization: 2 → 1
  - duration/finding event assembly: 4 → 1
- Public exports: unchanged
- Profiling event fields and summary ordering: unchanged
- User-facing behavior, CLI output, schemas, and compatibility: unchanged

## Validation

- `bun test tests/detect-antipatterns.test.js` — 388 passed, 0 failed
- detector/browser portions of `bun run test` — 424 Bun + 179 Node tests passed
- `node --check cli/engine/profile/profiler.mjs`
- `node scripts/benchmark-detector.mjs --quick --json`
- `bun run build` — all 18 provider builds and validators passed
- `git diff --check`

The full default test command reaches the unrelated, pre-existing `tests/live-reference.test.mjs` wording mismatch on current `main` (expected “load the one playbook…” while source says “Load the request's playbook”). Open PR #696 addresses that baseline contract; this PR intentionally does not mix that unrelated fix into the profiler refactor.

Generated root harness output is intentionally omitted under the source-first policy.

## Risk

Low and limited to profiling instrumentation. Characterization tests cover normalization, summary output, result identity, finding-ID deduplication, and sync/async error semantics. Timing values remain nondeterministic by nature but retain the existing finite, non-negative contract.

## Authorization and AI disclosure

Prepared with AI assistance by Codex under maintainer **pbakaus's explicit scheduled architecture-refactor authorization**. This is a regular ready-for-review PR. The automation is not authorized to merge it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to internal profiler helpers with new characterization tests; exports and profiling schema are unchanged, so detector/CLI behavior should be unaffected aside from instrumentation code paths.
> 
> **Overview**
> Internal refactor of **`cli/engine/profile/profiler.mjs`** that keeps the public profiler API and event/summary shape the same while removing duplicated logic.
> 
> **`normalizeProfileEvent`** is now the single place that applies defaults (`engine`, `phase`, `ruleId`, `target`), coerces non-finite `ms`/`findings` to safe numbers, and optionally attaches `detail` / `findingIds`. **`recordProfileEvent`** and **`summarizeDetectorProfile`** both use it instead of repeating those rules.
> 
> **`recordDuration`** centralizes building the timed event (elapsed `ms`, finding count, deduped **`findingIds`**). Sync/async **`profileFindings`** / **`profileStep`** wrappers call it so duration recording is not copy-pasted four times; sync/async timing and throw/reject behavior stay as before.
> 
> Adds a **`detector profiler`** test block in **`tests/detect-antipatterns.test.js`** covering normalization on record/summarize, summary grouping, callback return identity, errors from step wrappers, and finite non-negative `ms`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abfa8d2b9034a846eaa74e2fd2207ba507c6632d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->