### PR TITLE
CLI: --version reports the npm package version

### DIFF
--- a/cli/bin/cli.js
+++ b/cli/bin/cli.js
@@ -71,7 +71,7 @@ async function locate() {
 // `--version` / `-v` is answered by the shim itself: the number users mean
 // is this npm package's version, not the engine's (docs/CLI-CONTRACT.md).
 const argv = process.argv.slice(2);
-if (argv.length === 1 && (argv[0] === '--version' || argv[0] === '-v')) {
+if (argv[0] === '--version' || argv[0] === '-v') {
   process.stdout.write(`${pkg.version}\n`);
   process.exit(0);
 }

--- a/cli/bin/cli.js
+++ b/cli/bin/cli.js
@@ -68,6 +68,14 @@ async function locate() {
   return download().catch((err) => { process.stderr.write(`impeccable: ${err.message}\n`); return null; });
 }
 
+// `--version` / `-v` is answered by the shim itself: the number users mean
+// is this npm package's version, not the engine's (docs/CLI-CONTRACT.md).
+const argv = process.argv.slice(2);
+if (argv.length === 1 && (argv[0] === '--version' || argv[0] === '-v')) {
+  process.stdout.write(`${pkg.version}\n`);
+  process.exit(0);
+}
+
 const bin = await locate();
 if (!bin) {
   process.stderr.write(
@@ -76,7 +84,7 @@ if (!bin) {
   );
   process.exit(127);
 }
-const result = spawnSync(bin, process.argv.slice(2), {
+const result = spawnSync(bin, argv, {
   stdio: 'inherit',
   env: { IMPECCABLE_SELF: 'npx impeccable', ...process.env },
 });

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -108,7 +108,7 @@ fn run(args: &[String], io: &mut Io) -> i32 {
 
 /// The npm `impeccable` package version `cli.js --version` prints (its
 /// `package.json`), tracked separately from the crate version.
-pub const CLI_VERSION: &str = "3.6.0";
+pub const CLI_VERSION: &str = "4.0.0";
 
 /// The engines wired into `impeccable detect`: the static HTML engine
 /// (crates/html). The browser engine (crates/browser) plugs in here once it

--- a/tests/cli-shim.test.mjs
+++ b/tests/cli-shim.test.mjs
@@ -176,8 +176,9 @@ describe('npm shim download verification', { skip: process.platform === 'win32' 
 
   it('answers --version and -v from its own package.json without touching a binary', async () => {
     const expected = JSON.parse(fs.readFileSync(PKG_PATH, 'utf-8')).version;
-    for (const flag of ['--version', '-v']) {
-      const res = await runShim([flag]);
+    for (const args of [['--version'], ['-v'], ['--version', 'extra']]) {
+      const flag = args.join(' ');
+      const res = await runShim(args);
       assert.equal(res.status, 0, `${flag} exits 0`);
       assert.equal(res.stdout, `${expected}\n`);
       assert.deepEqual(requests, [], 'no download was attempted');

--- a/tests/cli-shim.test.mjs
+++ b/tests/cli-shim.test.mjs
@@ -174,6 +174,16 @@ describe('npm shim download verification', { skip: process.platform === 'win32' 
     assert.deepEqual(cacheEntries(res.home), []);
   });
 
+  it('answers --version and -v from its own package.json without touching a binary', async () => {
+    const expected = JSON.parse(fs.readFileSync(PKG_PATH, 'utf-8')).version;
+    for (const flag of ['--version', '-v']) {
+      const res = await runShim([flag]);
+      assert.equal(res.status, 0, `${flag} exits 0`);
+      assert.equal(res.stdout, `${expected}\n`);
+      assert.deepEqual(requests, [], 'no download was attempted');
+    }
+  });
+
   it('prefers IMPECCABLE_BIN and never downloads', async () => {
     sidecar = { status: 404, body: '' };
     const { dir, shim } = stageShim();

--- a/tests/oracle/DELTAS.md
+++ b/tests/oracle/DELTAS.md
@@ -155,3 +155,12 @@ file, the file set, or the printed lines differs from the JS.
 
 - `pin-opencode-project`, `pin-opencode-user-scope`, `pin-opencode-skips-foreign-command`, `pin-opencode-then-unpin`, `pin-opencode-unpin-skips-foreign`.
 
+
+## Recorded 2026-09-04: `--version` follows the npm package to 4.0.0
+
+The npm shim answers `--version` / `-v` itself from its own `package.json`
+(docs/CLI-CONTRACT.md), so the number users see tracks the package they
+installed. The binary's `CLI_VERSION` moves from `3.6.0` to `4.0.0` with the
+CLI 4.0.0 release; it is what the binary prints when run directly.
+
+- `cli-version`.

--- a/tests/oracle/golden/cli-version.json
+++ b/tests/oracle/golden/cli-version.json
@@ -1,5 +1,5 @@
 {
-  "stdout": "3.6.0\n",
+  "stdout": "4.0.0\n",
   "stderr": "",
   "exit": 0,
   "signal": null,


### PR DESCRIPTION
`npx impeccable@4.0.0 --version` prints 3.6.0: the shim handed every argument to the engine, whose baked-in `CLI_VERSION` still said 3.6.0. The shim now answers `--version` and `-v` from its own package.json, as docs/CLI-CONTRACT.md specifies, without locating or downloading a binary; `tests/cli-shim.test.mjs` covers both flags. The engine's `CLI_VERSION` moves to 4.0.0 for the next engine release, with the `cli-version` golden re-recorded and the delta recorded in tests/oracle/DELTAS.md.

Ships to users as CLI 4.0.1 (a separate release bump).

AI assistance: prepared by Claude Code under pbakaus's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vau2X53xGTjjTCXWMVBoNY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to version reporting and early exit in the shim; no auth, data, or core scan logic is touched.
> 
> **Overview**
> **`npx impeccable --version` now prints the installed npm package version** instead of delegating to the engine binary (which previously reported a stale baked-in `CLI_VERSION`).
> 
> The Node shim handles **`--version` and `-v` before** `locate()` / download / `spawnSync`, printing `package.json`’s `version` and exiting 0 per **`docs/CLI-CONTRACT.md`**. Other args still pass through via a shared `argv` slice.
> 
> The Rust binary’s **`CLI_VERSION` is bumped to `4.0.0`** for direct invocations; oracle golden **`cli-version`** and **`DELTAS.md`** are updated. **`tests/cli-shim.test.mjs`** asserts both flags, including that no download runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2713bff65499556650192bf990da4ac9fcc69511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->