### PR TITLE
extension: the mark is ink on paper, like the site header

### DIFF
--- a/extension/shared/kinpaku.css
+++ b/extension/shared/kinpaku.css
@@ -126,8 +126,9 @@ body {
 }
 
 /* ============================================================
-   The mark. The one place gold fills a shape: a carved ink tile
-   split by the slash, the same glyph the toolbar icon carries.
+   The mark. The site's header sets the glyph in ink straight on
+   the paper, no tile behind it and no gold: the same two-shape
+   slash the toolbar icon carries, at the header's proportion.
    ============================================================ */
 .ks-mark {
   display: grid;
@@ -135,15 +136,13 @@ body {
   flex: none;
   width: 22px;
   height: 22px;
-  border-radius: var(--ks-radius-sm);
-  background: var(--ks-ink);
-  color: var(--ks-kinpaku);
+  color: var(--ks-ink);
 }
 
 .ks-mark svg {
   display: block;
-  width: 15px;
-  height: 15px;
+  width: 20px;
+  height: 20px;
 }
 
 .ks-wordmark {


### PR DESCRIPTION
Follow-up to #729. The popup, panel and sidebar header carried the glyph as gold on an ink tile, a treatment the brand uses nowhere; the site header sets the same two-shape slash in ink straight on the paper. The extension's mark now does the same, at the header's proportion. CSS only.

AI assistance: prepared by Claude Code under pbakaus's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vau2X53xGTjjTCXWMVBoNY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic CSS in shared extension styling with no logic, auth, or data impact.
> 
> **Overview**
> **Aligns the extension header glyph with impeccable.style:** the slash mark in popup, DevTools panel, and sidebar headers no longer sits on an ink tile with gold fill.
> 
> **`.ks-mark` is now ink-on-paper only** — drops the rounded ink background and `--ks-kinpaku` glyph color, sets `color: var(--ks-ink)`, and scales the SVG from 15px to 20px so it matches the site header proportion. Comment copy is updated to describe that treatment. CSS-only; no markup or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3098e796981019fd753c26d5bdcd94f4856cc58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->