### PR TITLE
Fix Windows CSP candidate path normalization

### DIFF
--- a/crates/context/src/detect_csp.rs
+++ b/crates/context/src/detect_csp.rs
@@ -167,7 +167,11 @@ fn walk(root: &str, dir: &str, depth: usize, hits: &mut Hits) {
         let Ok(bytes) = std::fs::read(&abs) else { continue };
         let slice = if bytes.len() > MAX_READ_BYTES { &bytes[..MAX_READ_BYTES] } else { &bytes[..] };
         let body = String::from_utf8_lossy(slice);
-        visit(root, &abs, &jsp::relative("/", root, &abs), &body, hits);
+        // Candidate patterns use '/', while native Windows relative paths
+        // use '\\'. Normalize once for classification and portable signals;
+        // to_posix preserves literal backslashes in Unix filenames.
+        let rel = jsp::to_posix(&jsp::relative("/", root, &abs));
+        visit(root, &abs, &rel, &body, hits);
     }
 }
 

--- a/crates/context/src/detect_csp.rs
+++ b/crates/context/src/detect_csp.rs
@@ -214,12 +214,18 @@ mod tests {
 
     impl Fixture {
         fn new() -> Self {
-            let root = std::env::temp_dir().join(format!(
-                "impeccable-csp-761-{}-{}",
-                std::process::id(), NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed),
-            ));
-            std::fs::create_dir(&root).unwrap();
-            Self(root)
+            loop {
+                let root = std::env::temp_dir().join(format!(
+                    "impeccable-csp-761-{}-{}",
+                    std::process::id(), NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed),
+                ));
+                match std::fs::create_dir(&root) {
+                    Ok(()) => return Self(root),
+                    // Never reuse or remove files left by another run.
+                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(e) => panic!("create CSP fixture: {e}"),
+                }
+            }
         }
 
         fn scan(&self, path: &str, body: &str) -> Value {

--- a/crates/context/src/detect_csp.rs
+++ b/crates/context/src/detect_csp.rs
@@ -197,3 +197,82 @@ pub fn run(_args: &[String], io: &mut Io) -> i32 {
     io.out(&format!("{}\n", json_pretty(&v)));
     0
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static NEXT_FIXTURE: AtomicUsize = AtomicUsize::new(0);
+
+    struct Fixture(PathBuf);
+
+    impl Fixture {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "impeccable-csp-761-{}-{}",
+                std::process::id(), NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed),
+            ));
+            std::fs::create_dir(&root).unwrap();
+            Self(root)
+        }
+
+        fn scan(&self, path: &str, body: &str) -> Value {
+            let file = self.0.join(path);
+            std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+            std::fs::write(file, body).unwrap();
+            detect_csp(self.0.to_str().unwrap())
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn nested_csp_candidates_use_portable_paths() {
+        // Exercise the filesystem walker and native path.relative semantics,
+        // not just regexes with pre-normalized input. Windows CI reproduces #761.
+        for (path, body, shape) in [
+            ("packages/app/src/security/csp.ts", "buildCSPConfig()", "append-arrays"),
+            ("packages/app/src/next-config.ts", "createBaseNextConfig()", "append-arrays"),
+            ("apps/web/svelte.config.js", "kit: { csp: { directives: {} } }", "append-arrays"),
+            ("apps/web/nuxt.config.ts", "'nuxt-security'; contentSecurityPolicy", "append-arrays"),
+            ("apps/web/next.config.mjs", "'Content-Security-Policy': 'script-src self; connect-src self'", "append-string"),
+            ("next.config.mjs", "'Content-Security-Policy': 'script-src self; connect-src self'", "append-string"),
+            ("apps/web/src/middleware.ts", "headers.set('Content-Security-Policy', policy)", "middleware"),
+            ("apps/web/src/layout.astro", "<meta http-equiv='Content-Security-Policy'>", "meta-tag"),
+        ] {
+            assert_eq!(Fixture::new().scan(path, body), serde_json::json!({
+                "shape": shape, "signals": [path],
+            }), "{path}");
+        }
+    }
+
+    #[test]
+    fn unrelated_nested_files_are_not_csp_candidates() {
+        for (path, body) in [
+            ("packages/app/src/utils/csp.ts", "buildCSPConfig()"),
+            ("apps/web/not-svelte.config.js", "kit: { csp: { directives: {} } }"),
+            ("apps/web/next.config.mjs", "'Content-Security-Policy': 'script-src self'"),
+        ] {
+            assert_eq!(Fixture::new().scan(path, body), serde_json::json!({
+                "shape": null, "signals": [],
+            }), "{path}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn posix_backslashes_remain_literal_filename_characters() {
+        let result = Fixture::new().scan(
+            "packages/app/src/config\\notes.ts", "buildCSPConfig()",
+        );
+        assert_eq!(result, serde_json::json!({
+            "shape": "append-arrays", "signals": ["packages/app/src/config\\notes.ts"],
+        }));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #761. Normalize native relative paths before CSP candidate classification so nested Windows monorepo helpers and framework configs match the same slash-based rules as Unix.

The fix uses the existing platform-aware `jsp::to_posix` helper once at the walker/classifier boundary. It preserves literal backslashes in Unix filenames and emits portable signal paths.

## Validation

- Test-first commit 74c71b420: Windows CI failed on the exact reported nested helper (`shape: null` instead of `append-arrays`): https://github.com/pbakaus/impeccable/actions/runs/34159778058/job/101859013831
- Regression tests exercise the real filesystem walker: nested monorepo helpers, Svelte/Nuxt/Next configs, root config, middleware, meta tags, non-candidates, and literal Unix backslashes.
- `cargo test -p impeccable-context detect_csp::tests` — passed locally.
- `cargo test --workspace` — passed locally.
- Rebuilt release engine, then ran `IMPECCABLE_BIN=<rebuilt engine> bun run test` — full non-billed suite passed, including oracle and real Claude plugin loader.
- `git diff --check` — passed.
- Fixed runtime commit 50be8bb35: all CI passed, including the Windows regression and oracle; Greptile scored 5/5 and Cursor Bugbot had no findings.
- Addressed Copilot's fixture-collision finding by retrying an unused directory on `AlreadyExists`, without deleting or reusing pre-existing contents. Focused tests passed again; final test-only commit CI pending.

Generated provider output is intentionally omitted. No manifest bumps, dependency changes, or changelog entries.

AI assistance: Codex, under maintainer direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to CSP detection path formatting plus regression tests; no runtime CSP policy or auth behavior changes.
> 
> **Overview**
> Fixes **#761** by normalizing filesystem-relative paths to forward slashes before CSP candidate classification and before emitting `signals`, so slash-based path rules work on Windows monorepos.
> 
> In `walk`, relative paths from `jsp::relative` now pass through **`jsp::to_posix`** once at the classifier boundary (Unix filenames with literal `\` stay unchanged).
> 
> Adds **integration tests** that write temp fixtures and run the real walker: nested helpers and framework configs (Next/Svelte/Nuxt), middleware/meta-tag hits, negative cases, and a Unix-only check for literal backslashes in paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a80d18059e6888763f2252c360290060c54c136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->