### PR TITLE
Release: skill 4.2.0, CLI 4.0.0, extension 1.4.0

### DIFF
--- a/.agent/skills/impeccable/SKILL.md
+++ b/.agent/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 license: Apache 2.0
 allowed-tools:
   - Bash(npx impeccable *)

--- a/.agents/skills/impeccable/SKILL.md
+++ b/.agents/skills/impeccable/SKILL.md
@@ -2,7 +2,7 @@
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
 metadata:
-  version: 4.1.3
+  version: 4.2.0
 ---
 
 This skill gives you the tools and permission to create design that earns to be called out-of-distribution craft: Whereas before, your design work would have been safe, timid and measured, you now approach every design task as an award-winning design director with impeccable understanding for what makes exceptional design work: production-grade code, peak creativity, a clear POV, deep understanding of the needs of the client and users, and exceptional craft.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "impeccable",
       "description": "Design fluency for frontend development. 1 skill with 23 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
-      "version": "4.1.3",
+      "version": "4.2.0",
       "author": {
         "name": "Paul Bakaus",
         "email": "paul@paulbakaus.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "impeccable",
   "description": "Design fluency for frontend development. 1 skill with 23 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "author": {
     "name": "Paul Bakaus",
     "email": "paul@paulbakaus.com"

--- a/.claude/skills/impeccable/SKILL.md
+++ b/.claude/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.cursor/skills/impeccable/SKILL.md
+++ b/.cursor/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 license: Apache 2.0
 ---
 

--- a/.gemini/skills/impeccable/SKILL.md
+++ b/.gemini/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 ---
 
 This skill gives you the tools and permission to create design that earns to be called out-of-distribution craft: Whereas before, your design work would have been safe, timid and measured, you now approach every design task as an award-winning design director with impeccable understanding for what makes exceptional design work: production-grade code, peak creativity, a clear POV, deep understanding of the needs of the client and users, and exceptional craft.

--- a/.github/skills/impeccable/SKILL.md
+++ b/.github/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.grok/skills/impeccable/SKILL.md
+++ b/.grok/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.hermes/skills/impeccable/SKILL.md
+++ b/.hermes/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 license: Apache 2.0
 ---
 

--- a/.kiro/skills/impeccable/SKILL.md
+++ b/.kiro/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 license: Apache 2.0
 ---
 

--- a/.opencode/skills/impeccable/SKILL.md
+++ b/.opencode/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.pi/skills/impeccable/SKILL.md
+++ b/.pi/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 license: Apache 2.0
 allowed-tools:
   - Bash(npx impeccable *)

--- a/.qoder/skills/impeccable/SKILL.md
+++ b/.qoder/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.rovodev/skills/impeccable/SKILL.md
+++ b/.rovodev/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.trae-cn/skills/impeccable/SKILL.md
+++ b/.trae-cn/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.trae/skills/impeccable/SKILL.md
+++ b/.trae/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0

--- a/.veto/skills/impeccable/SKILL.md
+++ b/.veto/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 license: Apache 2.0
 ---
 

--- a/.vibe/skills/impeccable/SKILL.md
+++ b/.vibe/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 license: Apache 2.0
 allowed-tools:

--- a/extension/STORE_LISTING.md
+++ b/extension/STORE_LISTING.md
@@ -1,5 +1,10 @@
 # Chrome Web Store Listing
 
+Copy for the Developer Dashboard. Every field below maps to one dashboard
+field; paste them as they are. Keep this file in step with the manifest
+(`extension/manifest.json`) and the rule registry (the count comes from
+`extension/detector/antipatterns.json` after `bun run build:extension`).
+
 ## Name
 Impeccable
 
@@ -8,7 +13,7 @@ Detect AI slop and design anti-patterns in any web page. Open DevTools and see w
 
 ## Detailed description
 
-Impeccable detects 41 common UI anti-patterns directly in your browser. Open DevTools on any page and overlays instantly highlight issues, from AI-generated design tells to accessibility and quality problems.
+Impeccable detects 61 common UI anti-patterns directly in your browser. Open the Impeccable panel in DevTools on any page and overlays highlight issues, from AI-generated design tells to accessibility and quality problems.
 
 WHAT IT DETECTS
 
@@ -17,44 +22,52 @@ AI slop (design tells that scream "AI made this"):
 - Purple/violet AI color palettes
 - Gradient text on headings
 - Side-tab and rounded-border accent stripes
-- Nested cards, monotonous spacing, icon-tile stacks
-- Bounce and elastic easing, hover image zoom
-- Dark mode with glowing accents
-- Overused or single-family fonts, flat type hierarchy
-- Oversized H1s, extreme negative letter-spacing, italic-serif heroes
-- Uppercase eyebrows, repeated kickers, numbered section markers
-- Em-dash overuse, marketing buzzwords, "not just X, it's Y" cadence
-- Thin borders with wide drop shadows, repeating-stripe backgrounds
+- Nested cards, monotonous spacing, icon-tile stacks, edge-flush cards
+- Bounce and elastic easing, hover image zoom, marquees, pulsing dots, blinking cursors
+- Dark mode with glowing accents, radial halos and spotlight glows
+- Overused fonts, flat type hierarchy, italic-serif heroes
+- Oversized H1s, extreme negative letter-spacing
+- Uppercase eyebrow chips, kickers above headings, numbered section markers
+- Em-dash overuse, marketing buzzwords, aphoristic cadence, "theater" phrases
+- Thin borders with wide drop shadows, repeating-stripe and grid backgrounds
+- Shape-assembled illustrations, organic clip paths, buried raster images
 
 Quality issues (general design and accessibility):
-- Low contrast text (WCAG AA), gray text on colored backgrounds
-- Cramped padding, tight line height
+- Low contrast text (WCAG AA), gray text on colored backgrounds, occluded text
+- Cramped padding, tight line height, uneven heading rhythm
 - Skipped heading levels
-- Line length too long, text running to the viewport edge
-- Tiny body text, justified text, all-caps body copy, wide letter-spacing
+- Line length too long, text running to the viewport edge, columns overflowing the first viewport
+- Tiny body text, undersized UI text, justified text, all-caps body copy, wide letter-spacing
 - Layout-property animations, clipped overflow containers, text overflow
-- Broken images
+- Broken images, script errors, content hidden at rest, repeated container text
+- Drift from a project's own design system (fonts, colors, radii, type sizes)
 
 HOW IT WORKS
 
 1. Install the extension
-2. Open DevTools on any page (Cmd+Opt+I / F12)
-3. Overlays appear automatically, highlighting issues
-4. Click the "Impeccable" panel tab for a structured list of all findings
+2. Open DevTools on any page (Cmd+Opt+I / F12) and click the "Impeccable" panel tab
+3. The page is scanned and overlays highlight every finding
+4. The panel lists the findings, grouped as AI tells and quality issues
 5. Click any finding to jump to the element in the Elements panel
 
 FEATURES
 
-- Auto-scans when DevTools opens, no manual step needed
+- Scans when you open the panel; opt in to scanning the moment DevTools opens
 - Grouped findings: AI tells vs. quality issues
 - Click-to-inspect: jump from a finding to the element
-- Toggle overlays on/off from the panel or toolbar popup
+- Toggle overlays on/off from the panel or the toolbar popup
 - Per-rule settings: disable detections you don't care about
 - Re-scans on navigation, including SPA route changes
-- Works on any website
+- Works on any website, including pages with a strict Content Security Policy
 - Runs 100% locally, no data sent anywhere
 
+The same 61 rules power the Impeccable CLI and the live design mode, built from one open-source rule engine.
+
 Open source at https://github.com/pbakaus/impeccable
+
+## What's new (version notes for 1.4.0)
+
+The detector now runs as WebAssembly in an extension offscreen document. The page is snapshotted and the rules evaluate that snapshot, so a site's Content Security Policy no longer decides whether the detector runs. Same rules as the Impeccable CLI and live mode, built from the same source, now 61 of them. New "offscreen" permission for exactly that; nothing about what the extension can see has changed.
 
 ## Category
 Developer Tools
@@ -67,3 +80,18 @@ https://impeccable.style/privacy
 
 ## Single purpose description
 Detects and highlights UI anti-patterns (AI-generated design tells and general quality issues) on any web page.
+
+## Permission justifications (Privacy practices tab)
+
+- **activeTab**: Scans the page the user is looking at when they open the panel or press Scan in the popup; nothing runs on tabs the user has not asked about.
+- **scripting**: Injects the content script that takes the page snapshot and draws the finding overlays on the current tab.
+- **storage**: Saves the user's own settings (disabled rules, overlay visibility, the auto-scan preference) in Chrome sync storage. No page data is stored.
+- **webNavigation**: Re-scans after in-page navigation in single-page apps, where no full page load happens.
+- **offscreen**: Runs the WebAssembly rule engine over the page snapshot in an offscreen document, because page Content Security Policies block WebAssembly in the content-script and page worlds. The document is created for a scan and closed afterward.
+- **Host permission (all sites)**: The user can scan any site they visit; the scan runs only on the active tab when the user asks for it.
+
+## Remote code
+No. The rule engine (WebAssembly) and all scripts ship inside the package. Nothing is fetched or evaluated from the network.
+
+## Data usage
+The extension collects no user data. Scans run locally; no page content, findings, or identifiers leave the browser. Certify: not being sold to third parties, not used for purposes unrelated to the single purpose, not used for creditworthiness or lending.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Impeccable",
   "description": "Detect common UI anti-patterns in any web page",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "permissions": [
     "activeTab",
     "scripting",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impeccable",
-  "version": "3.6.1",
+  "version": "4.0.0",
   "author": "Paul Bakaus",
   "description": "Design skills, commands, and anti-pattern detection for AI coding agents",
   "keywords": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "impeccable",
   "description": "Design fluency for frontend development. 1 skill with 23 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "author": {
     "name": "Paul Bakaus",
     "email": "paul@paulbakaus.com"

--- a/plugin/.grok-plugin/plugin.json
+++ b/plugin/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "impeccable",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Design fluency for frontend development. 1 skill with 23 commands (/impeccable polish, /impeccable audit, /impeccable critique, etc.) and curated anti-pattern detection.",
   "author": {
     "name": "Paul Bakaus",

--- a/plugin/skills/impeccable/SKILL.md
+++ b/plugin/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 4.1.3
+version: 4.2.0
 user-invocable: true
 argument-hint: "[shape · audit|critique · animate|bolder|colorize|delight|layout|overdrive|quieter|typeset · adapt|clarify|distill · harden|onboard|optimize|polish · init|document|extract|live] [target]"
 license: Apache 2.0


### PR DESCRIPTION
Version bumps for the Rust engine release, with the plugin subtree and provider directories regenerated at the new versions (`bun run build:release`, tree clean afterward).

| Component | From | To | Why |
|---|---|---|---|
| Skill (`.claude-plugin/plugin.json`, marketplace) | 4.1.3 | 4.2.0 | New runtime (launcher plus engine binary, no Node), same commands and behavior |
| CLI (`package.json`) | 3.6.1 | 4.0.0 | The package is a shim now and its JavaScript `detect` export is gone, a breaking change for anyone importing it |
| Extension (`extension/manifest.json`) | 1.3.3 | 1.4.0 | wasm core in an offscreen document; new `offscreen` permission |

The matching changelog entries (v4.2.0, CLI v4.0.0, Extension v1.4.0) are in the impeccable-site PR; `bun run release:<component>` reads them from there. `bun run build:extension` produces `dist/extension.zip` with the `offscreen` permission for the Web Store resubmission.

AI assistance: prepared by Claude Code under pbakaus's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vau2X53xGTjjTCXWMVBoNY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are version strings and store listing copy only; no runtime or detector logic in this diff.
> 
> **Overview**
> **Coordinated release** that aligns version metadata across the monorepo after the Rust engine work landed elsewhere: **skill/plugin `4.2.0`** (every provider `SKILL.md` copy plus `.claude-plugin`, `plugin/`, and marketplace manifests), **npm package `4.0.0`** in root `package.json`, and **Chrome extension `1.4.0`** in `extension/manifest.json`.
> 
> The only substantive non-version edit is **`extension/STORE_LISTING.md`**, refreshed for Web Store resubmission: anti-pattern count **41 → 61**, updated DevTools/scan flow (panel-first scan, optional auto-scan, **CSP-safe** messaging), expanded rule bullets, **1.4.0 release notes** (WASM detector in an offscreen document), and new dashboard sections for **permission justifications**, **remote code**, and **data usage**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be92da1f8d3507157038b91225f700ce8f9004b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->