### PR TITLE
ci: make engine-release-ready a hard gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,14 +219,12 @@ jobs:
   # release/merge that depends on them. The launcher, npm shim, and
   # `impeccable install` all dead-end without those assets.
   #
-  # continue-on-error is a release-time toggle: until the first engine release is
-  # published, the assets cannot exist and this job would block
-  # every PR. It emits a loud ::warning instead. Once v<ENGINE_VERSION> is live,
-  # flip `continue-on-error` to false so a MIS-ORDERED release (skill/CLI ahead of
-  # the engine) fails CI. release.mjs already hard-fails `release:skill`/`release:cli`.
+  # A hard gate since engine-v0.1.0 shipped: the assets for the pinned
+  # ENGINE_VERSION must exist before a skill/CLI release or a merge that bumps the
+  # pin, or the launcher, the npm shim and `impeccable install` dead-end.
+  # release.mjs hard-fails `release:skill`/`release:cli` on the same check.
   engine-release-ready:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -237,14 +235,12 @@ jobs:
           node-version: 24
 
       - name: Check engine release assets for pinned ENGINE_VERSION
-        id: check
-        continue-on-error: true
         run: node scripts/check-engine-release.mjs
 
       - name: Annotate missing engine release
-        if: steps.check.outcome != 'success'
+        if: failure()
         run: |
-          echo "::warning title=Engine release not ready::The engine release for v$(cat ENGINE_VERSION) is not fully published (engine-v$(cat ENGINE_VERSION) release) and/or the @impeccable/cli-<os>-<arch> npm platform packages. Releasing the skill/CLI (or merging) now would dead-end the launcher, the npm shim, and impeccable install. Expected until the first engine release exists; after that, publish the engine + platform packages and flip this job's continue-on-error to false so a mis-ordered release fails CI."
+          echo "::error title=Engine release not ready::The engine release for v$(cat ENGINE_VERSION) is not fully published (engine-v$(cat ENGINE_VERSION) release assets and/or the @impeccable/cli-<os>-<arch> npm platform packages). Publish the engine (bun run release:engine) and the platform packages (bun run release:platform-packages) before bumping ENGINE_VERSION on main or releasing the skill/CLI."
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,10 +235,12 @@ jobs:
           node-version: 24
 
       - name: Check engine release assets for pinned ENGINE_VERSION
+        id: check
         run: node scripts/check-engine-release.mjs
 
       - name: Annotate missing engine release
-        if: failure()
+        # Only when the check itself failed, so a checkout or setup failure keeps its own error.
+        if: failure() && steps.check.outcome == 'failure'
         run: |
           echo "::error title=Engine release not ready::The engine release for v$(cat ENGINE_VERSION) is not fully published (engine-v$(cat ENGINE_VERSION) release assets and/or the @impeccable/cli-<os>-<arch> npm platform packages). Publish the engine (bun run release:engine) and the platform packages (bun run release:platform-packages) before bumping ENGINE_VERSION on main or releasing the skill/CLI."
 


### PR DESCRIPTION
The engine release (engine-v0.1.0) and the five @impeccable/cli-<os>-<arch> npm platform packages are published, so the release-order check no longer needs its soft-fail. The job now fails CI when the assets for the pinned ENGINE_VERSION are missing, which is the behavior the workflow comment deferred until the first engine release existed. The missing-release annotation becomes an error that names both release commands.

AI assistance: prepared by Claude Code under pbakaus's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vau2X53xGTjjTCXWMVBoNY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release-order enforcement with no runtime or auth changes; the main effect is stricter merge gates when `ENGINE_VERSION` is ahead of published assets.
> 
> **Overview**
> **The `engine-release-ready` CI job is now a blocking check** instead of a soft-fail that only warned when pinned `ENGINE_VERSION` assets were missing.
> 
> `continue-on-error` was removed from the job and from the `check-engine-release.mjs` step, so PRs and merges fail if the engine GitHub release binaries (plus `.sha256` sidecars) or the five `@impeccable/cli-<os>-<arch>` npm packages are not fully published. Workflow comments were updated to state this is intentional now that **engine-v0.1.0** is live.
> 
> The follow-up annotation step only runs when that check step fails (`failure() && steps.check.outcome == 'failure'`), avoiding a misleading engine message on checkout/setup failures. The annotation was upgraded from `::warning` to `::error` and now points maintainers at `bun run release:engine` and `bun run release:platform-packages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0c5e0dcf80d07d63c8ccce74e737d989f89522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->