### PR TITLE
Fix Next.js 16 CSP and parent hook discovery

### DIFF
--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -1313,6 +1313,39 @@ function hookEnabledAt(root) {
 
 const STOP_REVIEW_PROVIDERS = new Set(['claude-code', 'codex', 'agents', 'grok']);
 
+// Harness project settings are discovered by walking up from the active
+// working directory. Context resolution can intentionally select a nested
+// product root even when the harness project (and its hook manifest) lives at
+// the enclosing git root, so checking only projectRoot/repoRoot produces a
+// false MANUAL_DETECTOR_REQUIRED directive. Mirror the ancestor lookup through
+// the nearest git boundary, while retaining exact resolved roots for explicit
+// targets outside the invoking directory.
+function hookManifestSearchRoots(ctx) {
+  const roots = [];
+  const seen = new Set();
+  const add = (root) => {
+    if (!root) return;
+    const resolved = path.resolve(root);
+    if (seen.has(resolved)) return;
+    seen.add(resolved);
+    roots.push(resolved);
+  };
+
+  let current = path.resolve(process.cwd());
+  const home = path.resolve(os.homedir());
+  while (true) {
+    add(current);
+    if (current === home || hasGitBoundary(current)) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  add(ctx.projectRoot);
+  add(ctx.repoRoot);
+  return roots;
+}
+
 function automaticHookMode(ctx) {
   if (ctx.platform === 'ios' || ctx.platform === 'android' || ctx.platform === 'adaptive') {
     return 'none';
@@ -1320,8 +1353,7 @@ function automaticHookMode(ctx) {
   const activeRoot = path.resolve(ctx.projectRoot || process.cwd());
   if (!hookEnabledAt(activeRoot)) return 'none';
   const manifests = HOOK_MANIFESTS_BY_PROVIDER[IMPECCABLE_PROVIDER_ID] || [];
-  const roots = [...new Set([process.cwd(), ctx.projectRoot, ctx.repoRoot].filter(Boolean).map((root) => path.resolve(root)))];
-  for (const root of roots) {
+  for (const root of hookManifestSearchRoots(ctx)) {
     for (const rel of manifests) {
       const raw = readJson(path.join(root, rel));
       if (raw?.hooks && valueHasHookMarker(raw.hooks)) {

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -1313,13 +1313,11 @@ function hookEnabledAt(root) {
 
 const STOP_REVIEW_PROVIDERS = new Set(['claude-code', 'codex', 'agents', 'grok']);
 
-// Harness project settings are discovered by walking up from the active
-// working directory. Context resolution can intentionally select a nested
-// product root even when the harness project (and its hook manifest) lives at
-// the enclosing git root, so checking only projectRoot/repoRoot produces a
-// false MANUAL_DETECTOR_REQUIRED directive. Mirror the ancestor lookup through
-// the nearest git boundary, while retaining exact resolved roots for explicit
-// targets outside the invoking directory.
+// Harness project settings are discovered by walking up from the resolved
+// project root. Its hook manifest can live at an enclosing git root, so
+// checking only projectRoot/repoRoot produces a false
+// MANUAL_DETECTOR_REQUIRED directive. Starting from projectRoot also prevents
+// an explicit target from borrowing an unrelated manifest near the caller.
 function hookManifestSearchRoots(ctx) {
   const roots = [];
   const seen = new Set();
@@ -1331,7 +1329,7 @@ function hookManifestSearchRoots(ctx) {
     roots.push(resolved);
   };
 
-  let current = path.resolve(process.cwd());
+  let current = path.resolve(ctx.projectRoot || process.cwd());
   const home = path.resolve(os.homedir());
   while (true) {
     add(current);

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -200,7 +200,20 @@ export function resolveTargetSelection(cwd = process.cwd(), options = {}) {
 function resolveProject(cwd = process.cwd(), options = {}) {
   const absCwd = path.resolve(cwd);
   const targetDir = resolveTargetDir(absCwd, options);
+  const hasExplicitTarget = hasTargetOption(options) && targetDir !== absCwd;
+  const targetGitRoot = hasExplicitTarget ? findGitBoundaryRoot(targetDir) : null;
   let repoRoot = findMonorepoRoot(targetDir);
+  if (!repoRoot && targetGitRoot) {
+    const cwdGitRoot = findGitBoundaryRoot(absCwd);
+    if (targetGitRoot !== cwdGitRoot) {
+      return {
+        targetDir,
+        projectRoot: nearestTargetContextRoot(targetGitRoot, targetDir) || targetGitRoot,
+        repoRoot: targetGitRoot,
+        isMonorepo: false,
+      };
+    }
+  }
   if (!repoRoot && targetDir !== absCwd) {
     const cwdRepoRoot = findMonorepoRoot(absCwd);
     if (cwdRepoRoot && isPathInside(targetDir, cwdRepoRoot)) {
@@ -212,7 +225,7 @@ function resolveProject(cwd = process.cwd(), options = {}) {
       && targetDir !== absCwd
       && !isPathInside(targetDir, absCwd);
     if (targetIsExternal) {
-      const targetRepoRoot = findGitBoundaryRoot(targetDir) || targetDir;
+      const targetRepoRoot = targetGitRoot || targetDir;
       return {
         targetDir,
         projectRoot: nearestTargetContextRoot(targetRepoRoot, targetDir) || targetRepoRoot,
@@ -239,8 +252,8 @@ function findGitBoundaryRoot(startDir) {
   let dir = path.resolve(startDir);
   const homeDir = path.resolve(os.homedir());
   while (true) {
-    if (hasGitBoundary(dir)) return dir;
     if (dir === homeDir) return null;
+    if (hasGitBoundary(dir)) return dir;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
     dir = parent;
@@ -1359,8 +1372,9 @@ function hookManifestSearchRoots(ctx) {
   let current = path.resolve(ctx.projectRoot || process.cwd());
   const home = path.resolve(os.homedir());
   while (true) {
+    if (current === home) break;
     add(current);
-    if (current === home || hasGitBoundary(current)) break;
+    if (hasGitBoundary(current)) break;
     const parent = path.dirname(current);
     if (parent === current) break;
     current = parent;

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -1315,9 +1315,12 @@ const STOP_REVIEW_PROVIDERS = new Set(['claude-code', 'codex', 'agents', 'grok']
 
 // Harness project settings are discovered by walking up from the resolved
 // project root. Its hook manifest can live at an enclosing git root, so
-// checking only projectRoot/repoRoot produces a false
-// MANUAL_DETECTOR_REQUIRED directive. Starting from projectRoot also prevents
-// an explicit target from borrowing an unrelated manifest near the caller.
+// checking only projectRoot produces a false MANUAL_DETECTOR_REQUIRED
+// directive. Starting from projectRoot also prevents an explicit target from
+// borrowing an unrelated manifest near the caller. The walk itself is the
+// authority: do not append repoRoot afterward, because resolveProject can
+// retain an outer workspace root for a target inside an independent nested
+// Git repository.
 function hookManifestSearchRoots(ctx) {
   const roots = [];
   const seen = new Set();
@@ -1339,8 +1342,6 @@ function hookManifestSearchRoots(ctx) {
     current = parent;
   }
 
-  add(ctx.projectRoot);
-  add(ctx.repoRoot);
   return roots;
 }
 

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -208,6 +208,18 @@ function resolveProject(cwd = process.cwd(), options = {}) {
     }
   }
   if (!repoRoot) {
+    const targetIsExternal = hasTargetOption(options)
+      && targetDir !== absCwd
+      && !isPathInside(targetDir, absCwd);
+    if (targetIsExternal) {
+      const targetRepoRoot = findGitBoundaryRoot(targetDir) || targetDir;
+      return {
+        targetDir,
+        projectRoot: nearestTargetContextRoot(targetRepoRoot, targetDir) || targetRepoRoot,
+        repoRoot: targetRepoRoot,
+        isMonorepo: false,
+      };
+    }
     return {
       targetDir,
       projectRoot: nearestTargetContextRoot(absCwd, targetDir) || absCwd,
@@ -221,6 +233,18 @@ function resolveProject(cwd = process.cwd(), options = {}) {
     repoRoot,
     isMonorepo: true,
   };
+}
+
+function findGitBoundaryRoot(startDir) {
+  let dir = path.resolve(startDir);
+  const homeDir = path.resolve(os.homedir());
+  while (true) {
+    if (hasGitBoundary(dir)) return dir;
+    if (dir === homeDir) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
 }
 
 function isPathInside(candidate, root) {

--- a/skill/scripts/context.mjs
+++ b/skill/scripts/context.mjs
@@ -1352,6 +1352,9 @@ function automaticHookMode(ctx) {
   if (!hookEnabledAt(activeRoot)) return 'none';
   const manifests = HOOK_MANIFESTS_BY_PROVIDER[IMPECCABLE_PROVIDER_ID] || [];
   for (const root of hookManifestSearchRoots(ctx)) {
+    // A manifest can live above the resolved product. Honor the hook lifecycle
+    // config beside that manifest before treating it as active coverage.
+    if (!hookEnabledAt(root)) continue;
     for (const rel of manifests) {
       const raw = readJson(path.join(root, rel));
       if (raw?.hooks && valueHasHookMarker(raw.hooks)) {

--- a/skill/scripts/detect-csp.mjs
+++ b/skill/scripts/detect-csp.mjs
@@ -88,17 +88,45 @@ const NEXT_PROXY_FILES = new Set([
   'proxy.js',
   'proxy.mjs',
 ]);
+const NEXT_CONFIG_FILES = [
+  'next.config.js',
+  'next.config.mjs',
+  'next.config.cjs',
+  'next.config.ts',
+  'next.config.mts',
+  'next.config.cts',
+];
 const MIDDLEWARE_HINT = /headers\.set\(\s*["']Content-Security-Policy["']/i;
 const META_TAG_HINT = /http-equiv\s*=\s*["']Content-Security-Policy["']/i;
 
-function isNextRequestHookFile(relPath, base) {
+function hasNextProjectMarker(projectRoot) {
+  if (NEXT_CONFIG_FILES.some(name => fs.existsSync(path.join(projectRoot, name)))) return true;
+  if (['app', 'pages', 'src/app', 'src/pages'].some(rel => fs.existsSync(path.join(projectRoot, rel)))) return true;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
+    return ['dependencies', 'devDependencies', 'peerDependencies']
+      .some(group => pkg?.[group] && Object.prototype.hasOwnProperty.call(pkg[group], 'next'));
+  } catch {
+    return false;
+  }
+}
+
+function isNextRequestHookFile(root, absPath, relPath, base) {
   if (NEXT_MIDDLEWARE_FILES.has(base)) return true;
   if (!NEXT_PROXY_FILES.has(base)) return false;
   const normalized = relPath.split(path.sep).join('/').toLowerCase();
   // Next.js 16 recognizes proxy at the project root or in the optional src/
-  // directory, alongside app/ or pages/. A same-named helper deeper in the
-  // tree is not the framework request hook.
-  return normalized === base || normalized === `src/${base}`;
+  // directory, alongside app/ or pages/. The scan root is commonly a
+  // monorepo, so also accept that placement relative to a nested directory
+  // that carries a concrete Next.js project marker. A same-named helper
+  // elsewhere in the tree is not the framework request hook.
+  if (normalized === base || normalized === `src/${base}`) return true;
+  const hookDir = path.dirname(absPath);
+  const projectRoot = path.basename(hookDir).toLowerCase() === 'src'
+    ? path.dirname(hookDir)
+    : hookDir;
+  if (path.resolve(projectRoot) === path.resolve(root)) return true;
+  return hasNextProjectMarker(projectRoot);
 }
 
 /**
@@ -154,7 +182,7 @@ export function detectCsp(cwd = process.cwd()) {
 
     // === detect-only shapes ===
 
-    if (isNextRequestHookFile(relPath, base) && MIDDLEWARE_HINT.test(body)) {
+    if (isNextRequestHookFile(cwd, absPath, relPath, base) && MIDDLEWARE_HINT.test(body)) {
       hits.middleware.push(relPath);
     }
 

--- a/skill/scripts/detect-csp.mjs
+++ b/skill/scripts/detect-csp.mjs
@@ -78,16 +78,28 @@ const NUXT_ROUTE_RULES_SIGNALS = [
   /\bscript-src\b/,
 ];
 
-const NEXT_REQUEST_HOOK_FILES = new Set([
+const NEXT_MIDDLEWARE_FILES = new Set([
   'middleware.ts',
   'middleware.js',
   'middleware.mjs',
+]);
+const NEXT_PROXY_FILES = new Set([
   'proxy.ts',
   'proxy.js',
   'proxy.mjs',
 ]);
 const MIDDLEWARE_HINT = /headers\.set\(\s*["']Content-Security-Policy["']/i;
 const META_TAG_HINT = /http-equiv\s*=\s*["']Content-Security-Policy["']/i;
+
+function isNextRequestHookFile(relPath, base) {
+  if (NEXT_MIDDLEWARE_FILES.has(base)) return true;
+  if (!NEXT_PROXY_FILES.has(base)) return false;
+  const normalized = relPath.split(path.sep).join('/').toLowerCase();
+  // Next.js 16 recognizes proxy at the project root or in the optional src/
+  // directory, alongside app/ or pages/. A same-named helper deeper in the
+  // tree is not the framework request hook.
+  return normalized === base || normalized === `src/${base}`;
+}
 
 /**
  * @param {string} cwd Project root.
@@ -142,7 +154,7 @@ export function detectCsp(cwd = process.cwd()) {
 
     // === detect-only shapes ===
 
-    if (NEXT_REQUEST_HOOK_FILES.has(base) && MIDDLEWARE_HINT.test(body)) {
+    if (isNextRequestHookFile(relPath, base) && MIDDLEWARE_HINT.test(body)) {
       hits.middleware.push(relPath);
     }
 

--- a/skill/scripts/detect-csp.mjs
+++ b/skill/scripts/detect-csp.mjs
@@ -18,8 +18,9 @@
  *                       Covers:
  *                         - Inline Next.js headers() with CSP string
  *                         - Nuxt routeRules / nitro.routeRules CSP headers
- *   - "middleware":     CSP set dynamically in middleware.{ts,js}.
- *                       Detected but not auto-patched in v1.
+ *   - "middleware":     CSP set dynamically in middleware.{ts,js,mjs} or
+ *                       Next.js 16's proxy.{ts,js,mjs} convention. Detected
+ *                       but not auto-patched in v1.
  *   - "meta-tag":       <meta http-equiv="Content-Security-Policy"> in
  *                       layout files. Detected but not auto-patched in v1.
  *   - null:             no CSP signals found; no patch needed.
@@ -77,6 +78,14 @@ const NUXT_ROUTE_RULES_SIGNALS = [
   /\bscript-src\b/,
 ];
 
+const NEXT_REQUEST_HOOK_FILES = new Set([
+  'middleware.ts',
+  'middleware.js',
+  'middleware.mjs',
+  'proxy.ts',
+  'proxy.js',
+  'proxy.mjs',
+]);
 const MIDDLEWARE_HINT = /headers\.set\(\s*["']Content-Security-Policy["']/i;
 const META_TAG_HINT = /http-equiv\s*=\s*["']Content-Security-Policy["']/i;
 
@@ -133,8 +142,7 @@ export function detectCsp(cwd = process.cwd()) {
 
     // === detect-only shapes ===
 
-    if ((base === 'middleware.ts' || base === 'middleware.js' || base === 'middleware.mjs') &&
-        MIDDLEWARE_HINT.test(body)) {
+    if (NEXT_REQUEST_HOOK_FILES.has(base) && MIDDLEWARE_HINT.test(body)) {
       hits.middleware.push(relPath);
     }
 

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -408,7 +408,7 @@ describe('loadContext (monorepo project context)', () => {
     assert.equal(ctx.designPath, null);
   });
 
-  it('resolves an explicit root target into a nested-git workspace child', () => {
+  it('keeps an explicit root target inside its nested Git repository', () => {
     write('package.json', JSON.stringify({
       private: true,
       workspaces: ['repos/*'],
@@ -421,13 +421,13 @@ describe('loadContext (monorepo project context)', () => {
 
     const project = path.join(scratch, 'repos', 'standalone');
     const ctx = loadContext(scratch, { targetPath: 'repos/standalone/src/App.jsx' });
-    assert.equal(ctx.isMonorepo, true);
+    assert.equal(ctx.isMonorepo, false);
     assert.equal(ctx.projectRoot, project);
-    assert.equal(ctx.repoRoot, scratch);
+    assert.equal(ctx.repoRoot, project);
     assert.match(ctx.product, /Standalone product/);
-    assert.match(ctx.design, /Outer design/);
+    assert.equal(ctx.design, null);
     assert.equal(ctx.productPath, path.join('repos', 'standalone', 'PRODUCT.md'));
-    assert.equal(ctx.designPath, 'DESIGN.md');
+    assert.equal(ctx.designPath, null);
   });
 
   it('supports double-star workspace patterns by resolving the shallow child project', () => {
@@ -1298,6 +1298,39 @@ describe('context.mjs CLI', () => {
     assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
   });
 
+  it('treats a markerless nested Git target as an independent repository', () => {
+    const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
+    stageContextBundle(scripts, { providerId: 'claude-code' });
+
+    const repo = path.join(scratch, 'repo');
+    const target = path.join(repo, 'repos', 'standalone');
+    fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(repo, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(target, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({ private: true, workspaces: ['repos/*'] }));
+    fs.writeFileSync(path.join(repo, 'PRODUCT.md'), '# Outer product\n');
+    fs.writeFileSync(path.join(repo, '.claude', 'settings.local.json'), JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ command: 'node .claude/skills/impeccable/scripts/hook.mjs' }] }] },
+    }));
+    fs.writeFileSync(path.join(target, 'src', 'App.jsx'), 'export default function App() { return "standalone"; }\n');
+
+    const res = spawnSync(process.execPath, [
+      path.join(scripts, 'context.mjs'),
+      '--target',
+      path.join('repos', 'standalone', 'src', 'App.jsx'),
+    ], {
+      cwd: repo,
+      encoding: 'utf8',
+      env: { ...process.env, IMPECCABLE_NO_UPDATE_CHECK: '1', IMPECCABLE_NO_STALENESS_CHECK: '1' },
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /"projectRoot": ".*\/repos\/standalone"/);
+    assert.match(res.stdout, /"repoRoot": ".*\/repos\/standalone"/);
+    assert.doesNotMatch(res.stdout, /# Outer product/);
+    assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
+  });
+
   it('does not borrow the caller hook for a target in an independent sibling repository', () => {
     const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
     stageContextBundle(scripts, { providerId: 'claude-code' });
@@ -1329,6 +1362,45 @@ describe('context.mjs CLI', () => {
     assert.match(res.stdout, /"repoRoot": ".*\/target"/);
     assert.match(res.stdout, /# Target/);
     assert.doesNotMatch(res.stdout, /# Caller/);
+    assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
+  });
+
+  it('does not treat a home-directory Git checkout as an external target repository', () => {
+    const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
+    stageContextBundle(scripts, { providerId: 'claude-code' });
+
+    const fakeHome = path.join(scratch, 'home');
+    const caller = path.join(fakeHome, 'caller');
+    const target = path.join(fakeHome, 'target');
+    fs.mkdirSync(path.join(fakeHome, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(fakeHome, '.claude'), { recursive: true });
+    fs.mkdirSync(caller, { recursive: true });
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(fakeHome, 'PRODUCT.md'), '# Home product\n');
+    fs.writeFileSync(path.join(fakeHome, '.claude', 'settings.local.json'), JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ command: 'node .claude/skills/impeccable/scripts/hook.mjs' }] }] },
+    }));
+    fs.writeFileSync(path.join(target, 'PRODUCT.md'), '# Target product\n');
+
+    const res = spawnSync(process.execPath, [
+      path.join(scripts, 'context.mjs'),
+      '--target',
+      target,
+    ], {
+      cwd: caller,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        IMPECCABLE_NO_UPDATE_CHECK: '1',
+        IMPECCABLE_NO_STALENESS_CHECK: '1',
+      },
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /"projectRoot": ".*\/target"/);
+    assert.match(res.stdout, /"repoRoot": ".*\/target"/);
+    assert.match(res.stdout, /# Target product/);
+    assert.doesNotMatch(res.stdout, /# Home product/);
     assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
   });
 

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -1266,6 +1266,38 @@ describe('context.mjs CLI', () => {
     assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
   });
 
+  it('does not borrow an outer workspace hook for a target in a nested Git repository', () => {
+    const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
+    stageContextBundle(scripts, { providerId: 'claude-code' });
+
+    const repo = path.join(scratch, 'repo');
+    const target = path.join(repo, 'repos', 'standalone');
+    fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(repo, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(target, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({ private: true, workspaces: ['repos/*'] }));
+    fs.writeFileSync(path.join(repo, '.claude', 'settings.local.json'), JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ command: 'node .claude/skills/impeccable/scripts/hook.mjs' }] }] },
+    }));
+    fs.writeFileSync(path.join(target, 'package.json'), JSON.stringify({ name: 'standalone' }));
+    fs.writeFileSync(path.join(target, 'PRODUCT.md'), '# Standalone\n');
+    fs.writeFileSync(path.join(target, 'src', 'App.jsx'), 'export default function App() { return "standalone"; }\n');
+
+    const res = spawnSync(process.execPath, [
+      path.join(scripts, 'context.mjs'),
+      '--target',
+      path.join('repos', 'standalone', 'src', 'App.jsx'),
+    ], {
+      cwd: repo,
+      encoding: 'utf8',
+      env: { ...process.env, IMPECCABLE_NO_UPDATE_CHECK: '1', IMPECCABLE_NO_STALENESS_CHECK: '1' },
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /"projectRoot": ".*\/repos\/standalone"/);
+    assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
+  });
+
   it('adds no detector directive when a per-edit-only hook is active', () => {
     const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
     stageContextBundle(scripts, { providerId: 'cursor' });

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -1221,6 +1221,39 @@ describe('context.mjs CLI', () => {
     assert.doesNotMatch(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
   });
 
+  it('does not borrow a hook manifest from the invoking workspace when targeting a sibling', () => {
+    const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
+    stageContextBundle(scripts, { providerId: 'claude-code' });
+
+    const repo = path.join(scratch, 'repo');
+    const caller = path.join(repo, 'apps', 'marketing');
+    const target = path.join(repo, 'apps', 'dashboard');
+    fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(caller, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({ private: true, workspaces: ['apps/*'] }));
+    fs.writeFileSync(path.join(repo, 'turbo.json'), JSON.stringify({ tasks: {} }));
+    fs.writeFileSync(path.join(caller, 'package.json'), JSON.stringify({ name: 'marketing' }));
+    fs.writeFileSync(path.join(target, 'package.json'), JSON.stringify({ name: 'dashboard' }));
+    fs.writeFileSync(path.join(target, 'PRODUCT.md'), '# Dashboard\n');
+    fs.writeFileSync(path.join(target, 'src', 'App.jsx'), 'export default function App() { return "dashboard"; }\n');
+    fs.writeFileSync(path.join(caller, '.claude', 'settings.local.json'), JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ command: 'node .claude/skills/impeccable/scripts/hook.mjs' }] }] },
+    }));
+
+    const res = spawnSync(process.execPath, [
+      path.join(scripts, 'context.mjs'),
+      '--target',
+      path.join(target, 'src', 'App.jsx'),
+    ], {
+      cwd: caller,
+      encoding: 'utf8',
+      env: { ...process.env, IMPECCABLE_NO_UPDATE_CHECK: '1', IMPECCABLE_NO_STALENESS_CHECK: '1' },
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
+  });
+
   it('adds no detector directive when a per-edit-only hook is active', () => {
     const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
     stageContextBundle(scripts, { providerId: 'cursor' });

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -1219,6 +1219,18 @@ describe('context.mjs CLI', () => {
     });
     assert.equal(res.status, 0, res.stderr);
     assert.doesNotMatch(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
+
+    fs.mkdirSync(path.join(repo, '.impeccable'), { recursive: true });
+    fs.writeFileSync(path.join(repo, '.impeccable', 'config.local.json'), JSON.stringify({
+      hook: { enabled: false },
+    }));
+    const disabled = spawnSync(process.execPath, [path.join(scripts, 'context.mjs')], {
+      cwd: project,
+      encoding: 'utf8',
+      env: { ...process.env, IMPECCABLE_NO_UPDATE_CHECK: '1', IMPECCABLE_NO_STALENESS_CHECK: '1' },
+    });
+    assert.equal(disabled.status, 0, disabled.stderr);
+    assert.match(disabled.stdout, /MANUAL_DETECTOR_REQUIRED:/);
   });
 
   it('does not borrow a hook manifest from the invoking workspace when targeting a sibling', () => {

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -1198,6 +1198,29 @@ describe('context.mjs CLI', () => {
     assert.match(disabled.stdout, /detect\.mjs --json <changed targets>/);
   });
 
+  it('finds the active hook manifest at an enclosing harness project root', () => {
+    const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
+    stageContextBundle(scripts, { providerId: 'claude-code' });
+
+    const repo = path.join(scratch, 'repo');
+    const project = path.join(repo, 'web');
+    fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(repo, '.claude'), { recursive: true });
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(path.join(project, 'PRODUCT.md'), '# Nested web product\n');
+    fs.writeFileSync(path.join(repo, '.claude', 'settings.local.json'), JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ command: 'node .claude/skills/impeccable/scripts/hook.mjs' }] }] },
+    }));
+
+    const res = spawnSync(process.execPath, [path.join(scripts, 'context.mjs')], {
+      cwd: project,
+      encoding: 'utf8',
+      env: { ...process.env, IMPECCABLE_NO_UPDATE_CHECK: '1', IMPECCABLE_NO_STALENESS_CHECK: '1' },
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.doesNotMatch(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
+  });
+
   it('adds no detector directive when a per-edit-only hook is active', () => {
     const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
     stageContextBundle(scripts, { providerId: 'cursor' });

--- a/tests/context.test.mjs
+++ b/tests/context.test.mjs
@@ -1298,6 +1298,40 @@ describe('context.mjs CLI', () => {
     assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
   });
 
+  it('does not borrow the caller hook for a target in an independent sibling repository', () => {
+    const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
+    stageContextBundle(scripts, { providerId: 'claude-code' });
+
+    const caller = path.join(scratch, 'caller');
+    const target = path.join(scratch, 'target');
+    fs.mkdirSync(path.join(caller, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(caller, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(target, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(caller, 'PRODUCT.md'), '# Caller\n');
+    fs.writeFileSync(path.join(caller, '.claude', 'settings.local.json'), JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ command: 'node .claude/skills/impeccable/scripts/hook.mjs' }] }] },
+    }));
+    fs.writeFileSync(path.join(target, 'PRODUCT.md'), '# Target\n');
+    fs.writeFileSync(path.join(target, 'src', 'App.jsx'), 'export default function App() { return "target"; }\n');
+
+    const res = spawnSync(process.execPath, [
+      path.join(scripts, 'context.mjs'),
+      '--target',
+      path.join('..', 'target', 'src', 'App.jsx'),
+    ], {
+      cwd: caller,
+      encoding: 'utf8',
+      env: { ...process.env, IMPECCABLE_NO_UPDATE_CHECK: '1', IMPECCABLE_NO_STALENESS_CHECK: '1' },
+    });
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /"projectRoot": ".*\/target"/);
+    assert.match(res.stdout, /"repoRoot": ".*\/target"/);
+    assert.match(res.stdout, /# Target/);
+    assert.doesNotMatch(res.stdout, /# Caller/);
+    assert.match(res.stdout, /MANUAL_DETECTOR_REQUIRED:/);
+  });
+
   it('adds no detector directive when a per-edit-only hook is active', () => {
     const scripts = path.join(scratch, 'bundle', 'skills', 'impeccable', 'scripts');
     stageContextBundle(scripts, { providerId: 'cursor' });

--- a/tests/framework-fixtures.test.mjs
+++ b/tests/framework-fixtures.test.mjs
@@ -286,20 +286,32 @@ for (const name of listFixtures()) {
 }
 
 describe('detectCsp — Next.js proxy placement', () => {
-  it('accepts root and src proxy files but ignores same-named nested helpers', () => {
+  it('accepts proxy files at app roots and src roots but ignores same-named helpers', () => {
     const source = `export function proxy() {
   const response = new Response();
   response.headers.set('Content-Security-Policy', "script-src 'self'");
   return response;
 }\n`;
-    for (const [relPath, expectedShape] of [
+    for (const [relPath, expectedShape, markers = []] of [
       ['proxy.ts', 'middleware'],
       ['src/proxy.ts', 'middleware'],
+      ['apps/web/proxy.ts', 'middleware', ['apps/web/app']],
+      ['apps/docs/src/proxy.ts', 'middleware', ['apps/docs/src/pages']],
+      ['apps/store/proxy.ts', 'middleware', ['apps/store/package.json']],
       ['lib/network/proxy.ts', null],
+      ['apps/web/lib/proxy.ts', null, ['apps/web/app']],
     ]) {
       const tmp = mkdtempSync(join(tmpdir(), 'impeccable-proxy-placement-'));
       try {
         mkdirSync(dirname(join(tmp, relPath)), { recursive: true });
+        for (const marker of markers) {
+          if (marker.endsWith('package.json')) {
+            mkdirSync(dirname(join(tmp, marker)), { recursive: true });
+            writeFileSync(join(tmp, marker), JSON.stringify({ dependencies: { next: '^16.0.0' } }));
+          } else {
+            mkdirSync(join(tmp, marker), { recursive: true });
+          }
+        }
         writeFileSync(join(tmp, relPath), source);
         assert.equal(detectCsp(tmp).shape, expectedShape, relPath);
       } finally {

--- a/tests/framework-fixtures.test.mjs
+++ b/tests/framework-fixtures.test.mjs
@@ -284,3 +284,27 @@ for (const name of listFixtures()) {
     });
   });
 }
+
+describe('detectCsp — Next.js proxy placement', () => {
+  it('accepts root and src proxy files but ignores same-named nested helpers', () => {
+    const source = `export function proxy() {
+  const response = new Response();
+  response.headers.set('Content-Security-Policy', "script-src 'self'");
+  return response;
+}\n`;
+    for (const [relPath, expectedShape] of [
+      ['proxy.ts', 'middleware'],
+      ['src/proxy.ts', 'middleware'],
+      ['lib/network/proxy.ts', null],
+    ]) {
+      const tmp = mkdtempSync(join(tmpdir(), 'impeccable-proxy-placement-'));
+      try {
+        mkdirSync(dirname(join(tmp, relPath)), { recursive: true });
+        writeFileSync(join(tmp, relPath), source);
+        assert.equal(detectCsp(tmp).shape, expectedShape, relPath);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/tests/framework-fixtures/README.md
+++ b/tests/framework-fixtures/README.md
@@ -94,6 +94,9 @@ Fixtures can also opt into a **runtime E2E** pass that actually installs depende
 }
 ```
 
+The legacy `middleware` shape name covers CSP set in either Next.js
+`middleware.*` files or the Next.js 16 `proxy.*` convention.
+
 The `expectedAfter` file lives alongside `fixture.json` (not inside `files/`) and is a human/agent-review reference — tests don't auto-apply the patch.
 
 The `runtime` block is optional. Fixtures without it only run the static unit checks (is-generated, inject, wrap, csp-detect). Fixtures *with* it additionally run the E2E suite in `tests/live-e2e.test.mjs` (`bun run test:live-e2e`), which:

--- a/tests/framework-fixtures/nextjs-proxy-csp/files/app/layout.tsx
+++ b/tests/framework-fixtures/nextjs-proxy-csp/files/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/framework-fixtures/nextjs-proxy-csp/files/proxy.ts
+++ b/tests/framework-fixtures/nextjs-proxy-csp/files/proxy.ts
@@ -1,0 +1,10 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const response = NextResponse.next({ request });
+  response.headers.set(
+    "Content-Security-Policy",
+    "default-src 'self'; script-src 'self' 'nonce-runtime'; connect-src 'self'",
+  );
+  return response;
+}

--- a/tests/framework-fixtures/nextjs-proxy-csp/fixture.json
+++ b/tests/framework-fixtures/nextjs-proxy-csp/fixture.json
@@ -1,0 +1,15 @@
+{
+  "name": "Next.js 16 (proxy CSP)",
+  "config": {
+    "files": ["app/layout.tsx"],
+    "insertBefore": "</body>",
+    "commentSyntax": "jsx"
+  },
+  "sourceFiles": ["proxy.ts", "app/layout.tsx"],
+  "generatedFiles": [],
+  "wrapCases": [],
+  "csp": {
+    "shape": "middleware",
+    "signals": ["proxy.ts:Content-Security-Policy"]
+  }
+}

--- a/tests/framework-fixtures/nextjs-proxy-csp/gitignore.txt
+++ b/tests/framework-fixtures/nextjs-proxy-csp/gitignore.txt
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+out/


### PR DESCRIPTION
## Summary

- recognize Next.js 16 `proxy.{ts,js,mjs}` request hooks at the documented project-root/`src` locations when detecting response-header CSP, while preserving the existing `middleware` result shape
- discover active provider hook manifests from the resolved project through the nearest Git boundary, without borrowing a caller workspace's manifest
- honor hook-disable config beside an ancestor manifest and add regressions for target scope, config precedence, and Proxy placement

## Validation

- `bun run build`
- `node --test tests/context.test.mjs` (111/111)
- `node --test tests/framework-fixtures.test.mjs` (223/223)
- full `bun run test` was attempted; it reached 840 passing tests before the unrelated `tests/build-phase.test.mjs` process stalled locally, with no changed-file failure reported

Refs #625

AI assistance disclosure: Codex implemented and verified this change under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how monorepos, nested repos, and `--target` resolve roots and whether automatic hooks run—wrong scope could skip detection or pull wrong product context, but behavior is heavily regression-tested.
> 
> **Overview**
> **Context resolution** now treats an explicit `--target` inside a **nested or sibling Git repo** as its own `repoRoot`/`projectRoot`, instead of folding it into an outer monorepo and inheriting outer `PRODUCT.md`/hooks. A **`findGitBoundaryRoot`** walk supports that, including external targets and a guard so a Git checkout at `$HOME` is not misclassified.
> 
> **Automatic hook detection** no longer scans `cwd` + `repoRoot` in one flat list. It walks **up from `projectRoot` to the nearest Git boundary**, finds manifests on ancestors (e.g. harness config at repo root while cwd is a nested app), respects **`hook.enabled` beside each manifest**, and **does not** treat a caller’s or outer-workspace hook as active for a scoped target.
> 
> **CSP detection** still reports the existing **`middleware`** shape but also classifies **Next.js 16 `proxy.{ts,js,mjs}`** when they set `Content-Security-Policy`, with placement rules (project/`src` roots or a directory with a Next marker) so unrelated `proxy.ts` helpers are ignored.
> 
> Tests and a **`nextjs-proxy-csp`** fixture cover nested-git context, hook borrowing, and proxy placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5712d782555da4900f2797fa9efde99669e6d572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->