### PR TITLE
Docs: clarify live mode development scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,12 @@ npx impeccable install
 npx impeccable update
 ```
 
+## Live mode and production sites
+
+Live mode edits a local checkout through a development server or local static HTML. Injecting its localhost HTTP helper into a deployed production site, including an HTTPS site, is not supported. Do not disable browser security or weaken production CSP to make it work.
+
+For production inspection, use `npx impeccable detect https://example.com` or the browser extension. These inspect the rendered page; they do not provide live variant editing or write changes back to your source.
+
 ## CLI
 
 Impeccable includes a standalone CLI for detecting anti-patterns without an AI harness. `npx impeccable` is a small shim that runs the same engine binary the skill uses (installed as a platform-specific optional dependency, or fetched once into `~/.impeccable/bin/`); Node is needed only for `npx` itself, and you can also download the binary directly and put it on your PATH.

--- a/skill/reference/live-setup.md
+++ b/skill/reference/live-setup.md
@@ -42,6 +42,8 @@ On every boot the project is scanned for HTML files under common page roots (`pu
 
 ## CSP detection (first-time only)
 
+Keep all allowances below development-only, including manual middleware and meta-tag edits. Do not change a deployed production site's CSP to load the localhost helper; see [live.md](live.md) for production inspection alternatives.
+
 If `config.cspChecked === true`, skip this whole section; the user was already asked once.
 
 ```bash

--- a/skill/reference/live.md
+++ b/skill/reference/live.md
@@ -4,6 +4,8 @@ Interactive live variant mode: select elements in the browser, pick a design act
 
 A running dev server with HMR (Vite, Next.js, Bun, etc.), OR a static HTML file open in the browser. If the dev server's default port is busy, the app is very likely ALREADY running; probe the default URL before spawning a second server.
 
+Live editing requires a local checkout; injection into deployed production sites (including HTTPS) is unsupported. For production inspection, use `{{scripts_path}}/impeccable detect <url>` or the browser extension, not the live helper. Do not disable browser security or weaken production CSP to enable live mode.
+
 <codex>
 Codex: run live helper commands, the app dev server, and any dependency-installing setup with `sandbox_permissions: "require_escalated"` from the start; live mode depends on localhost and package-manager network access that the sandbox blocks.
 </codex>


### PR DESCRIPTION
## Summary
- Clarify that live editing uses a local checkout and development server or local static HTML; production-site injection is unsupported.
- Route production inspection to URL detection or the browser extension, without promising live variant editing or source writes.
- Keep manual CSP allowances development-only; do not weaken production CSP or browser security.

Related to #539. The UTF-8 response fix is already present in the Rust engine. This PR documents the remaining support boundary; it does not add TLS or change runtime behavior. Keep the issue open for a separately approved closing reply.

## Validation
- Source-first build passed, including repository prose/plugin validators.
- Full default Bun/Node suite passed with engine 0.1.3, including oracle, framework, and real plugin-loader checks.
- Existing Rust UTF-8 response-header tests passed.
- Generated Claude and Codex live references inspected; launcher paths resolve correctly.
- git diff --check passed.
- Maintainer-approved Anthropic routing scenarios 6 and 7 completed (2/2 reported pass). Trace review found that the existing fileLoaded assertion counts a filename search as a reference load: the audit case searched for audit.md but did not read it. Treat this as limited routing evidence, not a verified audit flow or validation of the new production boundary. No test assertions were changed; harness follow-up remains separate from this docs-only PR.
- Generic skill-creator validator unavailable because its Python environment lacks PyYAML; repository validation passed.

Only README.md and two source references change. Generated harness output intentionally omitted; no version bumps or changelog changes.

AI assistance: Codex, under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no code or configuration behavior; low risk aside from clearer user expectations.
> 
> **Overview**
> **Documents the support boundary for live mode** so users and agents do not try to inject the localhost helper into deployed (including HTTPS) production sites.
> 
> **README** adds a **Live mode and production sites** section: live editing is for a local checkout via a dev server or local static HTML; production inspection should use `npx impeccable detect <url>` or the browser extension (read-only, no variant editing or source writes). It explicitly warns against disabling browser security or weakening production CSP.
> 
> **Skill references** (`live.md`, `live-setup.md`) repeat the same limits in prerequisites and CSP setup: CSP allowances stay **development-only**; do not relax production CSP for the helper. No engine, TLS, or runtime behavior changes—documentation only (related to #539).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7582075d7b5b3dd9d99fbac026ac166b5ea34a7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->