### PR TITLE
Fix skill subcommand help handling

### DIFF
--- a/cli/bin/commands/skills.mjs
+++ b/cli/bin/commands/skills.mjs
@@ -525,6 +525,54 @@ async function promptCheckbox(message, options, { selectedValues = [] } = {}) {
 
 // ─── skills help ──────────────────────────────────────────────────────────────
 
+const SUBCOMMAND_HELP = {
+  install: `Usage: impeccable install [options]
+
+Install compiled Impeccable skills into project or user-level harness folders.
+
+Options:
+  -y, --yes              Accept detected defaults without prompting
+  --providers=<names>    Comma-separated harnesses to install
+  --scope=<scope>        Install scope: project or global
+  --project              Install into the current project
+  --user, --global       Install at the user level
+  --no-hooks             Install skills without provider hook manifests
+  --force                Replace an existing installation
+  -h, --help             Show this help message`,
+  link: `Usage: impeccable link [options]
+
+Link Impeccable skills from a local checkout or submodule.
+
+Options:
+  --source=<path>        Source checkout (default: .impeccable)
+  --providers=<names>    Comma-separated harnesses to link
+  -y, --yes              Accept detected defaults without prompting
+  --force                Replace existing skill folders with links
+  -h, --help             Show this help message`,
+  update: `Usage: impeccable update [options]
+
+Update an existing Impeccable skill installation.
+
+Options:
+  -y, --yes              Accept detected defaults without prompting
+  --scope=<scope>        Update scope: project or global
+  --project              Update the current project installation
+  --user, --global       Update the user-level installation
+  --no-hooks             Update skills without changing hook manifests
+  --force                Replace installed skill files
+  -h, --help             Show this help message`,
+  check: `Usage: impeccable check [options]
+
+Check whether installed Impeccable skills are up to date.
+
+Options:
+  -h, --help             Show this help message`,
+};
+
+function showSubcommandHelp(subcommand) {
+  console.log(SUBCOMMAND_HELP[subcommand]);
+}
+
 async function showHelp() {
   let commands;
   try {
@@ -2532,6 +2580,11 @@ export {
 
 export async function run(args) {
   const sub = args[0];
+
+  if (SUBCOMMAND_HELP[sub] && args.slice(1).some(arg => arg === '--help' || arg === '-h')) {
+    showSubcommandHelp(sub);
+    return;
+  }
 
   if (!sub || sub === 'help' || sub === '--help' || sub === '-h') {
     await showHelp();

--- a/tests/skills-cli.test.js
+++ b/tests/skills-cli.test.js
@@ -864,6 +864,40 @@ describe('skills install/update: local universal bundle e2e', () => {
     expect(output).not.toContain('skills install                   Install impeccable skills');
   });
 
+  test('skill-management subcommand help exits before downloads, prompts, or writes (#699)', () => {
+    const commands = ['install', 'link', 'update', 'check'];
+    const prefixes = ['', 'skills '];
+    const helpFlags = ['--help', '-h'];
+
+    for (const command of commands) {
+      for (const prefix of prefixes) {
+        for (const helpFlag of helpFlags) {
+          const tmp = mkdtempSync(join(tmpdir(), `imp-test-${command}-help-`));
+          const home = mkdtempSync(join(tmpdir(), `imp-home-${command}-help-`));
+          execSync('git init', { cwd: tmp });
+
+          const output = run(`${prefix}${command} ${helpFlag}`, {
+            cwd: tmp,
+            env: {
+              ...process.env,
+              HOME: home,
+              IMPECCABLE_BUNDLE_PATH: join(tmp, 'must-not-be-read'),
+            },
+          });
+
+          expect(output).toContain(`Usage: impeccable ${command}`);
+          for (const provider of ['.agents', '.claude', '.cursor', '.impeccable']) {
+            expect(existsSync(join(tmp, provider))).toBe(false);
+            expect(existsSync(join(home, provider))).toBe(false);
+          }
+
+          rmSync(tmp, { recursive: true, force: true });
+          rmSync(home, { recursive: true, force: true });
+        }
+      }
+    }
+  }, 30000);
+
   test('top-level install aliases the legacy skills install command', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'imp-test-top-level-install-'));
     const home = mkdtempSync(join(tmpdir(), 'imp-home-top-level-install-'));


### PR DESCRIPTION
## Summary

- add static command-specific help for `install`, `link`, `update`, and `check`
- intercept `-h` and `--help` in the shared skills router before any network, prompt, hook, or filesystem operation
- cover both top-level commands and the legacy `skills <command>` namespace

## Validation

- `bun test tests/skills-cli.test.js` — 108 passed, 8 remote-only skipped
- `bun run test:cli-remote-e2e` — 112 passed
- regression coverage exercises all 16 command/namespace/help-flag combinations with an invalid bundle path and verifies no harness directories are written

Generated provider output is intentionally omitted because this is a CLI-only change.

Closes #699

_AI-assisted implementation under maintainer direction._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change: early return on help flags with no changes to install/update behavior when help is not requested.
> 
> **Overview**
> **Fixes** `impeccable install|link|update|check --help` (and `-h`) so they print usage immediately instead of starting installs, network calls, prompts, or filesystem writes.
> 
> The skills router now keeps **static usage text** for `install`, `link`, `update`, and `check`, and **handles `-h` / `--help` at the top of `run()`** before any subcommand logic runs. That applies to both **top-level** commands and the legacy **`skills <command>`** namespace.
> 
> Regression tests cover all 16 command × namespace × help-flag combinations and assert no harness directories are created when `IMPECCABLE_BUNDLE_PATH` points at a path that must not be read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e06f99f475ef657c430c33666af61d2470380cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->