### PR TITLE
Set registered VS Code publisher identity

### DIFF
--- a/docs/VSCODE-EXTENSION.md
+++ b/docs/VSCODE-EXTENSION.md
@@ -2,7 +2,7 @@
 
 The VS Code extension is a declarative delivery channel for the GitHub Copilot skill. `bun run build` stages `dist/vscode/` from the GitHub provider output; `bun run package:vscode` builds and packages a VSIX with pinned `@vscode/vsce` tooling. Nothing is published by either command.
 
-The package version follows `.claude-plugin/plugin.json`. Do not independently bump it for feature work. The proposed Marketplace identifier is `pbakaus.impeccable`; publisher ownership and initial publication are separate maintainer steps.
+The package version follows `.claude-plugin/plugin.json`. Do not independently bump it for feature work. The Marketplace identifier is `renaissance-geek.impeccable`, under the registered Renaissance Geek publisher. Initial extension publication is a separate maintainer step; publisher registration alone does not publish the extension.
 
 ## Scope
 

--- a/scripts/lib/vscode-extension.js
+++ b/scripts/lib/vscode-extension.js
@@ -42,7 +42,7 @@ export function stageVSCodeExtension(rootDir, distDir) {
     displayName: 'Impeccable',
     description: 'Design skills for GitHub Copilot: build, critique, audit, and refine interfaces.',
     version,
-    publisher: 'pbakaus',
+    publisher: 'renaissance-geek',
     license: 'Apache-2.0',
     homepage: 'https://impeccable.style',
     repository: { type: 'git', url: 'https://github.com/pbakaus/impeccable.git' },

--- a/tests/vscode-extension.test.mjs
+++ b/tests/vscode-extension.test.mjs
@@ -26,6 +26,7 @@ describe('VS Code skill extension', () => {
 
   it('registers only the skill, without editor runtime or project-install sidecars', () => {
     const manifest = JSON.parse(fs.readFileSync(path.join(extension, 'package.json'), 'utf8'));
+    assert.equal(manifest.publisher, 'renaissance-geek');
     assert.deepEqual(manifest.contributes, { chatSkills: [{ path: './skills/impeccable/SKILL.md' }] });
     for (const key of ['main', 'browser', 'activationEvents', 'scripts']) assert.equal(key in manifest, false);
     assert.equal(manifest.version, JSON.parse(fs.readFileSync(path.join(repo, '.claude-plugin/plugin.json'))).version);


### PR DESCRIPTION
## Summary

- Set the VS Code extension publisher to the newly registered `renaissance-geek`, giving Impeccable the Marketplace identifier `renaissance-geek.impeccable`.
- Add a packaging regression assertion for the publisher ID.
- Update the maintainer documentation to distinguish publisher registration from extension publication.

## Validation

- `node --test tests/vscode-extension.test.mjs` — 5 passed.
- `bun run package:vscode` — built `impeccable-4.2.2.vsix` (57 files, approximately 789 KB).
- Inspected both the packaged `extension/package.json` and `extension.vsixmanifest`: both use `renaissance-geek`.
- Full non-billed `bun run test` passed with the current-main engine binary.
- `git diff --check` passed.

## Scope and publication status

No version bump, changelog entry, or tracked generated harness refresh. The generated VSIX is local and not committed. No extension has been uploaded or published.

Windows and remote runtime smoke checks and minimum-supported-version behavior testing remain outstanding before publication, as recorded in `docs/VSCODE-EXTENSION.md`. Prior macOS Copilot behavior testing is documented there; this change only updates the publisher identity.

AI assistance: Codex, under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only publisher and doc updates with a regression test; no runtime, auth, or skill behavior changes.
> 
> **Overview**
> Switches the staged VS Code extension manifest from publisher **`pbakaus`** to **`renaissance-geek`**, so the Marketplace ID becomes **`renaissance-geek.impeccable`**.
> 
> **`docs/VSCODE-EXTENSION.md`** now documents that identifier and the registered Renaissance Geek publisher, and clarifies that publisher registration is separate from uploading the extension.
> 
> A packaging test asserts **`manifest.publisher === 'renaissance-geek'`** so the ID cannot drift on rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c4372abf77f77632193f500cf0e5be97c68644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->