### PR TITLE
Release: CLI 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "impeccable",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Paul Bakaus",
   "description": "Design skills, commands, and anti-pattern detection for AI coding agents",
   "keywords": [


### PR DESCRIPTION
Version bump for the npm shim so #731 ships: `npx impeccable --version` reports the package version instead of the engine's baked-in 3.6.0. The matching changelog entry (CLI v4.0.1) is in the impeccable-site PR.

AI assistance: prepared by Claude Code under pbakaus's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vau2X53xGTjjTCXWMVBoNY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime logic modified in this diff.
> 
> **Overview**
> **Patch release** for the `impeccable` npm shim: `package.json` version moves from **4.0.0** to **4.0.1** so published installs align with the intended CLI release.
> 
> This ships the shim behavior where `npx impeccable --version` prints the **npm package version** (from `package.json`) instead of forwarding to the engine’s embedded version. No other code changes are in this PR; release notes live in the impeccable-site changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7206e41a6a0d24fb3ae45a408684b32432860f5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->