### PR TITLE
Oracle fixtures: move the astro pins past the open advisories

### DIFF
--- a/tests/oracle/workspaces/live-astro/package.json
+++ b/tests/oracle/workspaces/live-astro/package.json
@@ -1,1 +1,1 @@
-{ "name": "oracle-live-astro", "private": true, "type": "module", "dependencies": { "astro": "^5.0.0" } }
+{ "name": "oracle-live-astro", "private": true, "type": "module", "dependencies": { "astro": "^7.1.0" } }

--- a/tests/oracle/workspaces/live-workspaces/apps/admin/package.json
+++ b/tests/oracle/workspaces/live-workspaces/apps/admin/package.json
@@ -1,1 +1,1 @@
-{ "name": "admin", "private": true, "type": "module", "dependencies": { "astro": "^5.0.0" } }
+{ "name": "admin", "private": true, "type": "module", "dependencies": { "astro": "^7.1.0" } }


### PR DESCRIPTION
All 16 open Dependabot alerts on `main` are the same `astro` pin in two oracle workspace fixtures. Both move from `^5.0.0` to `^7.1.0`:

- `tests/oracle/workspaces/live-astro/package.json`
- `tests/oracle/workspaces/live-workspaces/apps/admin/package.json`

`^7.1.0` satisfies every advisory's first-patched version, so all 16 alerts close (8 advisories, each reported once per manifest):

| GHSA | Severity | First patched |
|---|---|---|
| GHSA-4g3v-8h47-v7g6 | medium | 7.1.0 |
| GHSA-f48w-9m4c-m7f5 | medium | 7.0.6 |
| GHSA-7pw4-f3q4-r2p2 | low | 7.0.4 |
| GHSA-jrpj-wcv7-9fh9 | medium | 6.4.6 |
| GHSA-2pvr-wf23-7pc7 | high | 6.4.6 |
| GHSA-8hv8-536x-4wqp | high | 6.3.3 |
| GHSA-xr5h-phrj-8vxv | low | 6.1.10 |
| GHSA-j687-52p2-xcff | medium | 6.1.6 |

## Why this is safe

These are test fixtures, never installed by users. The oracle stages each workspace as a plain file tree and runs no package install, so no `astro` release is ever fetched from these manifests. The engine's astro detection (`crates/live/src/inject/astro.rs`) keys on `has_any_dependency(cwd, &["astro"])`, presence only, with no version comparison. No golden echoes the version or the package.json text of either workspace, and neither file falls inside the cases' snapshot globs (`.impeccable/**`, `src/**`).

The live-e2e astro fixture (`tests/framework-fixtures/astro-vite7`) is a separate tree that already pins `^7.1.0`, so it is untouched and the suite is not owed here: `scripts/test-suites.mjs` triggers live-e2e on `tests/framework-fixtures` and `tests/live-e2e/`, neither of which this diff touches.

## Verification

- `cargo build --release -p impeccable`, then `IMPECCABLE_BIN=... node --test tests/oracle.test.mjs`: passes with zero unreviewed differences, so no golden moved and `DELTAS.md` gains no entry.
- `bun run build`: clean, including the count, version, manifest, and prose validators.
- `bun run test` with `IMPECCABLE_BIN` set: 186 unit and fixture tests plus the plugin loader E2E, all green.

AI assistance: prepared by Claude Code under pbakaus's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vau2X53xGTjjTCXWMVBoNY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only manifest version bumps with no production or install-path impact.
> 
> **Overview**
> Bumps the `astro` dependency from `^5.0.0` to `^7.1.0` in two oracle test workspace manifests: `live-astro` and `live-workspaces/apps/admin`. The goal is to clear open Dependabot advisories on those pins without changing runtime behavior.
> 
> These files are oracle fixtures only (not user installs); engine astro handling still depends on having an `astro` dependency, not on the pinned version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7269e5b94ff842f6ac2431fc06e7e8d375c02ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->