### PR TITLE
Self-discard orphaned JSX live sessions again

### DIFF
--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6239,35 +6239,45 @@
   function probeJsxWrapperForOrphan(filePath, sessionId, opts) {
     const attempt = opts._orphanAttempt || 0;
     const url = 'http://localhost:' + PORT + '/source?token=' + TOKEN + '&path=' + encodeURIComponent(filePath);
-    // A read that cannot answer (the file renamed or deleted: 404; a transient
-    // fetch failure) counts against the same retry budget as a read that
-    // answers without the marker. Either way the session cannot recover its
-    // wrapper from source, and after the budget it is discarded rather than
-    // left frozen in GENERATING or CYCLING; the reason names which it was.
-    const retryOrDiscard = (reason) => {
-      if (sessionId !== currentSessionId) return;
-      if (state !== 'GENERATING' && state !== 'CYCLING') return;
-      if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) {
-        setTimeout(() => {
-          if (sessionId !== currentSessionId) return;
-          if (state !== 'GENERATING' && state !== 'CYCLING') return;
-          injectVariantsFromSource(filePath, sessionId, { ...opts, _orphanAttempt: attempt + 1 });
-        }, COMPLETED_SOURCE_FALLBACK_RETRY_MS);
-        return;
-      }
+    const stillActive = () => sessionId === currentSessionId && (state === 'GENERATING' || state === 'CYCLING');
+    const retryLater = () => {
+      setTimeout(() => {
+        if (!stillActive()) return;
+        injectVariantsFromSource(filePath, sessionId, { ...opts, _orphanAttempt: attempt + 1 });
+      }, COMPLETED_SOURCE_FALLBACK_RETRY_MS);
+    };
+    // Discarding is durable (the session moves to the discarded phase and the
+    // picker replaces it), so it needs evidence that the wrapper is gone: a
+    // read that answers without the marker, or a 404 (the file itself was
+    // renamed or deleted). Either kind retries on the shared budget first.
+    // A read that fails for any other reason (the server briefly away, a
+    // transient fetch error) says nothing about the wrapper; after the budget
+    // the session is kept, the user told, and the next event retries.
+    const onNoWrapper = (reason) => {
+      if (!stillActive()) return;
+      if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) { retryLater(); return; }
       discardOrphanedSession(reason);
+    };
+    const onUnreadable = (detail) => {
+      if (!stillActive()) return;
+      if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) { retryLater(); return; }
+      console.warn('[impeccable] Could not read source to check the variant wrapper; keeping the session: ' + detail);
+      showToast('Could not read the source file to check this session; it stays open and is checked again on the next event.', 5500);
     };
     fetch(url)
       .then(r => { if (!r.ok) throw new Error('source read failed: ' + r.status); return r.text(); })
       .then(text => {
-        if (sessionId !== currentSessionId) return;
-        if (state !== 'GENERATING' && state !== 'CYCLING') return;
+        if (!stillActive()) return;
         if (sourceHasSessionWrapper(text, sessionId)) return;
-        retryOrDiscard('variant wrapper missing from source');
+        onNoWrapper('variant wrapper missing from source');
       })
       .catch(err => {
-        console.warn('[impeccable] Orphan probe could not read source: ' + (err && err.message ? err.message : err));
-        retryOrDiscard('source unreadable while checking for the variant wrapper (' + (err && err.message ? err.message : 'fetch failed') + ')');
+        const detail = err && err.message ? err.message : 'fetch failed';
+        if (/source read failed: 404$/.test(detail)) {
+          onNoWrapper('source file missing (404) while checking for the variant wrapper');
+          return;
+        }
+        onUnreadable(detail);
       });
   }
 

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6239,23 +6239,36 @@
   function probeJsxWrapperForOrphan(filePath, sessionId, opts) {
     const attempt = opts._orphanAttempt || 0;
     const url = 'http://localhost:' + PORT + '/source?token=' + TOKEN + '&path=' + encodeURIComponent(filePath);
+    // A read that cannot answer (the file renamed or deleted: 404; a transient
+    // fetch failure) counts against the same retry budget as a read that
+    // answers without the marker. Either way the session cannot recover its
+    // wrapper from source, and after the budget it is discarded rather than
+    // left frozen in GENERATING or CYCLING; the reason names which it was.
+    const retryOrDiscard = (reason) => {
+      if (sessionId !== currentSessionId) return;
+      if (state !== 'GENERATING' && state !== 'CYCLING') return;
+      if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) {
+        setTimeout(() => {
+          if (sessionId !== currentSessionId) return;
+          if (state !== 'GENERATING' && state !== 'CYCLING') return;
+          injectVariantsFromSource(filePath, sessionId, { ...opts, _orphanAttempt: attempt + 1 });
+        }, COMPLETED_SOURCE_FALLBACK_RETRY_MS);
+        return;
+      }
+      discardOrphanedSession(reason);
+    };
     fetch(url)
-      .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })
+      .then(r => { if (!r.ok) throw new Error('source read failed: ' + r.status); return r.text(); })
       .then(text => {
         if (sessionId !== currentSessionId) return;
         if (state !== 'GENERATING' && state !== 'CYCLING') return;
         if (sourceHasSessionWrapper(text, sessionId)) return;
-        if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) {
-          setTimeout(() => {
-            if (sessionId !== currentSessionId) return;
-            if (state !== 'GENERATING' && state !== 'CYCLING') return;
-            injectVariantsFromSource(filePath, sessionId, { ...opts, _orphanAttempt: attempt + 1 });
-          }, COMPLETED_SOURCE_FALLBACK_RETRY_MS);
-          return;
-        }
-        discardOrphanedSession('variant wrapper missing from source');
+        retryOrDiscard('variant wrapper missing from source');
       })
-      .catch(() => {});
+      .catch(err => {
+        console.warn('[impeccable] Orphan probe could not read source: ' + (err && err.message ? err.message : err));
+        retryOrDiscard('source unreadable while checking for the variant wrapper (' + (err && err.message ? err.message : 'fetch failed') + ')');
+      });
   }
 
   function completeSourceInjection(wrapper, sessionId, opts) {

--- a/skill/scripts/live-browser.js
+++ b/skill/scripts/live-browser.js
@@ -6216,6 +6216,48 @@
     return /\.[cm]?[jt]sx$/i.test(String(filePath || ''));
   }
 
+  function sourceHasSessionWrapper(text, sessionId) {
+    const src = String(text || '');
+    return src.indexOf('data-impeccable-variants="' + sessionId + '"') !== -1
+      || src.indexOf("data-impeccable-variants='" + sessionId + "'") !== -1
+      || src.indexOf('impeccable-variants-start ' + sessionId) !== -1;
+  }
+
+  /**
+   * Orphan probe for JSX targets (#439 + #454). An unmounted wrapper and a
+   * wrapper deleted from source look identical in the DOM, and only the second
+   * is an orphan, so the DOM alone cannot decide. #454 forbids parsing or
+   * injecting raw JSX; reading the file as plain text and matching the session
+   * marker honors that, because no DOM is ever built from what comes back.
+   * Marker present means the component is simply not mounted right now (a
+   * closed modal, another route) and the variant observer keeps waiting.
+   * Marker absent after the same retry budget the HTML path uses means the
+   * file was edited out from under the session, which no reload, HMR push, or
+   * server restart can repair, so the session self-discards and hands the
+   * surface back to the picker.
+   */
+  function probeJsxWrapperForOrphan(filePath, sessionId, opts) {
+    const attempt = opts._orphanAttempt || 0;
+    const url = 'http://localhost:' + PORT + '/source?token=' + TOKEN + '&path=' + encodeURIComponent(filePath);
+    fetch(url)
+      .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })
+      .then(text => {
+        if (sessionId !== currentSessionId) return;
+        if (state !== 'GENERATING' && state !== 'CYCLING') return;
+        if (sourceHasSessionWrapper(text, sessionId)) return;
+        if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) {
+          setTimeout(() => {
+            if (sessionId !== currentSessionId) return;
+            if (state !== 'GENERATING' && state !== 'CYCLING') return;
+            injectVariantsFromSource(filePath, sessionId, { ...opts, _orphanAttempt: attempt + 1 });
+          }, COMPLETED_SOURCE_FALLBACK_RETRY_MS);
+          return;
+        }
+        discardOrphanedSession('variant wrapper missing from source');
+      })
+      .catch(() => {});
+  }
+
   function completeSourceInjection(wrapper, sessionId, opts) {
     recoveryWaitingForAnchor = false;
     if (pendingVariantAnchorRetryObserver) {
@@ -6326,14 +6368,7 @@
         return;
       }
       if (opts.orphanDiscard && !liveWrapper && sessionId === currentSessionId) {
-        const attempt = opts._orphanAttempt || 0;
-        if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) {
-          setTimeout(() => {
-            if (sessionId !== currentSessionId) return;
-            if (state !== 'GENERATING' && state !== 'CYCLING') return;
-            injectVariantsFromSource(filePath, sessionId, { ...opts, _orphanAttempt: attempt + 1 });
-          }, COMPLETED_SOURCE_FALLBACK_RETRY_MS);
-        }
+        probeJsxWrapperForOrphan(filePath, sessionId, opts);
       }
       return;
     }

--- a/tests/live-browser-source.test.mjs
+++ b/tests/live-browser-source.test.mjs
@@ -622,7 +622,7 @@ describe('live-browser source contracts', () => {
     for (const forbidden of ['DOMParser', 'parseFromString', 'replaceChild', 'innerHTML']) {
       assert.ok(!probe.includes(forbidden), 'the orphan probe must not ' + forbidden + ' JSX source');
     }
-    assert.match(probe, /\.then\(r => \{ if \(!r\.ok\) throw new Error\(r\.status\); return r\.text\(\); \}\)/);
+    assert.match(probe, /\.then\(r => \{ if \(!r\.ok\) throw new Error\('source read failed: ' \+ r\.status\); return r\.text\(\); \}\)/);
     assert.match(
       probe,
       /if \(sourceHasSessionWrapper\(text, sessionId\)\) return;/,
@@ -630,8 +630,22 @@ describe('live-browser source contracts', () => {
     );
     assert.match(
       probe,
-      /if \(attempt < COMPLETED_SOURCE_FALLBACK_RETRIES\) \{[\s\S]*?\}\s*discardOrphanedSession\('variant wrapper missing from source'\);/,
+      /if \(attempt < COMPLETED_SOURCE_FALLBACK_RETRIES\) \{[\s\S]*?\}\s*discardOrphanedSession\(reason\);/,
       'the probe must exhaust the shared retry budget before discarding',
+    );
+    assert.match(
+      probe,
+      /retryOrDiscard\('variant wrapper missing from source'\)/,
+      'a read without the marker retries on the budget, then discards',
+    );
+    // A read that cannot answer (404 after a rename or delete, a transient
+    // fetch failure) must not strand the session: it shares the retry budget
+    // and ends in a discard that names the failure, never an empty catch.
+    assert.doesNotMatch(probe, /\.catch\(\(\) => \{\}\)/, 'the probe must not swallow source read failures');
+    assert.match(
+      probe,
+      /\.catch\(err => \{[\s\S]*?retryOrDiscard\('source unreadable while checking for the variant wrapper/,
+      'a failed source read retries on the same budget and then discards',
     );
 
     const matchStart = SOURCE.indexOf('function sourceHasSessionWrapper(');

--- a/tests/live-browser-source.test.mjs
+++ b/tests/live-browser-source.test.mjs
@@ -630,22 +630,32 @@ describe('live-browser source contracts', () => {
     );
     assert.match(
       probe,
-      /if \(attempt < COMPLETED_SOURCE_FALLBACK_RETRIES\) \{[\s\S]*?\}\s*discardOrphanedSession\(reason\);/,
+      /const onNoWrapper = \(reason\) => \{[\s\S]*?if \(attempt < COMPLETED_SOURCE_FALLBACK_RETRIES\) \{ retryLater\(\); return; \}\s*discardOrphanedSession\(reason\);/,
       'the probe must exhaust the shared retry budget before discarding',
     );
     assert.match(
       probe,
-      /retryOrDiscard\('variant wrapper missing from source'\)/,
+      /onNoWrapper\('variant wrapper missing from source'\)/,
       'a read without the marker retries on the budget, then discards',
     );
-    // A read that cannot answer (404 after a rename or delete, a transient
-    // fetch failure) must not strand the session: it shares the retry budget
-    // and ends in a discard that names the failure, never an empty catch.
+    // A read that cannot answer must not strand the session (no empty catch),
+    // and only evidence that the wrapper is gone may discard: a 404 (the file
+    // renamed or deleted) counts, a transient failure does not.
     assert.doesNotMatch(probe, /\.catch\(\(\) => \{\}\)/, 'the probe must not swallow source read failures');
     assert.match(
       probe,
-      /\.catch\(err => \{[\s\S]*?retryOrDiscard\('source unreadable while checking for the variant wrapper/,
-      'a failed source read retries on the same budget and then discards',
+      /source read failed: 404\$\/\.test\(detail\)\) \{\s*onNoWrapper\('source file missing \(404\)/,
+      'a 404 is evidence the file is gone: retry on the budget, then discard',
+    );
+    assert.match(
+      probe,
+      /const onUnreadable = \(detail\) => \{[\s\S]*?retryLater\(\); return; \}[\s\S]*?showToast\(/,
+      'a transient failure retries on the budget and then keeps the session, telling the user',
+    );
+    assert.doesNotMatch(
+      probe.slice(probe.indexOf('const onUnreadable')),
+      /discardOrphanedSession/,
+      'a transient failure must never discard a session',
     );
 
     const matchStart = SOURCE.indexOf('function sourceHasSessionWrapper(');

--- a/tests/live-browser-source.test.mjs
+++ b/tests/live-browser-source.test.mjs
@@ -555,7 +555,7 @@ describe('live-browser source contracts', () => {
 
   it('never DOMParser-injects JSX source (#454)', () => {
     const isJsxStart = SOURCE.indexOf('function isJsxSourceFile(');
-    const isJsxEnd = SOURCE.indexOf('function completeSourceInjection', isJsxStart);
+    const isJsxEnd = SOURCE.indexOf('function sourceHasSessionWrapper(', isJsxStart);
     const isJsxSourceFile = new Function(
       SOURCE.slice(isJsxStart, isJsxEnd) + '\nreturn isJsxSourceFile;',
     )();
@@ -580,7 +580,12 @@ describe('live-browser source contracts', () => {
     assert.doesNotMatch(
       jsxGate,
       /discardOrphanedSession/,
-      'a missing JSX wrap must wait for mount, not discard as an orphan',
+      'a missing JSX wrap must not discard from the DOM alone; only the source probe may decide',
+    );
+    assert.match(
+      jsxGate,
+      /if \(opts\.orphanDiscard && !liveWrapper && sessionId === currentSessionId\) \{\s*probeJsxWrapperForOrphan\(filePath, sessionId, opts\);/,
+      'a resumed CYCLING session with no mounted JSX wrapper must run the source orphan probe (#439)',
     );
     assert.match(
       jsxGate,
@@ -604,6 +609,40 @@ describe('live-browser source contracts', () => {
       /querySelectorAll\(tag \+ '\\.' \+ cls\.split/,
       'source fallback should not construct unsafe selectors from JSX-ish class strings',
     );
+  });
+
+  it('self-discards a JSX session whose wrapper left the source file (#439)', () => {
+    const probeStart = SOURCE.indexOf('function probeJsxWrapperForOrphan(');
+    assert.ok(probeStart !== -1, 'the JSX orphan probe must exist');
+    const probeEnd = SOURCE.indexOf('function completeSourceInjection', probeStart);
+    const probe = SOURCE.slice(probeStart, probeEnd);
+
+    // #454 stands: the probe reads the file as text and never builds a DOM
+    // from it, so raw JSX can never reach the page through this path.
+    for (const forbidden of ['DOMParser', 'parseFromString', 'replaceChild', 'innerHTML']) {
+      assert.ok(!probe.includes(forbidden), 'the orphan probe must not ' + forbidden + ' JSX source');
+    }
+    assert.match(probe, /\.then\(r => \{ if \(!r\.ok\) throw new Error\(r\.status\); return r\.text\(\); \}\)/);
+    assert.match(
+      probe,
+      /if \(sourceHasSessionWrapper\(text, sessionId\)\) return;/,
+      'a wrapper still in source is an unmounted component, not an orphan',
+    );
+    assert.match(
+      probe,
+      /if \(attempt < COMPLETED_SOURCE_FALLBACK_RETRIES\) \{[\s\S]*?\}\s*discardOrphanedSession\('variant wrapper missing from source'\);/,
+      'the probe must exhaust the shared retry budget before discarding',
+    );
+
+    const matchStart = SOURCE.indexOf('function sourceHasSessionWrapper(');
+    const sourceHasSessionWrapper = new Function(
+      SOURCE.slice(matchStart, probeStart) + '\nreturn sourceHasSessionWrapper;',
+    )();
+    assert.equal(sourceHasSessionWrapper('<div data-impeccable-variants="ab12cd34">', 'ab12cd34'), true);
+    assert.equal(sourceHasSessionWrapper("<div data-impeccable-variants='ab12cd34'>", 'ab12cd34'), true);
+    assert.equal(sourceHasSessionWrapper('{/* impeccable-variants-start ab12cd34 */}', 'ab12cd34'), true);
+    assert.equal(sourceHasSessionWrapper('<div data-impeccable-variants="99887766">', 'ab12cd34'), false);
+    assert.equal(sourceHasSessionWrapper('', 'ab12cd34'), false);
   });
 
   it('does not source-inject per variant_progress checkpoint (HMR owns mid-generation reconciliation)', () => {


### PR DESCRIPTION
## Cause

#694 stopped the no-HMR source fallback from fetching and DOMParser-injecting raw JSX, which had been painting `{expressions}` and comment markers into the page. The JSX gate it added in front of the fetch decides everything from the live DOM, and there an unmounted wrapper and a wrapper deleted from the file look identical, so both were treated as "wait for mount". The orphan branch counted down its retry budget and then fell out of the function with no terminal action:

```js
if (opts.orphanDiscard && !liveWrapper && sessionId === currentSessionId) {
  const attempt = opts._orphanAttempt || 0;
  if (attempt < COMPLETED_SOURCE_FALLBACK_RETRIES) {
    setTimeout(/* retry */, COMPLETED_SOURCE_FALLBACK_RETRY_MS);
  }
  // retries exhausted: nothing happens
}
```

A resumed CYCLING session whose region had been edited out of source therefore never reached `discardOrphanedSession`, the durable snapshot never entered the `discarded` phase, and the picker stayed frozen. That is the #439 regression `tests/live-e2e.test.mjs` pins as "self-discards an orphaned session when its wrapper is edited out of source" (fixture `vite8-react-plain`), which is outside the `core` scenario group the PR smoke jobs run, so only the nightly full sweep saw it.

## Fix

Restore the decision without restoring the parse. `probeJsxWrapperForOrphan` reads the file from `/source` as plain text and matches the session marker with `indexOf`; no DOM is built from what comes back, so #694's rule that raw JSX never reaches the page still holds. Marker present means the component is simply not mounted right now (a closed modal, another route) and the variant observer keeps waiting, which is #694's other intent. Marker absent after the same retry budget the HTML path uses means the file was edited out from under the session, which no reload, HMR push, or server restart can repair, so the session self-discards and hands the surface back to the picker.

The #695 HMR-ownership guards on the accept and discard cleanup paths are untouched.

`tests/live-browser-source.test.mjs` gains a case for the probe (never `DOMParser` / `parseFromString` / `replaceChild` / `innerHTML`; discards only after the marker check fails and the retries run out) plus unit coverage of the marker matcher. The existing #454 case keeps asserting the gate itself never discards from the DOM alone, and now also asserts that it delegates to the probe.

## Verification

- `bun run test:live-e2e` on this branch (main's JS live server), clean machine: **36 tests, 35 pass, 0 fail, 1 skipped** (manual-scenario filter). Baseline on `main` was 34 pass / 1 fail. An earlier sweep run concurrently with a `bun run build` showed three `waitForCycling` timeouts, all load flakes; the isolated rerun is green.
- `bun run test:live` (page-script unit tests): 889 tests, 887 pass, 0 fail, 2 skipped.
- `bun run build`: green, including the prose and skill-prose validators.
- Rust engine: the changed `skill/scripts/live-browser.js` copied over a worktree of `rust-swap` (page JS there is byte-identical to main's), `cargo build --release -p impeccable`, then `IMPECCABLE_E2E_ONLY=vite8-react-plain bun run test:live-e2e` against that binary: **4 tests, 4 pass, 0 fail**, including the orphan scenario. Nothing was committed to `rust-swap`; the fix reaches it through the next merge from `main`.

Fixes #715

AI assistance: prepared by Claude Code under pbakaus's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vau2X53xGTjjTCXWMVBoNY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live-session lifecycle and source-fetch discard paths for JSX; behavior is constrained by text-only reads and shared retry budgets, but wrong orphan detection could discard active sessions or leave stale UI.
> 
> **Overview**
> Fixes a regression where **resumed CYCLING JSX live sessions** whose variant wrapper was removed from source never called **`discardOrphanedSession`**, leaving the picker stuck after the no-DOMParser JSX gate (#694) stopped inferring orphans from the live DOM alone.
> 
> Adds **`sourceHasSessionWrapper`** and **`probeJsxWrapperForOrphan`**, which fetch the file from **`/source` as plain text** and look for the session marker—no **`DOMParser`** or DOM injection (#454). If the marker is still in source, the session keeps waiting for mount (modal/route). After the same retry budget as HTML fallback, a missing marker or **404** triggers self-discard; transient read failures retry, then keep the session with a toast.
> 
> The JSX branch in **`injectVariantsFromSource`** now delegates **`orphanDiscard`** when there is no mounted wrapper to this probe instead of retrying with no terminal action. **`tests/live-browser-source.test.mjs`** extends the #454 contract and adds probe/matcher coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bba9b919e5500fbe46b3875831c5de7b95dde8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->